### PR TITLE
Detect and drop duplicate URLs when linting

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -54,6 +54,13 @@ const clarifyErrors = errors => {
 };
 
 
+function compareSpecs(a, b) {
+  const aurl = (typeof a === "string") ? a : a.url;
+  const burl = (typeof b === "string") ? b : b.url;
+  return aurl.localeCompare(burl);
+}
+
+
 // Lint specs list defined as a JSON string
 function lintStr(specsStr) {
   const specs = JSON.parse(specsStr);
@@ -76,14 +83,11 @@ function lintStr(specsStr) {
   const sorted = specs.map(spec => (typeof spec === "string") ?
       new URL(spec).toString() :
       Object.assign({}, spec, { url: new URL(spec.url).toString() }));
-  sorted.sort((a, b) => {
-    const aurl = (typeof a === "string") ? a : a.url;
-    const burl = (typeof b === "string") ? b : b.url;
-    return aurl.localeCompare(burl);
-  });
+  sorted.sort(compareSpecs);
 
-  // Prefer URL-only format when we only have a URL
+  // Drop duplicates and prefer URL-only format when we only have a URL
   const fixed = sorted
+    .filter((spec, idx) => !sorted.find((s, i) => i < idx && compareSpecs(s, spec) === 0))
     .map(spec => (Object.keys(spec).length > 1) ? spec : spec.url);
 
   const linted = JSON.stringify(fixed, null, 2) + "\n";

--- a/test/lint.js
+++ b/test/lint.js
@@ -34,6 +34,20 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), toStr(["https://example.org/"]));
     });
 
+    it("drops duplicate URLs", () => {
+      const specs = ["https://example.org/", "https://example.org/"];
+      assert.equal(
+        lintStr(toStr(specs)),
+        toStr(["https://example.org/"]));
+    });
+
+    it("drops duplicate URLs defined as string and object", () => {
+      const specs = [{ "url": "https://example.org/" }, "https://example.org/"];
+      assert.equal(
+        lintStr(toStr(specs)),
+        toStr(["https://example.org/"]));
+    });
+
     it("throws if specs is not an array", () => {
       const specs = 0;
       assert.throws(


### PR DESCRIPTION
It is relatively easy to end up with duplicate URLs if they get added in bulk.
The linter now only keeps the first one.