### PR TITLE
Add logic to compute shortname, family name and level

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 "use strict";
 
+const computeShortname = require("./src/compute-shortname.js");
+
 const specs = require("./specs.json")
-  .map(spec => (typeof spec === "string") ? { url: spec } : spec);
+  .map(spec => (typeof spec === "string") ? { url: spec } : spec)
+  .map(spec => Object.assign({ "url": spec.url }, computeShortname(spec.shortname || spec.url), spec));
 
 module.exports = { specs };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@ const computeShortname = require("./src/compute-shortname.js");
 
 const specs = require("./specs.json")
   .map(spec => (typeof spec === "string") ? { url: spec } : spec)
-  .map(spec => Object.assign({ "url": spec.url }, computeShortname(spec.shortname || spec.url), spec));
+  .map(spec => Object.assign({ "url": spec.url }, computeShortname(spec.name || spec.url), spec));
 
 module.exports = { specs };

--- a/lint.js
+++ b/lint.js
@@ -87,10 +87,10 @@ function lintStr(specsStr) {
   const fixed = sorted
     .map(spec => (Object.keys(spec).length > 1) ? spec : spec.url);
 
-  // Make sure that we can generate shortnames for all specifications or that
+  // Make sure that we can generate names for all specifications or that
   // the specification already defines one. An exception will be thrown if not.
   fixed.forEach(spec => computeShortname(
-    (typeof spec === "string") ? spec : spec.shortname || spec.url));
+    (typeof spec === "string") ? spec : spec.name || spec.url));
 
   const linted = JSON.stringify(fixed, null, 2) + "\n";
   return (linted !== specsStr) ? linted : null;

--- a/lint.js
+++ b/lint.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs").promises;
 const schema = require("./schema.json");
+const computeShortname = require("./src/compute-shortname.js");
 const Ajv = require("ajv");
 const ajv = new Ajv();
 
@@ -85,6 +86,11 @@ function lintStr(specsStr) {
   // Prefer URL-only format when we only have a URL
   const fixed = sorted
     .map(spec => (Object.keys(spec).length > 1) ? spec : spec.url);
+
+  // Make sure that we can generate shortnames for all specifications or that
+  // the specification already defines one. An exception will be thrown if not.
+  fixed.forEach(spec => computeShortname(
+    (typeof spec === "string") ? spec : spec.shortname || spec.url));
 
   const linted = JSON.stringify(fixed, null, 2) + "\n";
   return (linted !== specsStr) ? linted : null;

--- a/schema.json
+++ b/schema.json
@@ -14,11 +14,11 @@
             "type": "string",
             "format": "uri"
           },
