### PR TITLE
Allow delta flag and add previous/next links

### DIFF
--- a/index-schema.json
+++ b/index-schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "name": {
+        "type": "string",
+        "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
+      },
+      "shortname": {
+        "type": "string",
+        "pattern": "^[\\w\\-]+$"
+      },
+      "level": {
+        "type": "number",
+        "minimum": 1
+      },
+      "delta": {
+        "type": "boolean"
+      },
+      "previousLevel": {
+        "type": "string",
+        "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
+      },
+      "nextLevel": {
+        "type": "string",
+        "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
+      }
+    },
+    "required": ["url", "name", "shortname"],
+    "additionalProperties": false
+  },
+  "minItems": 1
+}

--- a/index-schema.json
+++ b/index-schema.json
@@ -20,8 +20,9 @@
         "type": "number",
         "minimum": 1
       },
-      "delta": {
-        "type": "boolean"
+      "levelComposition": {
+        "type": "string",
+        "enum": ["full", "delta"]
       },
       "previousLevel": {
         "type": "string",

--- a/index.js
+++ b/index.js
@@ -1,9 +1,33 @@
 "use strict";
 
 const computeShortname = require("./src/compute-shortname.js");
+const computePrevNext = require("./src/compute-prevnext.js");
 
 const specs = require("./specs.json")
-  .map(spec => (typeof spec === "string") ? { url: spec } : spec)
-  .map(spec => Object.assign({ "url": spec.url }, computeShortname(spec.name || spec.url), spec));
+  // Turn all specs into objects
+  // (and handle syntactic sugar notation for "delta" flag)
+  .map(spec => {
+    if (typeof spec === "string") {
+      if (spec.split(" ")[1] === "delta") {
+        return { url: spec.split(" ")[0], delta: true };
+      }
+      else {
+        return { url: spec };
+      }
+    }
+    else {
+      return spec;
+    }
+  })
+
+  // Complete information and output result starting with the URL, names,
+  // level, and additional info
+  .map(spec => Object.assign(
+    { "url": spec.url },
+    computeShortname(spec.name || spec.url),
+    spec))
+
+  // Complete information with previous/next level links
+  .map((spec, _, list) => Object.assign(spec, computePrevNext(spec, list)));
 
 module.exports = { specs };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const specs = require("./specs.json")
   .map(spec => {
     if (typeof spec === "string") {
       if (spec.split(" ")[1] === "delta") {
-        return { url: spec.split(" ")[0], delta: true };
+        return { url: spec.split(" ")[0], levelComposition: "delta" };
       }
       else {
         return { url: spec };
@@ -23,7 +23,7 @@ const specs = require("./specs.json")
   // Complete information and output result starting with the URL, names,
   // level, and additional info
   .map(spec => Object.assign(
-    { "url": spec.url },
+    { url: spec.url, levelComposition: spec.levelComposition || "full" },
     computeShortname(spec.name || spec.url),
     spec))
 

--- a/lint.js
+++ b/lint.js
@@ -69,18 +69,18 @@ function shortenDefinition(spec) {
   if (Object.keys(spec).length === 1) {
     return spec.url;
   }
-  else if (Object.keys(spec).length === 2 && spec.hasOwnProperty("delta")) {
-    if (spec.delta) {
+  else if (Object.keys(spec).length === 2 && spec.levelComposition) {
+    if (spec.levelComposition === "delta") {
       return `${spec.url} delta`;
     }
     else {
       return spec.url;
     }
   }
-  else if (spec.hasOwnProperty("delta") && !spec.delta) {
+  else if (spec.levelComposition === "full") {
     const short = {};
     for (const property of spec) {
-      if (property !== "delta") {
+      if (property !== "levelComposition") {
         short[property] = spec[property];
       }
     }
@@ -116,7 +116,7 @@ function lintStr(specsStr) {
     .map(spec => (typeof spec === "string") ?
       {
         url: new URL(spec.split(" ")[0]).toString(),
-        delta: spec.split(' ')[1] === "delta"
+        levelComposition: (spec.split(' ')[1] === "delta") ? "delta" : "full"
       } :
       Object.assign({}, spec, { url: new URL(spec.url).toString() }))
     .filter((spec, idx, list) =>
@@ -135,7 +135,8 @@ function lintStr(specsStr) {
     .map(s => Object.assign({}, s, computeShortname(s.name || s.url)))
     .map((s, _, list) => Object.assign({}, s, computePrevNext(s, list)))
     .filter((s, _, list) =>
-      s.delta && !list.find(p => !p.delta && p.name === s.previousLevel));
+      s.levelComposition === "delta" &&
+      !list.find(p => p.levelComposition === "full" && p.name === s.previousLevel));
   if (deltaWithoutFull.length > 0) {
     throw "Delta spec(s) found without full previous level: " +
       deltaWithoutFull.map(s => s.url).join(" ");

--- a/specs-schema.json
+++ b/specs-schema.json
@@ -26,8 +26,9 @@
             "type": "number",
             "minimum": 1
           },
-          "delta": {
-            "type": "boolean"
+          "levelComposition": {
+            "type": "string",
+            "enum": ["full", "delta"]
           }
         },
         "required": ["url"],

--- a/specs-schema.json
+++ b/specs-schema.json
@@ -5,7 +5,7 @@
     "oneOf": [
       {
         "type": "string",
-        "format": "uri"
+        "pattern": "^https://[^\\s]+(\\sdelta)?$"
       },
       {
         "type": "object",
@@ -24,8 +24,10 @@
           },
           "level": {
             "type": "number",
-            "multipleOf": 0.1,
             "minimum": 1
+          },
+          "delta": {
+            "type": "boolean"
           }
         },
         "required": ["url"],

--- a/specs.json
+++ b/specs.json
@@ -1,3 +1,3 @@
 [
-  "http://compat.spec.whatwg.org/"
+  "https://compat.spec.whatwg.org/"
 ]

--- a/src/compute-prevnext.js
+++ b/src/compute-prevnext.js
@@ -1,0 +1,40 @@
+/**
+ * Module that exports a function that takes a spec object that already has a
+ * "name", "shortname" and "level" properties (if needed) as input along with a
+ * list of specs with the same info for each spec, and that returns an object
+ * with "previousLevel" and "nextLevel" properties as needed, that point to the
+ * "name" of the spec object that describes the previous and next level for the
+ * spec in the list.
+ */
+
+/**
+ * Exports main function that takes a spec object and a list of specs (which
+ * may contain the spec object itself) and returns an object with properties
+ * "previousLevel" and/or "nextLevel" set. Function only sets the properties
+ * when needed, so returned object may be empty.
+ */
+module.exports = function (spec, list) {
+  if (!spec || !spec.name || !spec.shortname) {
+    throw "Invalid spec object passed as parameter";
+  }
+
+  list = list || [];
+  const level = spec.level || 0;
+
+  return list
+    .filter(s => s.shortname === spec.shortname)
+    .sort((a, b) => (a.level || 0) - (b.level || 0))
+    .reduce((res, s) => {
+      if ((s.level || 0) < level) {
+        // Previous level is the last spec with a lower level
+        res.previousLevel = s.name;
+      }
+      else if ((s.level || 0) > level) {
+        // Next level is the first spec with a greater level
+        if (!res.nextLevel) {
+          res.nextLevel = s.name;
+        }
+      }
+      return res;
+    }, {});
+}

--- a/test/compute-prevnext.js
+++ b/test/compute-prevnext.js
@@ -1,0 +1,144 @@
+const assert = require("assert");
+const computePrevNext = require("../src/compute-prevnext.js");
+
+describe("compute-prevnext module", () => {
+  function getSpec(level) {
+    if (level) {
+      return {
+        name: `spec-${level}`,
+        shortname: "spec",
+        level
+      };
+    }
+    else {
+      return {
+        name: `spec-${level}`,
+        shortname: "spec"
+      };
+    }
+  }
+  function getOther(level) {
+    if (level) {
+      return {
+        name: `other-${level}`,
+        shortname: "other",
+        level
+      };
+    }
+    else {
+      return {
+        name: `other-${level}`,
+        shortname: "other"
+      };
+    }
+  }
+
+  it("sets previous link if it exists", () => {
+    const prev = getSpec(1);
+    const spec = getSpec(2);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [prev]),
+      { previousLevel: prev.name });
+  });
+
+  it("sets next link if it exists", () => {
+    const spec = getSpec(1);
+    const next = getSpec(2);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [next]),
+      { nextLevel: next.name });
+  });
+
+  it("sets previous/next links when both exist", () => {
+    const prev = getSpec(1);
+    const spec = getSpec(2);
+    const next = getSpec(3);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [next, prev, spec]),
+      { previousLevel: prev.name, nextLevel: next.name });
+  });
+
+  it("sets previous/next links when level are version numbers", () => {
+    const prev = getSpec(1.1);
+    const spec = getSpec(1.2);
+    const next = getSpec(1.3);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [next, prev, spec]),
+      { previousLevel: prev.name, nextLevel: next.name });
+  });
+
+  it("selects the right previous level when multiple exist", () => {
+    const old = getSpec(1);
+    const prev = getSpec(2);
+    const spec = getSpec(4);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [spec, prev, old]),
+      { previousLevel: prev.name });
+  });
+
+  it("selects the right next level when multiple exist", () => {
+    const spec = getSpec(1);
+    const next = getSpec(2);
+    const last = getSpec(3);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [spec, last, next]),
+      { nextLevel: next.name });
+  });
+
+  it("considers absence of level to be level 0", () => {
+    const spec = getSpec();
+    const next = getSpec(1);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [next]),
+      { nextLevel: next.name });
+  });
+
+  it("is not affected by presence of other specs", () => {
+    const prev = getSpec(1);
+    const spec = getSpec(3);
+    const next = getSpec(5);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [next, getOther(2), spec, getOther(4), prev]),
+      { previousLevel: prev.name, nextLevel: next.name });
+  });
+
+  it("returns an empty object if list is empty", () => {
+    const spec = getSpec();
+    assert.deepStrictEqual(computePrevNext(spec), {});
+  });
+
+  it("returns an empty object if list is the spec to check", () => {
+    const spec = getSpec();
+    assert.deepStrictEqual(computePrevNext(spec, [spec]), {});
+  });
+
+  it("returns an empty object in absence of other levels", () => {
+    const spec = getSpec(2);
+    assert.deepStrictEqual(
+      computePrevNext(spec, [getOther(1), spec, getOther(3)]), {});
+  });
+
+  it("throws if spec object is not given", () => {
+    assert.throws(
+      () => computePrevNext(),
+      /^Invalid spec object passed as parameter$/);
+  });
+
+  it("throws if spec object is empty", () => {
+    assert.throws(
+      () => computePrevNext({}),
+      /^Invalid spec object passed as parameter$/);
+  });
+
+  it("throws if spec object does not have a name", () => {
+    assert.throws(
+      () => computePrevNext({ shortname: "spec" }),
+      /^Invalid spec object passed as parameter$/);
+  });
+
+  it("throws if spec object does not have a shortname", () => {
+    assert.throws(
+      () => computePrevNext({ name: "spec" }),
+      /^Invalid spec object passed as parameter$/);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,76 @@
+/**
+ * Make sure that the list of specs exposed by index.js looks consistent and
+ * includes the right info.
+ */
+
+const assert = require("assert");
+const source = require("../specs.json");
+const { specs } = require("../index.js");
+const schema = require("../index-schema.json");
+const Ajv = require("ajv");
+const ajv = new Ajv();
+
+describe("List of specs", () => {
+  it("has a valid JSON schema", () => {
+    const isSchemaValid = ajv.validateSchema(schema);
+    assert.ok(isSchemaValid);
+  });
+  
+  it("respects the JSON schema", () => {
+    const isValid = ajv.validate(schema, specs, { format: "full" });
+    assert.ok(isValid);
+  });
+
+  it("contains as many specs as in the source", () => {
+    assert.equal(source.length, specs.length);
+  });
+
+  it("is an array of objects with url, name, and shortname properties", () => {
+    const wrong = specs.filter(s => !(s.url && s.name && s.shortname));
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has level info for specs that have a previous link", () => {
+    const wrong = specs.filter(s => s.previousLevel && !s.level);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has previous links for all delta specs", () => {
+    const wrong = specs.filter(s => s.delta && !s.previousLevel);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has previous links that can be resolved to a spec", () => {
+    const wrong = specs.filter(s =>
+      s.previousLevel && !specs.find(p => p.name === s.previousLevel));
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has next links that can be resolved to a spec", () => {
+    const wrong = specs.filter(s =>
+      s.nextLevel && !specs.find(n => n.name === s.nextLevel));
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has correct next links for specs targeted by a previous link", () => {
+    const wrong = specs.filter(s => {
+      if (!s.previousLevel) {
+        return false;
+      }
+      const previous = specs.find(p => p.name === s.previousLevel);
+      return !previous || previous.nextLevel !== s.name;
+    });
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has correct previous links for specs targeted by a next link", () => {
+    const wrong = specs.filter(s => {
+      if (!s.nextLevel) {
+        return false;
+      }
+      const next = specs.find(n => n.name === s.nextLevel);
+      return !next || next.previousLevel !== s.name;
+    });
+    assert.deepStrictEqual(wrong, []);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,8 @@ describe("List of specs", () => {
   });
 
   it("has previous links for all delta specs", () => {
-    const wrong = specs.filter(s => s.delta && !s.previousLevel);
+    const wrong = specs.filter(s =>
+      s.levelComposition === "delta" && !s.previousLevel);
     assert.deepStrictEqual(wrong, []);
   });
 

--- a/test/lint.js
+++ b/test/lint.js
@@ -20,6 +20,14 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), null);
     });
 
+    it("passes if specs contains a URL with a delta spec", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/",
+        "https://www.w3.org/TR/spec-2/ delta"
+      ];
+      assert.equal(lintStr(toStr(specs)), null);
+    });
+
     it("sorts URLs", () => {
       const specs = [
         "https://www.w3.org/TR/spec2/",
@@ -48,6 +56,17 @@ describe("Linter", () => {
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec/"
+      ]));
+    });
+
+    it("lints an object with only a URL and a delta flag to a string", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/",
+        { "url": "https://www.w3.org/TR/spec-2/", delta: true }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec-1/",
+        "https://www.w3.org/TR/spec-2/ delta"
       ]));
     });
 
