### PR TITLE
Add currentLevel property

### DIFF
--- a/index-schema.json
+++ b/index-schema.json
@@ -24,6 +24,10 @@
         "type": "string",
         "enum": ["full", "delta"]
       },
+      "currentLevel": {
+        "type": "string",
+        "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
+      },
       "previousLevel": {
         "type": "string",
         "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
@@ -33,7 +37,7 @@
         "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
       }
     },
-    "required": ["url", "name", "shortname"],
+    "required": ["url", "name", "shortname", "currentLevel"],
     "additionalProperties": false
   },
   "minItems": 1

--- a/index.js
+++ b/index.js
@@ -2,18 +2,22 @@
 
 const computeShortname = require("./src/compute-shortname.js");
 const computePrevNext = require("./src/compute-prevnext.js");
+const computeCurrentLevel = require("./src/compute-currentlevel.js");
 
 const specs = require("./specs.json")
   // Turn all specs into objects
-  // (and handle syntactic sugar notation for "delta" flag)
+  // (and handle syntactic sugar notation for delta/current flags)
   .map(spec => {
     if (typeof spec === "string") {
-      if (spec.split(" ")[1] === "delta") {
-        return { url: spec.split(" ")[0], levelComposition: "delta" };
+      const parts = spec.split(" ");
+      const res = { url: parts[0] };
+      if (parts[1] === "delta") {
+        res.levelComposition = "delta";
       }
-      else {
-        return { url: spec };
+      else if (parts[1] === "current") {
+        res.forceCurrent = true;
       }
+      return res;
     }
     else {
       return spec;
@@ -26,6 +30,9 @@ const specs = require("./specs.json")
     { url: spec.url, levelComposition: spec.levelComposition || "full" },
     computeShortname(spec.name || spec.url),
     spec))
+
+  // Complete information with currentLevel property
+  .map((spec, _, list) => Object.assign(spec, computeCurrentLevel(spec, list)))
 
   // Complete information with previous/next level links
   .map((spec, _, list) => Object.assign(spec, computePrevNext(spec, list)));

--- a/specs-schema.json
+++ b/specs-schema.json
@@ -5,7 +5,7 @@
     "oneOf": [
       {
         "type": "string",
-        "pattern": "^https://[^\\s]+(\\sdelta)?$"
+        "pattern": "^https://[^\\s]+(\\s(delta|current))?$"
       },
       {
         "type": "object",
@@ -29,6 +29,9 @@
           "levelComposition": {
             "type": "string",
             "enum": ["full", "delta"]
+          },
+          "forceCurrent": {
+            "type": "boolean"
           }
         },
         "required": ["url"],

--- a/src/compute-currentlevel.js
+++ b/src/compute-currentlevel.js
@@ -1,0 +1,42 @@
+/**
+ * Module that exports a function that takes a spec object and a list of specs
+ * that contains it, and that returns an object with a "currentLevel" property
+ * set to the "name" of the spec object that should be seen as the current level
+ * for the set of specs with the same shortname in the list.
+ *
+ * Each spec in the list must have "name", "shortname" and "level" (if needed)
+ * properties.
+ *
+ * By default, the current level is defined as the last level that is not a
+ * delta spec, unless a level is explicitly flagged with a "forceCurrent"
+ * property in the list of specs.
+ */
+
+/**
+ * Exports main function that takes a spec object and a list of specs (which
+ * must contain the spec object itself) and returns an object with a
+ * "currentLevel" property. Function always sets the property (value is the
+ * name of the spec itself when it is the current level)
+ */
+module.exports = function (spec, list) {
+  list = list || [];
+  if (!spec) {
+    throw "Invalid spec object passed as parameter";
+  }
+
+  const current = list.reduce((candidate, curr) => {
+    if (curr.shortname === candidate.shortname &&
+        (curr.forceCurrent ||
+          (curr.levelComposition !== "delta" && !candidate.forceCurrent &&
+            (curr.level || 0) > (candidate.level || 0)))) {
+      return curr;
+    }
+    else {
+      return candidate;
+    }
+  }, spec);
+  
+  return {
+    currentLevel: current.name
+  };
+};

--- a/test/compute-currentlevel.js
+++ b/test/compute-currentlevel.js
@@ -1,0 +1,76 @@
+const assert = require("assert");
+const computeCurrentLevel = require("../src/compute-currentlevel.js");
+
+describe("compute-currentlevel module", () => {
+  function getCurrentName(spec, list) {
+    return computeCurrentLevel(spec, list).currentLevel;
+  }
+  function getSpec(options) {
+    options = options || {};
+    const res = {
+      name: (options.level ? `spec-${options.level}` : "spec"),
+      shortname: "spec",
+    };
+    for (const property of Object.keys(options)) {
+      res[property] = options[property];
+    }
+    return res;
+  }
+  function getOther(options) {
+    options = options || {};
+    const res = {
+      name: (options.level ? `other-${options.level}` : "other"),
+      shortname: "other",
+    };
+    for (const property of Object.keys(options)) {
+      res[property] = options[property];
+    }
+    return res;
+  }
+
+  it("returns the spec name if list is empty", () => {
+    const spec = getSpec();
+    assert.equal(getCurrentName(spec), spec.name);
+  });
+
+  it("returns the name of the latest level", () => {
+    const spec = getSpec({ level: 1 });
+    const current = getSpec({ level: 2 });
+    assert.equal(
+      getCurrentName(spec, [spec, current]),
+      current.name);
+  });
+
+  it("returns the name of the latest level that is not a delta spec", () => {
+    const spec = getSpec({ level: 1 });
+    const delta = getSpec({ level: 2, levelComposition: "delta" });
+    assert.equal(
+      getCurrentName(spec, [spec, delta]),
+      spec.name);
+  });
+
+  it("returns the spec name if it is flagged as current", () => {
+    const spec = getSpec({ level: 1, forceCurrent: true });
+    const last = getSpec({ level: 2 });
+    assert.equal(
+      getCurrentName(spec, [spec, last]),
+      spec.name);
+  });
+
+  it("returns the name of the level flagged as current", () => {
+    const spec = getSpec({ level: 1 });
+    const current = getSpec({ level: 2, forceCurrent: true });
+    const last = getSpec({ level: 3 });
+    assert.equal(
+      getCurrentName(spec, [spec, current, last]),
+      current.name);
+  });
+
+  it("does not take other shortnames into account", () => {
+    const spec = getSpec({ level: 1 });
+    const other = getOther({ level : 2});
+    assert.equal(
+      getCurrentName(spec, [spec, other]),
+      spec.name);
+  });
+});

--- a/test/lint.js
+++ b/test/lint.js
@@ -28,6 +28,14 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), null);
     });
 