-          "shortname": {
+          "name": {
             "type": "string",
             "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
           },
-          "familyname": {
+          "shortname": {
             "type": "string",
             "pattern": "^[\\w\\-]+$"
           },

--- a/schema.json
+++ b/schema.json
@@ -13,6 +13,19 @@
           "url": {
             "type": "string",
             "format": "uri"
+          },
+          "shortname": {
+            "type": "string",
+            "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
+          },
+          "familyname": {
+            "type": "string",
+            "pattern": "^[\\w\\-]+$"
+          },
+          "level": {
+            "type": "number",
+            "multipleOf": 0.1,
+            "minimum": 1
           }
         },
         "required": ["url"],

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -1,0 +1,158 @@
+/**
+ * Module that exports a function that takes a URL as input and computes a
+ * meaninful shortname, family name and level for it, when appropriate.
+ *
+ * The function returns an object with a "shortname" property. The shortname
+ * matches the /TR/ shortname for specs published there. It includes the spec
+ * level. For instance: "css-color-4" for "https://www.w3.org/TR/css-color-4/".
+ *
+ * For non-TR specs, the shortname returned is the "most logical" name that can
+ * be extracted from the URL. The function typically handles a few typical cases
+ * (such as "https://xxx.github.io/" URLs). It throws an exception when no
+ * meaningful shortname can be extracted.
+ *
+ * Returned object will also alway have a "familyname" property that contains
+ * an unleveled shortname for the specification. That name is shared across
+ * levels of the specification. In most cases, it is the shortname without the
+ * level. For instance: "css-page" for "https://www.w3.org/TR/css-page-4/".
+ * In rare cases, note the familyname may be different. For instance:
+ * "css-conditional" for "https://www.w3.org/TR/css3-conditional/".
+ *
+ * If the URL contains a level indication, the returned object will have a
+ * "level" property with that level. Level can either be an integer (1, 2, 3)
+ * or a float (1.2, 2.1). In some cases, the integer actually represents a year
+ * (2013, 2018). If the spec has no level, the "level" property is not set.
+ *
+ * Note that the function is NOT intended for use as a generic function that
+ * returns a shortname, familyname and level for ANY URL. It is only intended
+ * for use within the "browser-specs" project to automatically create shortnames
+ * for common-looking URLs. In particular, individual exceptions to the rule
+ * should NOT be hardcoded here but should rather be directly specified in the
+ * "specs.json" file. For instance, it does not make sense to extend the
+ * function to hardcode the fact that the "css3-mediaqueries" shortname should
+ * create a "mediaqueries" family name.
+ */
+
+
+/**
+ * Internal function that takes a URL as input and returns a shortname for it
+ * if the URL matches well-known patterns, or if the given parameter is actually
+ * already a shortname (meaning that it does not contains any "/").
+ *
+ * The function throws if it cannot compute a meaningful shortname from the URL.
+ */
+function computeShortname(url) {
+  function parseUrl(url) {
+    // Handle /TR/ URLs
+    const w3cTr = url.match(/^https?:\/\/(?:www\.)?w3\.org\/TR\/([^\/]+)\/$/);
+    if (w3cTr) {
+      return w3cTr[1];
+    }
+
+    // Handle WHATWG specs
+    const whatwg = url.match(/\/\/(.+)\.spec\.whatwg\.org\//);
+    if (whatwg) {
+        return whatwg[1];
+    }
+
+    // Handle extension specs defined in the same repo as the main spec
+    const ext = url.match(/\/.*\.github\.io\/([^\/]+)\/(extensions?)\.html$/);
+    if (ext) {
+      return ext[1] + '-' + ext[2];
+    }
+
+    // Handle draft specs on GitHub
+    const github = url.match(/\/.*\.github\.io\/(?:webappsec-)?([^\/]+)\//);
+    if (github) {
+        return github[1];
+    }
+
+    // Handle CSS WG specs
+    const css = url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org\/([^\/]+)\//);
+    if (css) {
+      return css[1];
+    }
+
+    // Handle SVG drafts
+    const svg = url.match(/\/svgwg\.org\/specs\/(?:svg-)?([^\/]+)\//);
+    if (svg) {
+      return "svg-" + svgSpec[1];
+    }
+
+    // Return shortname when one was given
+    if (!url.match(/\//)) {
+      return url;
+    }
+
+    throw `Cannot extract meaningful shortname from ${url}`;
+  }
+
+  // Parse the URL to extract the shortname
+  const shortname = parseUrl(url);
+
+  // Make sure shortname looks legit
+  if (!shortname.match(/^[\w\-]+((?<=\-\d+)\.\d+)?$/)) {
+    throw `Shortname contains unexpected characters: ${shortname} (extracted from ${url})`;
+  }
+
+  return shortname;
+}
+
+
+/**
+ * Compute the family name and level from the shortname, if possible.
+ */
+function completeWithFamilynameAndLevel(shortname) {
+  // Use latest convention for CSS specs
+  function modernizeFamilyname(familyname) {
+    if (familyname.startsWith("css3-")) {
+      return "css-" + familyname.substring("css3-".length);
+    }
+    else if (familyname.startsWith("css4-")) {
+      return "css-" + familyname.substring("css4-".length);
+    }
+    else {
+      return familyname;
+    }
+  }
+
+  // Extract X and X.Y levels, with form "name-X" or "name-X.Y".
+  // (e.g. 5 for "mediaqueries-5", 1.2 for "wai-aria-1.2")
+  let match = shortname.match(/^(.*?)-(\d+)(.\d+)?$/);
+  if (match) {
+    return {
+      shortname,
+      familyname: modernizeFamilyname(match[1]),
+      level: match[3] ? parseFloat(match[2] + match[3]) : parseInt(match[2], 10)
+    };
+  }
+
+  // Extract X and X.Y levels with form "nameX" or "nameXY" (but not "nameXXY")
+  // (e.g. 2.1 for "CSS21", 1.1 for "SVG11", 4 for "selectors4")
+  match = shortname.match(/^(.*?)(?<!\d)(\d)(\d?)$/);
+  if (match) {
+    return {
+      shortname,
+      familyname: modernizeFamilyname(match[1]),
+      level: match[3] ? parseFloat(match[2] + "." + match[3]) : parseInt(match[2], 10)
+    };
+  }
+
+  // No level found
+  return {
+    shortname,
+    familyname: modernizeFamilyname(shortname)
+  };
+}
+
+
+/**
+ * Exports main function that takes a URL (or a shortname) and returns an
+ * object with a shortname, a family name and a level, as needed.
+ */
+module.exports = function (url) {
+  if (!url) {
+    throw "No URL passed as parameter";
+  }
+  return completeWithFamilynameAndLevel(computeShortname(url));
+}

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -1,6 +1,6 @@
 /**
  * Module that exports a function that takes a URL as input and computes a
- * meaninful shortname, family name and level for it, when appropriate.
+ * meaningful shortname, family name and level for it, when appropriate.
  *
  * The function returns an object with a "shortname" property. The shortname
  * matches the /TR/ shortname for specs published there. It includes the spec
@@ -56,12 +56,15 @@ function computeShortname(url) {
     }
 
     // Handle extension specs defined in the same repo as the main spec
+    // (e.g. generate a "gamepad-extensions" shortname for
+    // https://w3c.github.io/gamepad/extensions.html")
     const ext = url.match(/\/.*\.github\.io\/([^\/]+)\/(extensions?)\.html$/);
     if (ext) {
       return ext[1] + '-' + ext[2];
     }
 
-    // Handle draft specs on GitHub
+    // Handle draft specs on GitHub, excluding the "webappsec-" prefix for
+    // specifications developed by the Web Application Security Working Group
     const github = url.match(/\/.*\.github\.io\/(?:webappsec-)?([^\/]+)\//);
     if (github) {
         return github[1];
@@ -90,7 +93,10 @@ function computeShortname(url) {
   // Parse the URL to extract the shortname
   const shortname = parseUrl(url);
 
-  // Make sure shortname looks legit
+  // Make sure shortname looks legit, in other words that it is composed of
+  // basic Latin characters (a-z letters, digits, underscore and "-"), and that
+  // it only contains a dot for fractional levels at the end of the name
+  // (e.g. "blah-1.2" is good but "blah.blah" and "blah-3.1-blah" are not)
   if (!shortname.match(/^[\w\-]+((?<=\-\d+)\.\d+)?$/)) {
     throw `Shortname contains unexpected characters: ${shortname} (extracted from ${url})`;
   }

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -76,7 +76,7 @@ function computeShortname(url) {
     // Handle SVG drafts
     const svg = url.match(/\/svgwg\.org\/specs\/(?:svg-)?([^\/]+)\//);
     if (svg) {
-      return "svg-" + svgSpec[1];
+      return "svg-" + svg[1];
     }
 
     // Return shortname when one was given

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -3,9 +3,9 @@ const computeInfo = require("../src/compute-shortname.js");
 
 describe("compute-shortname module", () => {
 
-  describe("shortname property", () => {
-    function assertName(url, shortname) {
-      assert.equal(computeInfo(url).shortname, shortname);
+  describe("name property", () => {
+    function assertName(url, name) {
+      assert.equal(computeInfo(url).name, name);
     }
 
     it("handles TR URLs", () => {
@@ -52,89 +52,89 @@ describe("compute-shortname module", () => {
       assertName("https://svgwg.org/specs/svg-module/", "svg-module");
     });
 
-    it("returns the shortname when given one", () => {
-      assertName("myshortname", "myshortname");
+    it("returns the name when given one", () => {
+      assertName("myname", "myname");
     });
 
     it("preserves case", () => {
       assertName("https://www.w3.org/TR/IndexedDB/", "IndexedDB");
     });
 
-    it("includes the version number in the shortname (int)", () => {
+    it("includes the version number in the name (int)", () => {
       assertName("https://www.w3.org/TR/level-42/", "level-42");
     });
 
-    it("includes the version number in the shortname (float)", () => {
+    it("includes the version number in the name (float)", () => {
       assertName("https://www.w3.org/TR/level-4.2/", "level-4.2");
     });
 
     it("throws when URL is a dated TR one", () => {
       assert.throws(
         () => computeInfo("https://www.w3.org/TR/2017/CR-presentation-api-20170601/"),
-        /^Cannot extract meaningful shortname from /);
+        /^Cannot extract meaningful name from /);
     });
 
     it("throws when URL that does not follow a known pattern", () => {
       assert.throws(
         () => computeInfo("https://www.w3.org/2001/tag/doc/promises-guide/"),
-        /^Cannot extract meaningful shortname from /);
+        /^Cannot extract meaningful name from /);
     });
 
-    it("throws when shortname contains non basic Latin characters", () => {
+    it("throws when name contains non basic Latin characters", () => {
       assert.throws(
         () => computeInfo("https://www.w3.org/TR/thé-ou-café/"),
-        /^Shortname contains unexpected characters/);
+        /^Specification name contains unexpected characters/);
     });
 
-    it("throws when shortname contains a dot outside of a level definition", () => {
+    it("throws when name contains a dot outside of a level definition", () => {
       assert.throws(
         () => computeInfo("https://w3c.github.io/spec.name/"),
-        /^Shortname contains unexpected characters/);
+        /^Specification name contains unexpected characters/);
     });
 
-    it("throws when shortname contains a non separated fractional level", () => {
+    it("throws when name contains a non separated fractional level", () => {
       assert.throws(
         () => computeInfo("https://w3c.github.io/spec4.2/"),
-        /^Shortname contains unexpected characters/);
+        /^Specification name contains unexpected characters/);
     });
   });
 
 
-  describe("familyname property", () => {
-    function assertFamily(url, familyname) {
-      assert.equal(computeInfo(url).familyname, familyname);
+  describe("shortname property", () => {
+    function assertShortname(url, shortname) {
+      assert.equal(computeInfo(url).shortname, shortname);
     }
 
-    it("parses form 'name-X'", () => {
-      assertFamily("spec-4", "spec");
+    it("parses form 'shortname-X'", () => {
+      assertShortname("spec-4", "spec");
     });
 
-    it("parses form 'name-XXX'", () => {
-      assertFamily("horizon-2050", "horizon");
+    it("parses form 'shortname-XXX'", () => {
+      assertShortname("horizon-2050", "horizon");
     });
 
-    it("parses form 'name-X.Y'", () => {
-      assertFamily("pi-3.1", "pi");
+    it("parses form 'shortname-X.Y'", () => {
+      assertShortname("pi-3.1", "pi");
     });
 
-    it("parses form 'nameX'", () => {
-      assertFamily("loveu2", "loveu");
+    it("parses form 'shortnameX'", () => {
+      assertShortname("loveu2", "loveu");
     });
 
-    it("parses form 'nameXY'", () => {
-      assertFamily("answer42", "answer");
+    it("parses form 'shortnameXY'", () => {
+      assertShortname("answer42", "answer");
     });
 
     it("includes final digits when they do not seem to be a level", () => {
-      assertFamily("cors-rfc1918", "cors-rfc1918");
+      assertShortname("cors-rfc1918", "cors-rfc1918");
     });
 
     it("does not get lost with inner digits", () => {
-      assertFamily("my-2-cents", "my-2-cents");
+      assertShortname("my-2-cents", "my-2-cents");
     });
 
-    it("automatically updates CSS specs with an old 'css3-' family name", () => {
-      assertFamily("css3-conditional", "css-conditional");
+    it("automatically updates CSS specs with an old 'css3-' name", () => {
+      assertShortname("css3-conditional", "css-conditional");
     });
   });
 
@@ -148,23 +148,23 @@ describe("compute-shortname module", () => {
         "did not expect to see a level property");
     }
 
-    it("finds the right level for form 'name-X'", () => {
+    it("finds the right level for form 'shortname-X'", () => {
       assertLevel("spec-4", 4);
     });
 
-    it("finds the right level for form 'name-XXX'", () => {
+    it("finds the right level for form 'shortname-XXX'", () => {
       assertLevel("horizon-2050", 2050);
     });
 
-    it("finds the right level for form 'name-X.Y'", () => {
+    it("finds the right level for form 'shortname-X.Y'", () => {
       assertLevel("pi-3.1", 3.1);
     });
 
-    it("finds the right level for form 'nameX'", () => {
+    it("finds the right level for form 'shortnameX'", () => {
       assertLevel("loveu2", 2);
     });
 
-    it("finds the right level for form 'nameXY'", () => {
+    it("finds the right level for form 'shortnameXY'", () => {
       assertLevel("answer42", 4.2);
     });
 

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -1,0 +1,183 @@
+const assert = require("assert");
+const computeInfo = require("../src/compute-shortname.js");
+
+describe("compute-shortname module", () => {
+
+  describe("shortname property", () => {
+    function assertName(url, shortname) {
+      assert.equal(computeInfo(url).shortname, shortname);
+    }
+
+    it("handles TR URLs", () => {
+      assertName("https://www.w3.org/TR/the-spec/", "the-spec");
+    });
+
+    it("handles WHATWG URLs", () => {
+      assertName("https://myspec.spec.whatwg.org/whatever/", "myspec");
+    });
+
+    it("handles URLs of drafts on GitHub", () => {
+      assertName("https://wicg.github.io/whataspec/", "whataspec");
+    });
+
+    it("handles URLs of WebAppSec drafts on GitHub", () => {
+      assertName("https://w3c.github.io/webappsec-ultrasecret/", "ultrasecret");
+    });
+
+    it("handles extension specs defined in the same repo as the main spec (singular)", () => {
+      assertName("https://w3c.github.io/specwithext/extension.html", "specwithext-extension");
+    });
+
+    it("handles extension specs defined in the same repo as the main spec (plural)", () => {
+      assertName("https://w3c.github.io/specwithext/extensions.html", "specwithext-extensions");
+    });
+
+    it("handles CSS WG draft URLs", () => {
+      assertName("https://drafts.csswg.org/css-is-aweso/", "css-is-aweso");
+    });
+
+    it("handles CSS FXTF draft URLs", () => {
+      assertName("https://drafts.fxtf.org/megafx/", "megafx");
+    });
+
+    it("handles CSS Houdini TF draft URLs", () => {
+      assertName("https://drafts.css-houdini.org/magic/", "magic");
+    });
+
+    it("handles SVG draft URLs", () => {
+      assertName("https://svgwg.org/specs/module/", "svg-module");
+    });
+
+    it("handles SVG draft URLs that have an svg prefix", () => {
+      assertName("https://svgwg.org/specs/svg-module/", "svg-module");
+    });
+
+    it("returns the shortname when given one", () => {
+      assertName("myshortname", "myshortname");
+    });
+
+    it("preserves case", () => {
+      assertName("https://www.w3.org/TR/IndexedDB/", "IndexedDB");
+    });
+
+    it("includes the version number in the shortname (int)", () => {
+      assertName("https://www.w3.org/TR/level-42/", "level-42");
+    });
+
+    it("includes the version number in the shortname (float)", () => {
+      assertName("https://www.w3.org/TR/level-4.2/", "level-4.2");
+    });
+
+    it("throws when URL is a dated TR one", () => {
+      assert.throws(
+        () => computeInfo("https://www.w3.org/TR/2017/CR-presentation-api-20170601/"),
+        /^Cannot extract meaningful shortname from /);
+    });
+
+    it("throws when URL that does not follow a known pattern", () => {
+      assert.throws(
+        () => computeInfo("https://www.w3.org/2001/tag/doc/promises-guide/"),
+        /^Cannot extract meaningful shortname from /);
+    });
+
+    it("throws when shortname contains non basic Latin characters", () => {
+      assert.throws(
+        () => computeInfo("https://www.w3.org/TR/thé-ou-café/"),
+        /^Shortname contains unexpected characters/);
+    });
+
+    it("throws when shortname contains a dot outside of a level definition", () => {
+      assert.throws(
+        () => computeInfo("https://w3c.github.io/spec.name/"),
+        /^Shortname contains unexpected characters/);
+    });
+
+    it("throws when shortname contains a non separated fractional level", () => {
+      assert.throws(
+        () => computeInfo("https://w3c.github.io/spec4.2/"),
+        /^Shortname contains unexpected characters/);
+    });
+  });
+
+
+  describe("familyname property", () => {
+    function assertFamily(url, familyname) {
+      assert.equal(computeInfo(url).familyname, familyname);
+    }
+
+    it("parses form 'name-X'", () => {
+      assertFamily("spec-4", "spec");
+    });
+
+    it("parses form 'name-XXX'", () => {
+      assertFamily("horizon-2050", "horizon");
+    });
+
+    it("parses form 'name-X.Y'", () => {
+      assertFamily("pi-3.1", "pi");
+    });
+
+    it("parses form 'nameX'", () => {
+      assertFamily("loveu2", "loveu");
+    });
+
+    it("parses form 'nameXY'", () => {
+      assertFamily("answer42", "answer");
+    });
+
+    it("includes final digits when they do not seem to be a level", () => {
+      assertFamily("cors-rfc1918", "cors-rfc1918");
+    });
+
+    it("does not get lost with inner digits", () => {
+      assertFamily("my-2-cents", "my-2-cents");
+    });
+
+    it("automatically updates CSS specs with an old 'css3-' family name", () => {
+      assertFamily("css3-conditional", "css-conditional");
+    });
+  });
+
+
+  describe("level property", () => {
+    function assertLevel(url, level) {
+      assert.equal(computeInfo(url).level, level);
+    }
+    function assertNoLevel(url) {
+      assert.equal(computeInfo(url).hasOwnProperty("level"), false,
+        "did not expect to see a level property");
+    }
+
+    it("finds the right level for form 'name-X'", () => {
+      assertLevel("spec-4", 4);
+    });
+
+    it("finds the right level for form 'name-XXX'", () => {
+      assertLevel("horizon-2050", 2050);
+    });
+
+    it("finds the right level for form 'name-X.Y'", () => {
+      assertLevel("pi-3.1", 3.1);
+    });
+
+    it("finds the right level for form 'nameX'", () => {
+      assertLevel("loveu2", 2);
+    });
+
+    it("finds the right level for form 'nameXY'", () => {
+      assertLevel("answer42", 4.2);
+    });
+
+    it("does not report any level when there are none", () => {
+      assertNoLevel("nolevel");
+    });
+
+    it("does not report a level when final digits do not seem to be one", () => {
+      assertNoLevel("cors-rfc1918");
+    });
+
+    it("does not get lost with inner digits", () => {
+      assertNoLevel("my-2-cents");
+    });
+  });
+});

--- a/test/lint.js
+++ b/test/lint.js
@@ -8,30 +8,47 @@ describe("Linter", () => {
     }
 
     it("passes if specs contains a valid URL", () => {
-      const specs = ["https://example.org/"];
+      const specs = ["https://www.w3.org/TR/spec/"];
       assert.equal(lintStr(toStr(specs)), null);
     });
 
     it("passes if specs contains multiple sorted URLs", () => {
-      const specs = ["https://example.com/", "https://example.org/"];
+      const specs = [
+        "https://www.w3.org/TR/spec1/",
+        "https://www.w3.org/TR/spec2/"
+      ];
       assert.equal(lintStr(toStr(specs)), null);
     });
 
     it("sorts URLs", () => {
-      const specs = ["https://example.org/", "https://example.com/"];
+      const specs = [
+        "https://www.w3.org/TR/spec2/",
+        "https://www.w3.org/TR/spec1/"
+      ];
       assert.equal(
         lintStr(toStr(specs)),
-        toStr(["https://example.com/", "https://example.org/"]));
+        toStr([
+          "https://www.w3.org/TR/spec1/",
+          "https://www.w3.org/TR/spec2/"
+        ]));
     });
 
     it("lints a URL", () => {
-      const specs = ["https://example.org"];
-      assert.equal(lintStr(toStr(specs)), toStr(["https://example.org/"]));
+      const specs = [
+        { "url": "https://example.org", "shortname": "test" }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        { "url": "https://example.org/", "shortname": "test" }
+      ]));
     });
 
     it("lints an object with only a URL to a URL", () => {
-      const specs = [{ "url": "https://example.org/" }];
-      assert.equal(lintStr(toStr(specs)), toStr(["https://example.org/"]));
+      const specs = [
+        { "url": "https://www.w3.org/TR/spec/" }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec/"
+      ]));
     });
 
     it("throws if specs is not an array", () => {
@@ -81,6 +98,13 @@ describe("Linter", () => {
       assert.throws(
         () => lintStr(toStr(specs)),
         /^specs\[0\] should not have additional property 'invalid'$/);
+    });
+
+    it("throws when no shortname can be derived from a URL", () => {
+      const specs = ["https://example.org/"];
+      assert.throws(
+        () => lintStr(toStr(specs)),
+        /^Cannot extract meaningful shortname from/);
     });
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -35,10 +35,10 @@ describe("Linter", () => {
 
     it("lints a URL", () => {
       const specs = [
-        { "url": "https://example.org", "shortname": "test" }
+        { "url": "https://example.org", "name": "test" }
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
-        { "url": "https://example.org/", "shortname": "test" }
+        { "url": "https://example.org/", "name": "test" }
       ]));
     });
 
@@ -100,11 +100,11 @@ describe("Linter", () => {
         /^specs\[0\] should not have additional property 'invalid'$/);
     });
 
-    it("throws when no shortname can be derived from a URL", () => {
+    it("throws when no name can be derived from a URL", () => {
       const specs = ["https://example.org/"];
       assert.throws(
         () => lintStr(toStr(specs)),
-        /^Cannot extract meaningful shortname from/);
+        /^Cannot extract meaningful name from/);
     });
   });
 });


### PR DESCRIPTION
Most specification URLs follow a few common patterns from which it is easy to derive a shortname (e.g. "webauthn-2" from "https://www.w3.org/TR/webauthn-2/"). In turn, this shortname can be used to derive a level ("2" for "webauthn-2") and a family name that is common across levels of the spec ("webauthn" here).

The "compute-shortname.js" module does just that. It handles main types of URLs and returns an object with "shortname", "familyname", and a "level" property when that makes sense.

An exception is thrown when the shortname cannot be computed. When that happens, the corresponding entry in "specs.json" should be updated to make the shortname (and/or family name and/or level) explicit. For instance, the entry for CSS Media Queries Level 3 should typically read:

```json
{
  "url": "https://www.w3.org/TR/css3-mediaqueries/",
  "familyname": "mediaqueries",
  "level": 3
}
```

The list of specs exposed in index.js now features the "shortname", "familyname" and "level" properties for each spec.

The family name is typically the property that Reffy would use to name CSS/IDL extracts. Testing on the list of specs used by Reffy (not part of this update), this seems to work just fine.

The update comes with unit tests.

Additional notes:
- I'm not married to the term "familyname", it just seemed good to keep "shortname" for the leveled name, and I needed a name that carried some notion of group...
- I propose to move lint.js to the src folder in a follow-up PR, to only leave the list of specs and the index.js files (plus other boilerplate files) in the root folder.