@@ -93,10 +112,10 @@ describe("Linter", () => {
     });
 
     it("throws if specs contains an invalid URL", () => {
-      const specs = ["invalid"];
+      const specs = ["https://?"];
       assert.throws(
         () => lintStr(toStr(specs)),
-        /^specs\[0\] should match format "uri"$/);
+        /^TypeError (.*) Invalid URL/);
     });
 
     it("throws if specs contains an object without URL", () => {
@@ -125,6 +144,13 @@ describe("Linter", () => {
       assert.throws(
         () => lintStr(toStr(specs)),
         /^Cannot extract meaningful name from/);
+    });
+
+    it("throws when a delta spec does not have a full previous level", () => {
+      const specs = ["https://www.w3.org/TR/spec/ delta"];
+      assert.throws(
+        () => lintStr(toStr(specs)),
+        /^Delta spec\(s\) found without full previous level/);
     });
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -62,7 +62,7 @@ describe("Linter", () => {
     it("lints an object with only a URL and a delta flag to a string", () => {
       const specs = [
         "https://www.w3.org/TR/spec-1/",
-        { "url": "https://www.w3.org/TR/spec-2/", delta: true }
+        { "url": "https://www.w3.org/TR/spec-2/", levelComposition: "delta" }
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec-1/",


### PR DESCRIPTION
To make sense of the contents of a given spec, it is necessary to track whether it is a "delta" spec that may not contain the entire contents of the previous level or a "full" spec. This update allows specs to be defined as delta specs.

Whether the spec is a delta spec cannot be determined automatically. Delta specs need to be flagged with a "delta" flag in specs.json through a `delta` property as in:

```json
  {
    "url": "https://www.w3.org/TR/mydelta-2/",
    "delta": true
  }
```

To keep the list of URLs in specs.json readable, the flag can also be specified directly within the string that describes the spec, after the URL:

```
  "https://www.w3.org/TR/mydelta-2/ delta"
```

This notation is syntactic sugar for the previous notation and can only be used when a string is used to describe the specification. The linter will actually prefer the synctactic sugar notation when possible (meaning when no other property is defined).

To ease traversing operations between levels of the same specifications, the list of specs returned by "index.js" now features a `previousLevel` and `nextLevel` properties, when possible, set to the name of the spec that represents the previous and/or next level. By construction, all specs linked together in a chain of previous/next links share the same `shortname` property.

The `previousLevel` property is typically useful to identify the name of the previous level that contains the base contents of a delta spec.

From a code perspective:
- The linter was updated to handle the delta flag, notably the syntactic sugar notation, and to make sure that delta spec definitions are ok (delta specs should always have a previous non delta level in the list)
- A new compute-prevnext module was created to compute previous/next links
- The index.js code was updated to include previous/next links in the list of specs returned
- The JSON schema for specs.json was updated to add the "delta" flag and renamed to "specs-schema.json". The "multipleOf" condition was also dropped (because 0.1 multiples cannot work because JS only has floats).
- A new JSON schema was defined to check the list of specs returned by "index.js". It is similar to "specs-schema.json" but also has `previousLevel` and `nextLevel` properties.
- New tests were added for the linter, the new module, and for the list of specs returned by index.js.