+    it("passes if specs contains a URL with a spec flagged as current", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/ current",
+        "https://www.w3.org/TR/spec-2/"
+      ];
+      assert.equal(lintStr(toStr(specs)), null);
+    });
+
     it("sorts URLs", () => {
       const specs = [
         "https://www.w3.org/TR/spec2/",
@@ -67,6 +75,55 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec-1/",
         "https://www.w3.org/TR/spec-2/ delta"
+      ]));
+    });
+
+    it("lints an object with only a URL and a current flag to a string", () => {
+      const specs = [
+        { "url": "https://www.w3.org/TR/spec-1/", "forceCurrent": true },
+        "https://www.w3.org/TR/spec-2/"
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec-1/ current",
+        "https://www.w3.org/TR/spec-2/"
+      ]));
+    });
+
+    it("lints an object with a useless current flag", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec/ current"
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec/"
+      ]));
+    });
+
+    it("lints an object with a useless current flag (delta version)", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/ current",
+        "https://www.w3.org/TR/spec-2/ delta"
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec-1/",
+        "https://www.w3.org/TR/spec-2/ delta",
+      ]));
+    });
+
+    it("lints an object with a 'full' flag", () => {
+      const specs = [
+        { "url": "https://www.w3.org/TR/spec/", "levelComposition": "full" }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec/"
+      ]));
+    });
+
+    it("lints an object with a current flag set to false", () => {
+      const specs = [
+        { "url": "https://www.w3.org/TR/spec/", "forceCurrent": false }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec/"
       ]));
     });
 
@@ -151,6 +208,28 @@ describe("Linter", () => {
       assert.throws(
         () => lintStr(toStr(specs)),
         /^Delta spec\(s\) found without full previous level/);
+    });
+
+    it("throws when a delta spec is flagged as current", () => {
+      const specs = [
+        { url: "https://www.w3.org/TR/spec-1/" },
+        { url: "https://www.w3.org/TR/spec-2/",
+          levelComposition: "delta", forceCurrent: true }
+      ];
+      assert.throws(
+        () => lintStr(toStr(specs)),
+        /^Delta spec\(s\) found that are also flagged as current/);
+    });
+
+    it("throws when multiple levels are defined as current", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/ current",
+        "https://www.w3.org/TR/spec-2/ current",
+        "https://www.w3.org/TR/spec-3/",
+      ];
+      assert.throws(
+        () => lintStr(toStr(specs)),
+        /^Too many current specs for shortname\(s\)/);
     });
   });
 });


### PR DESCRIPTION
See #9.

Groups may work on multiple levels of a given spec at once, and may want to redirect readers to one of these levels by default.

With this update, the code exposes a new `currentLevel` property for each spec in the list that points at the name of the specification with the same shortname that should be viewed as the current one.

By default, the `currentLevel` property points at the latest level that is not a delta spec. This rule may be overwritten by flagging the entry that should be seen as the current level in specs.json. This can be done through a `forceCurrent` boolean property:

```json
{
  "url": "https://www.w3.org/TR/spec-1",
  "forceCurrent": true
}
```

... or inline next to the URL with a `current` keyword:

```json
"https://www.w3.org/TR/spec-1 current"
```

The linter automatically switches to the latter form when possible, and complains when:
1. a delta spec is flagged as the current level
2. the list contains more than one spec flagged as current for a shortname

The linter also automatically drops current flags that are useless, e.g. because the flag is added to the latest spec that is not a delta spec.