### PR TITLE
Align property names with W3C API

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,12 +21,12 @@ function getSpecs(filter) {
       specs.filter(s =>
         s.url === filter ||
         s.name === filter ||
-        s.shortname === filter ||
-        s.levelComposition === filter ||
+        s.seriesComposition === filter ||
+        s.source === filter ||
         s.title === filter ||
-        s.trUrl === filter ||
-        s.edUrl === filter ||
-        s.source === filter);
+        (s.series && s.series.shortname === filter) ||
+        (s.release && s.release.url === filter) ||
+        (s.nightly && s.nightly.url === filter));
     return res;
   }
   else {

--- a/index.json
+++ b/index.json
@@ -1,11 +1,15 @@
 [
   {
     "url": "https://compat.spec.whatwg.org/",
-    "levelComposition": "full",
-    "name": "compat",
+    "seriesComposition": "full",
     "shortname": "compat",
-    "currentLevel": "compat",
-    "edUrl": "https://compat.spec.whatwg.org/",
+    "series": {
+      "shortname": "compat",
+      "currentSpecification": "compat"
+    },
+    "nightly": {
+      "url": "https://compat.spec.whatwg.org/"
+    },
     "title": "Compatibility Standard",
     "source": "specref"
   }

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -8,22 +8,30 @@
       "format": "uri"
     },
 
-    "name": {
+    "shortname": {
       "type": "string",
       "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
     },
 
-    "shortname": {
+    "series": {
+      "type": "object",
+      "properties": {
+        "shortname": {
+          "type": "string",
+          "pattern": "^[\\w\\-]+$"
+        },
+        "currentSpecification": { "$ref": "#/proptype/shortname" }
+      },
+      "required": ["shortname"],
+      "additionalProperties": false
+    },
+
+    "seriesVersion": {
       "type": "string",
-      "pattern": "^[\\w\\-]+$"
+      "pattern": "^\\d+(\\.\\d+){0,2}$"
     },
 
-    "level": {
-      "type": "number",
-      "minimum": 1
-    },
-
-    "levelComposition": {
+    "seriesComposition": {
       "type": "string",
       "enum": ["full", "delta"]
     },
@@ -39,6 +47,15 @@
     "source": {
       "type": "string",
       "enum": ["w3c", "specref", "spec"]
+    },
+
+    "release": {
+      "type": "object",
+      "properties": {
+        "url": { "$ref": "#/proptype/url" }
+      },
+      "required": ["url"],
+      "additionalProperties": false
     }
   }
 }

--- a/schema/index.json
+++ b/schema/index.json
@@ -7,19 +7,21 @@
     "type": "object",
     "properties": {
       "url": { "$ref": "definitions.json#/proptype/url" },
-      "name": { "$ref": "definitions.json#/proptype/name" },
       "shortname": { "$ref": "definitions.json#/proptype/shortname" },
-      "level": { "$ref": "definitions.json#/proptype/level" },
-      "levelComposition": { "$ref": "definitions.json#/proptype/levelComposition" },
-      "currentLevel": { "$ref": "definitions.json#/proptype/name" },
-      "previousLevel": { "$ref": "definitions.json#/proptype/name" },
-      "nextLevel": { "$ref": "definitions.json#/proptype/name" },
-      "edUrl": { "$ref": "definitions.json#/proptype/url" },
-      "trUrl": { "$ref": "definitions.json#/proptype/url" },
+      "series": { "$ref": "definitions.json#/proptype/series" },
+      "seriesVersion": { "$ref": "definitions.json#/proptype/seriesVersion" },
+      "seriesComposition": { "$ref": "definitions.json#/proptype/seriesComposition" },
+      "previousInSeries": { "$ref": "definitions.json#/proptype/shortname" },
+      "nextInSeries": { "$ref": "definitions.json#/proptype/shortname" },
+      "nightly": { "$ref": "definitions.json#/proptype/release" },
+      "release": { "$ref": "definitions.json#/proptype/release" },
       "title": { "$ref": "definitions.json#/proptype/title" },
       "source": { "$ref": "definitions.json#/proptype/source" }
     },
-    "required": ["url", "name", "shortname", "currentLevel", "title", "source"],
+    "required": [
+      "url", "shortname", "series", "seriesComposition", "nightly",
+      "title", "source"
+    ],
     "additionalProperties": false
   },
   "minItems": 1

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -13,10 +13,10 @@
         "type": "object",
         "properties": {
           "url": { "$ref": "definitions.json#/proptype/url" },
-          "name": { "$ref": "definitions.json#/proptype/name" },
           "shortname": { "$ref": "definitions.json#/proptype/shortname" },
-          "level": { "$ref": "definitions.json#/proptype/level" },
-          "levelComposition": { "$ref": "definitions.json#/proptype/levelComposition" },
+          "series": { "$ref": "definitions.json#/proptype/series" },
+          "seriesVersion": { "$ref": "definitions.json#/proptype/seriesVersion" },
+          "seriesComposition": { "$ref": "definitions.json#/proptype/seriesComposition" },
           "forceCurrent": { "type": "boolean" }
         },
         "required": ["url"],

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -20,7 +20,7 @@ const specs = require("../specs.json")
       const parts = spec.split(" ");
       const res = { url: parts[0] };
       if (parts[1] === "delta") {
-        res.levelComposition = "delta";
+        res.seriesComposition = "delta";
       }
       else if (parts[1] === "current") {
         res.forceCurrent = true;
@@ -35,13 +35,16 @@ const specs = require("../specs.json")
   // Complete information and output result starting with the URL, names,
   // level, and additional info
   .map(spec => Object.assign(
-    { url: spec.url, levelComposition: spec.levelComposition || "full" },
-    computeShortname(spec.name || spec.url),
+    { url: spec.url, seriesComposition: spec.seriesComposition || "full" },
+    computeShortname(spec.shortname || spec.url),
     spec))
 
-  // Complete information with currentLevel property and drop forceCurrent flags
-  // that no longer need to be exposed
-  .map((spec, _, list) => Object.assign(spec, computeCurrentLevel(spec, list)))
+  // Complete information with currentSpecification property and drop
+  // forceCurrent flags that no longer need to be exposed
+  .map((spec, _, list) => {
+    Object.assign(spec.series, computeCurrentLevel(spec, list));
+    return spec;
+  })
   .map(spec => { delete spec.forceCurrent; return spec; })
 
   // Complete information with previous/next level links
@@ -52,7 +55,7 @@ const specs = require("../specs.json")
 fetchInfo(specs, { w3cApiKey })
   .then(specInfo => {
     const index = specs
-      .map(spec => Object.assign(spec, specInfo[spec.name]));
+      .map(spec => Object.assign(spec, specInfo[spec.shortname]));
 
     // Return the resulting list
     console.log(JSON.stringify(index, null, 2));

--- a/src/compute-currentlevel.js
+++ b/src/compute-currentlevel.js
@@ -1,11 +1,12 @@
 /**
  * Module that exports a function that takes a spec object and a list of specs
- * that contains it, and that returns an object with a "currentLevel" property
- * set to the "name" of the spec object that should be seen as the current level
- * for the set of specs with the same shortname in the list.
+ * that contains it, and that returns an object with a "currentSpecification"
+ * property set to the "shortname" of the spec object that should be seen as
+ * the current level for the set of specs with the same series' shortname in
+ * the list.
  *
- * Each spec in the list must have "name", "shortname" and "level" (if needed)
- * properties.
+ * Each spec in the list must have "shortname", "series" and "seriesVersion"
+ * (if needed) properties.
  *
  * By default, the current level is defined as the last level that is not a
  * delta spec, unless a level is explicitly flagged with a "forceCurrent"
@@ -15,8 +16,8 @@
 /**
  * Exports main function that takes a spec object and a list of specs (which
  * must contain the spec object itself) and returns an object with a
- * "currentLevel" property. Function always sets the property (value is the
- * name of the spec itself when it is the current level)
+ * "currentSpecification" property. Function always sets the property (value is
+ * the name of the spec itself when it is the current level)
  */
 module.exports = function (spec, list) {
   list = list || [];
@@ -25,10 +26,11 @@ module.exports = function (spec, list) {
   }
 
   const current = list.reduce((candidate, curr) => {
-    if (curr.shortname === candidate.shortname && !candidate.forceCurrent &&
-      curr.levelComposition !== "delta" &&
-        (curr.forceCurrent || candidate.levelComposition === "delta" ||
-          (curr.level || 0) > (candidate.level || 0))) {
+    if (curr.series.shortname === candidate.series.shortname &&
+      !candidate.forceCurrent &&
+      curr.seriesComposition !== "delta" &&
+        (curr.forceCurrent || candidate.seriesComposition === "delta" ||
+          (curr.seriesVersion || "0") > (candidate.seriesVersion || "0"))) {
       return curr;
     }
     else {
@@ -37,6 +39,6 @@ module.exports = function (spec, list) {
   }, spec);
   
   return {
-    currentLevel: current.name
+    currentSpecification: current.shortname
   };
 };

--- a/src/compute-prevnext.js
+++ b/src/compute-prevnext.js
@@ -1,38 +1,38 @@
 /**
  * Module that exports a function that takes a spec object that already has a
- * "name", "shortname" and "level" properties (if needed) as input along with a
- * list of specs with the same info for each spec, and that returns an object
- * with "previousLevel" and "nextLevel" properties as needed, that point to the
- * "name" of the spec object that describes the previous and next level for the
- * spec in the list.
+ * "shortname", "series" and "level" properties (if needed) as input along with
+ * a list of specs with the same info for each spec, and that returns an object
+ * with "previousInSeries" and "nextInSeries" properties as needed, that point
+ * to the "shortname" of the spec object that describes the previous and next
+ * level for the spec in the list.
  */
 
 /**
  * Exports main function that takes a spec object and a list of specs (which
  * may contain the spec object itself) and returns an object with properties
- * "previousLevel" and/or "nextLevel" set. Function only sets the properties
- * when needed, so returned object may be empty.
+ * "previousInSeries" and/or "nextInSeries" set. Function only sets the
+ * properties when needed, so returned object may be empty.
  */
 module.exports = function (spec, list) {
-  if (!spec || !spec.name || !spec.shortname) {
+  if (!spec || !spec.shortname || !spec.series || !spec.series.shortname) {
     throw "Invalid spec object passed as parameter";
   }
 
   list = list || [];
-  const level = spec.level || 0;
+  const level = spec.seriesVersion || "0";
 
   return list
-    .filter(s => s.shortname === spec.shortname)
-    .sort((a, b) => (a.level || 0) - (b.level || 0))
+    .filter(s => s.series.shortname === spec.series.shortname)
+    .sort((a, b) => (a.seriesVersion || "0").localeCompare(b.seriesVersion || "0"))
     .reduce((res, s) => {
-      if ((s.level || 0) < level) {
+      if ((s.seriesVersion || "0") < level) {
         // Previous level is the last spec with a lower level
-        res.previousLevel = s.name;
+        res.previousInSeries = s.shortname;
       }
-      else if ((s.level || 0) > level) {
+      else if ((s.seriesVersion || "0") > level) {
         // Next level is the first spec with a greater level
-        if (!res.nextLevel) {
-          res.nextLevel = s.name;
+        if (!res.nextInSeries) {
+          res.nextInSeries = s.shortname;
         }
       }
       return res;

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -1,14 +1,17 @@
 /**
  * Module that exports a function that takes an array of specifications objects
- * that each have at least a "url" and a "name" property. The function returns
- * an object indexed by specification "name" with additional information
+ * that each have at least a "url" and a "short" property. The function returns
+ * an object indexed by specification "shortname" with additional information
  * about the specification fetched from the W3C API, Specref, or from the spec
  * itself. Object returned for each specification contains the following
  * properties:
  *
- * - "edUrl": the URL of the Editor's Draft of the specification. Always set.
- * - "trUrl": the URL of the latest version of the specification published to
- * /TR/. Only set when the specification has been published there.
+ * - "nightly": an object that describes the nightly version. The object will
+ * feature the URL of the Editor's Draft for W3C specs, of the living document
+ * for WHATWG specifications, or of the published Khronos Group specification.
+ * - "release": an object that describes the published version. The object will
+ * feature the URL of the TR document for W3C specs when it exists, and is not
+ * present for specs that don't have release versions (WHATWG specs, CG drafts).
  * - "title": the title of the specification. Always set.
  * - "source": one of "w3c", "specref", "spec", depending on how the information
  * was determined.
@@ -18,9 +21,9 @@
  * published to /TR/, if the specification cannot be fetched, or if no W3C API
  * key was specified for a /TR/ URL.
  *
- * The function will start by querying the W3C API, using the given "name"
+ * The function will start by querying the W3C API, using the given "shortname"
  * properties. For specifications where this fails, the function will query
- * SpecRef, using the given "name" as well. If that too fails, the function
+ * SpecRef, using the given "shortname" as well. If that too fails, the function
  * assumes that the given "url" is the URL of the Editor's Draft, and will fetch
  * it to determine the title.
  *
@@ -56,7 +59,7 @@ async function fetchInfoFromW3CApi(specs, options) {
       return;
     }
 
-    const url = `https://api.w3.org/specifications/${spec.name}`;
+    const url = `https://api.w3.org/specifications/${spec.shortname}`;
     return new Promise((resolve, reject) => {
       const request = https.get(url, options, res => {
         if (res.statusCode === 404) {
@@ -86,9 +89,9 @@ async function fetchInfoFromW3CApi(specs, options) {
   const results = {};
   specs.forEach((spec, idx) => {
     if (info[idx]) {
-      results[spec.name] = {
-        trUrl: info[idx].shortlink,
-        edUrl: info[idx]["editor-draft"],
+      results[spec.shortname] = {
+        release: { url: info[idx].shortlink },
+        nightly: { url: info[idx]["editor-draft"] },
         title: info[idx].title
       };
     }
@@ -111,7 +114,7 @@ async function fetchInfoFromSpecref(specs, options) {
   const chunks = chunkArray(specs, 50);
   const chunksRes = await Promise.all(chunks.map(async chunk => {
     let specrefUrl = "https://api.specref.org/bibrefs?refs=" +
-      chunk.map(spec => spec.name).join(',');
+      chunk.map(spec => spec.shortname).join(',');
 
     return new Promise((resolve, reject) => {
       const request = https.get(specrefUrl, options, res => {
@@ -153,10 +156,10 @@ async function fetchInfoFromSpecref(specs, options) {
       }
     }
     Object.keys(chunkRes).forEach(name => {
-      if (specs.find(spec => spec.name === name)) {
+      if (specs.find(spec => spec.shortname === name)) {
         const info = chunkRes[resolveAlias(name)];
         results[name] = {
-          edUrl: info.edDraft || info.href,
+          nightly: { url: info.edDraft || info.href },
           title: info.title
         };
       }
@@ -172,7 +175,7 @@ async function fetchInfoFromSpecs(specs, options) {
     const html = await new Promise((resolve, reject) => {
       const request = https.get(spec.url, options, res => {
         if (res.statusCode !== 200) {
-          reject(`Could not fetch URL ${spec.url} for spec "${spec.name}", ` +
+          reject(`Could not fetch URL ${spec.url} for spec "${spec.shortname}", ` +
             `status code is ${res.statusCode}`);
           return;
         }
@@ -191,7 +194,7 @@ async function fetchInfoFromSpecs(specs, options) {
     const h1Match = html.match(/<h1[^>]*?>(.*?)<\/h1>/mis);
     if (h1Match) {
       return {
-        edUrl: spec.url,
+        nightly: { url: spec.url },
         title: h1Match[1].replace(/\n/g, '').trim()
       };
     }
@@ -201,27 +204,27 @@ async function fetchInfoFromSpecs(specs, options) {
     const titleMatch = html.match(/<title[^>]*?>(.*?)<\/title>/mis);
     if (titleMatch) {
       return {
-        edUrl: spec.url,
+        nightly: { url: spec.url },
         title: titleMatch[1].replace(/\n/g, '').trim()
       };
     }
 
-    throw `Could not find title in ${spec.url} for spec "${spec.name}"`;
+    throw `Could not find title in ${spec.url} for spec "${spec.shortname}"`;
   }));
 
   const results = {};
-  specs.forEach((spec, idx) => results[spec.name] = info[idx]);
+  specs.forEach((spec, idx) => results[spec.shortname] = info[idx]);
   return results;
 }
 
 
 /**
  * Main function that takes a list of specifications and returns an object
- * indexed by specification "name" that provides, for each specification, the
- * URL of the Editor's Draft, of the /TR/ version, and the title.
+ * indexed by specification "shortname" that provides, for each specification,
+ * the URL of the Editor's Draft, of the /TR/ version, and the title.
  */
 async function fetchInfo(specs, options) {
-  if (!specs || specs.find(spec => !spec.name || !spec.url)) {
+  if (!specs || specs.find(spec => !spec.shortname || !spec.url)) {
     throw "Invalid list of specifications passed as parameter";
   }
 
@@ -233,16 +236,16 @@ async function fetchInfo(specs, options) {
   const w3cInfo = await fetchInfoFromW3CApi(remainingSpecs, options);
 
   // Compute information from Specref for remaining specs
-  remainingSpecs = remainingSpecs.filter(spec => !w3cInfo[spec.name]);
+  remainingSpecs = remainingSpecs.filter(spec => !w3cInfo[spec.shortname]);
   const specrefInfo = await fetchInfoFromSpecref(remainingSpecs, options);
 
   // Extract information directly from the spec for remaining specs
-  remainingSpecs = remainingSpecs.filter(spec => !specrefInfo[spec.name]);
+  remainingSpecs = remainingSpecs.filter(spec => !specrefInfo[spec.shortname]);
   const specInfo = await fetchInfoFromSpecs(remainingSpecs, options);
 
   // Merge results
   const results = {};
-  specs.map(spec => spec.name).forEach(name => results[name] =
+  specs.map(spec => spec.shortname).forEach(name => results[name] =
     (w3cInfo[name] ? Object.assign(w3cInfo[name], { source: "w3c" }) : null) ||
     (specrefInfo[name] ? Object.assign(specrefInfo[name], { source: "specref" }) : null) ||
     (specInfo[name] ? Object.assign(specInfo[name], { source: "spec" }) : null));

--- a/test/compute-currentlevel.js
+++ b/test/compute-currentlevel.js
@@ -3,13 +3,13 @@ const computeCurrentLevel = require("../src/compute-currentlevel.js");
 
 describe("compute-currentlevel module", () => {
   function getCurrentName(spec, list) {
-    return computeCurrentLevel(spec, list).currentLevel;
+    return computeCurrentLevel(spec, list).currentSpecification;
   }
   function getSpec(options) {
     options = options || {};
     const res = {
-      name: (options.level ? `spec-${options.level}` : "spec"),
-      shortname: "spec",
+      shortname: (options.seriesVersion ? `spec-${options.seriesVersion}` : "spec"),
+      series: { shortname: "spec" },
     };
     for (const property of Object.keys(options)) {
       res[property] = options[property];
@@ -19,8 +19,8 @@ describe("compute-currentlevel module", () => {
   function getOther(options) {
     options = options || {};
     const res = {
-      name: (options.level ? `other-${options.level}` : "other"),
-      shortname: "other",
+      shortname: (options.seriesVersion ? `other-${options.seriesVersion}` : "other"),
+      series: { shortname: "other" },
     };
     for (const property of Object.keys(options)) {
       res[property] = options[property];
@@ -30,55 +30,55 @@ describe("compute-currentlevel module", () => {
 
   it("returns the spec name if list is empty", () => {
     const spec = getSpec();
-    assert.equal(getCurrentName(spec), spec.name);
+    assert.equal(getCurrentName(spec), spec.shortname);
   });
 
   it("returns the name of the latest level", () => {
-    const spec = getSpec({ level: 1 });
-    const current = getSpec({ level: 2 });
+    const spec = getSpec({ seriesVersion: "1" });
+    const current = getSpec({ seriesVersion: "2" });
     assert.equal(
       getCurrentName(spec, [spec, current]),
-      current.name);
+      current.shortname);
   });
 
   it("returns the name of the latest level that is not a delta spec", () => {
-    const spec = getSpec({ level: 1 });
-    const delta = getSpec({ level: 2, levelComposition: "delta" });
+    const spec = getSpec({ seriesVersion: "1" });
+    const delta = getSpec({ seriesVersion: "2", seriesComposition: "delta" });
     assert.equal(
       getCurrentName(spec, [spec, delta]),
-      spec.name);
+      spec.shortname);
   });
 
   it("gets back to the latest level when spec is a delta spec", () => {
-    const spec = getSpec({ level: 1 });
-    const delta = getSpec({ level: 2, levelComposition: "delta" });
+    const spec = getSpec({ seriesVersion: "1" });
+    const delta = getSpec({ seriesVersion: "2", seriesComposition: "delta" });
     assert.equal(
       getCurrentName(delta, [spec, delta]),
-      spec.name);
+      spec.shortname);
   });
 
   it("returns the spec name if it is flagged as current", () => {
-    const spec = getSpec({ level: 1, forceCurrent: true });
-    const last = getSpec({ level: 2 });
+    const spec = getSpec({ seriesVersion: "1", forceCurrent: true });
+    const last = getSpec({ seriesVersion: "2" });
     assert.equal(
       getCurrentName(spec, [spec, last]),
-      spec.name);
+      spec.shortname);
   });
 
   it("returns the name of the level flagged as current", () => {
-    const spec = getSpec({ level: 1 });
-    const current = getSpec({ level: 2, forceCurrent: true });
-    const last = getSpec({ level: 3 });
+    const spec = getSpec({ seriesVersion: "1" });
+    const current = getSpec({ seriesVersion: "2", forceCurrent: true });
+    const last = getSpec({ seriesVersion: "3" });
     assert.equal(
       getCurrentName(spec, [spec, current, last]),
-      current.name);
+      current.shortname);
   });
 
   it("does not take other shortnames into account", () => {
-    const spec = getSpec({ level: 1 });
-    const other = getOther({ level : 2});
+    const spec = getSpec({ seriesVersion: "1" });
+    const other = getOther({ seriesVersion: "2"});
     assert.equal(
       getCurrentName(spec, [spec, other]),
-      spec.name);
+      spec.shortname);
   });
 });

--- a/test/compute-prevnext.js
+++ b/test/compute-prevnext.js
@@ -2,104 +2,104 @@ const assert = require("assert");
 const computePrevNext = require("../src/compute-prevnext.js");
 
 describe("compute-prevnext module", () => {
-  function getSpec(level) {
-    if (level) {
+  function getSpec(seriesVersion) {
+    if (seriesVersion) {
       return {
-        name: `spec-${level}`,
-        shortname: "spec",
-        level
+        shortname: `spec-${seriesVersion}`,
+        series: { shortname: "spec" },
+        seriesVersion
       };
     }
     else {
       return {
-        name: `spec-${level}`,
-        shortname: "spec"
+        shortname: `spec-${seriesVersion}`,
+        series: { shortname: "spec" }
       };
     }
   }
-  function getOther(level) {
-    if (level) {
+  function getOther(seriesVersion) {
+    if (seriesVersion) {
       return {
-        name: `other-${level}`,
-        shortname: "other",
-        level
+        shortname: `other-${seriesVersion}`,
+        series: { shortname: "other" },
+        seriesVersion
       };
     }
     else {
       return {
-        name: `other-${level}`,
-        shortname: "other"
+        shortname: `other-${seriesVersion}`,
+        series: { shortname: "other" }
       };
     }
   }
 
   it("sets previous link if it exists", () => {
-    const prev = getSpec(1);
-    const spec = getSpec(2);
+    const prev = getSpec("1");
+    const spec = getSpec("2");
     assert.deepStrictEqual(
       computePrevNext(spec, [prev]),
-      { previousLevel: prev.name });
+      { previousInSeries: prev.shortname });
   });
 
   it("sets next link if it exists", () => {
-    const spec = getSpec(1);
-    const next = getSpec(2);
+    const spec = getSpec("1");
+    const next = getSpec("2");
     assert.deepStrictEqual(
       computePrevNext(spec, [next]),
-      { nextLevel: next.name });
+      { nextInSeries: next.shortname });
   });
 
   it("sets previous/next links when both exist", () => {
-    const prev = getSpec(1);
-    const spec = getSpec(2);
-    const next = getSpec(3);
+    const prev = getSpec("1");
+    const spec = getSpec("2");
+    const next = getSpec("3");
     assert.deepStrictEqual(
       computePrevNext(spec, [next, prev, spec]),
-      { previousLevel: prev.name, nextLevel: next.name });
+      { previousInSeries: prev.shortname, nextInSeries: next.shortname });
   });
 
   it("sets previous/next links when level are version numbers", () => {
-    const prev = getSpec(1.1);
-    const spec = getSpec(1.2);
-    const next = getSpec(1.3);
+    const prev = getSpec("1.1");
+    const spec = getSpec("1.2");
+    const next = getSpec("1.3");
     assert.deepStrictEqual(
       computePrevNext(spec, [next, prev, spec]),
-      { previousLevel: prev.name, nextLevel: next.name });
+      { previousInSeries: prev.shortname, nextInSeries: next.shortname });
   });
 
   it("selects the right previous level when multiple exist", () => {
-    const old = getSpec(1);
-    const prev = getSpec(2);
-    const spec = getSpec(4);
+    const old = getSpec("1");
+    const prev = getSpec("2");
+    const spec = getSpec("4");
     assert.deepStrictEqual(
       computePrevNext(spec, [spec, prev, old]),
-      { previousLevel: prev.name });
+      { previousInSeries: prev.shortname });
   });
 
   it("selects the right next level when multiple exist", () => {
-    const spec = getSpec(1);
-    const next = getSpec(2);
-    const last = getSpec(3);
+    const spec = getSpec("1");
+    const next = getSpec("2");
+    const last = getSpec("3");
     assert.deepStrictEqual(
       computePrevNext(spec, [spec, last, next]),
-      { nextLevel: next.name });
+      { nextInSeries: next.shortname });
   });
 
   it("considers absence of level to be level 0", () => {
     const spec = getSpec();
-    const next = getSpec(1);
+    const next = getSpec("1");
     assert.deepStrictEqual(
       computePrevNext(spec, [next]),
-      { nextLevel: next.name });
+      { nextInSeries: next.shortname });
   });
 
   it("is not affected by presence of other specs", () => {
-    const prev = getSpec(1);
-    const spec = getSpec(3);
-    const next = getSpec(5);
+    const prev = getSpec("1");
+    const spec = getSpec("3");
+    const next = getSpec("5");
     assert.deepStrictEqual(
-      computePrevNext(spec, [next, getOther(2), spec, getOther(4), prev]),
-      { previousLevel: prev.name, nextLevel: next.name });
+      computePrevNext(spec, [next, getOther("2"), spec, getOther("4"), prev]),
+      { previousInSeries: prev.shortname, nextInSeries: next.shortname });
   });
 
   it("returns an empty object if list is empty", () => {
@@ -113,9 +113,9 @@ describe("compute-prevnext module", () => {
   });
 
   it("returns an empty object in absence of other levels", () => {
-    const spec = getSpec(2);
+    const spec = getSpec("2");
     assert.deepStrictEqual(
-      computePrevNext(spec, [getOther(1), spec, getOther(3)]), {});
+      computePrevNext(spec, [getOther("1"), spec, getOther("3")]), {});
   });
 
   it("throws if spec object is not given", () => {

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -3,9 +3,9 @@ const computeInfo = require("../src/compute-shortname.js");
 
 describe("compute-shortname module", () => {
 
-  describe("name property", () => {
+  describe("shortname property", () => {
     function assertName(url, name) {
-      assert.equal(computeInfo(url).name, name);
+      assert.equal(computeInfo(url).shortname, name);
     }
 
     it("handles TR URLs", () => {
@@ -100,84 +100,84 @@ describe("compute-shortname module", () => {
   });
 
 
-  describe("shortname property", () => {
-    function assertShortname(url, shortname) {
-      assert.equal(computeInfo(url).shortname, shortname);
+  describe("series' shortname property", () => {
+    function assertSeries(url, shortname) {
+      assert.equal(computeInfo(url).series.shortname, shortname);
     }
 
     it("parses form 'shortname-X'", () => {
-      assertShortname("spec-4", "spec");
+      assertSeries("spec-4", "spec");
     });
 
     it("parses form 'shortname-XXX'", () => {
-      assertShortname("horizon-2050", "horizon");
+      assertSeries("horizon-2050", "horizon");
     });
 
     it("parses form 'shortname-X.Y'", () => {
-      assertShortname("pi-3.1", "pi");
+      assertSeries("pi-3.1", "pi");
     });
 
     it("parses form 'shortnameX'", () => {
-      assertShortname("loveu2", "loveu");
+      assertSeries("loveu2", "loveu");
     });
 
     it("parses form 'shortnameXY'", () => {
-      assertShortname("answer42", "answer");
+      assertSeries("answer42", "answer");
     });
 
     it("includes final digits when they do not seem to be a level", () => {
-      assertShortname("cors-rfc1918", "cors-rfc1918");
+      assertSeries("cors-rfc1918", "cors-rfc1918");
     });
 
     it("does not get lost with inner digits", () => {
-      assertShortname("my-2-cents", "my-2-cents");
+      assertSeries("my-2-cents", "my-2-cents");
     });
 
     it("automatically updates CSS specs with an old 'css3-' name", () => {
-      assertShortname("css3-conditional", "css-conditional");
+      assertSeries("css3-conditional", "css-conditional");
     });
   });
 
 
-  describe("level property", () => {
-    function assertLevel(url, level) {
-      assert.equal(computeInfo(url).level, level);
+  describe("seriesVersion property", () => {
+    function assertSeriesVersion(url, level) {
+      assert.equal(computeInfo(url).seriesVersion, level);
     }
-    function assertNoLevel(url) {
-      assert.equal(computeInfo(url).hasOwnProperty("level"), false,
-        "did not expect to see a level property");
+    function assertNoSeriesVersion(url) {
+      assert.equal(computeInfo(url).hasOwnProperty("seriesVersion"), false,
+        "did not expect to see a seriesVersion property");
     }
 
-    it("finds the right level for form 'shortname-X'", () => {
-      assertLevel("spec-4", 4);
+    it("finds the right series version for form 'shortname-X'", () => {
+      assertSeriesVersion("spec-4", "4");
     });
 
-    it("finds the right level for form 'shortname-XXX'", () => {
-      assertLevel("horizon-2050", 2050);
+    it("finds the right series version for form 'shortname-XXX'", () => {
+      assertSeriesVersion("horizon-2050", "2050");
     });
 
-    it("finds the right level for form 'shortname-X.Y'", () => {
-      assertLevel("pi-3.1", 3.1);
+    it("finds the right series version for form 'shortname-X.Y'", () => {
+      assertSeriesVersion("pi-3.1", "3.1");
     });
 
-    it("finds the right level for form 'shortnameX'", () => {
-      assertLevel("loveu2", 2);
+    it("finds the right series version for form 'shortnameX'", () => {
+      assertSeriesVersion("loveu2", "2");
     });
 
-    it("finds the right level for form 'shortnameXY'", () => {
-      assertLevel("answer42", 4.2);
+    it("finds the right series version for form 'shortnameXY'", () => {
+      assertSeriesVersion("answer42", "4.2");
     });
 
-    it("does not report any level when there are none", () => {
-      assertNoLevel("nolevel");
+    it("does not report any series version when there are none", () => {
+      assertNoSeriesVersion("nolevel");
     });
 
-    it("does not report a level when final digits do not seem to be one", () => {
-      assertNoLevel("cors-rfc1918");
+    it("does not report a series version when final digits do not seem to be one", () => {
+      assertNoSeriesVersion("cors-rfc1918");
     });
 
     it("does not get lost with inner digits", () => {
-      assertNoLevel("my-2-cents");
+      assertNoSeriesVersion("my-2-cents");
     });
   });
 });

--- a/test/fetch-info-w3c.js
+++ b/test/fetch-info-w3c.js
@@ -24,8 +24,8 @@ describe("fetch-info module (with W3C API key)", function () {
   this.slow(5000);
   this.timeout(30000);
 
-  function getW3CSpec(name) {
-    return { name, url: `https://www.w3.org/TR/${name}/` };
+  function getW3CSpec(shortname) {
+    return { shortname, url: `https://www.w3.org/TR/${shortname}/` };
   }
 
   describe("W3C API key", () => {
@@ -39,28 +39,28 @@ describe("fetch-info module (with W3C API key)", function () {
     it("works on a TR spec", async () => {
       const spec = getW3CSpec("hr-time-2");
       const info = await fetchInfo([spec], { w3cApiKey });
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "w3c");
-      assert.equal(info[spec.name].trUrl, spec.url);
-      assert.equal(info[spec.name].edUrl, "https://w3c.github.io/hr-time/");
-      assert.equal(info[spec.name].title, "High Resolution Time Level 2");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "w3c");
+      assert.equal(info[spec.shortname].release.url, spec.url);
+      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/hr-time/");
+      assert.equal(info[spec.shortname].title, "High Resolution Time Level 2");
     });
 
     it("can operate on multiple specs at once", async () => {
       const spec = getW3CSpec("hr-time-2");
       const other = getW3CSpec("presentation-api");
       const info = await fetchInfo([spec, other], { w3cApiKey });
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "w3c");
-      assert.equal(info[spec.name].trUrl, spec.url);
-      assert.equal(info[spec.name].edUrl, "https://w3c.github.io/hr-time/");
-      assert.equal(info[spec.name].title, "High Resolution Time Level 2");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "w3c");
+      assert.equal(info[spec.shortname].release.url, spec.url);
+      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/hr-time/");
+      assert.equal(info[spec.shortname].title, "High Resolution Time Level 2");
 
-      assert.ok(info[other.name]);
-      assert.equal(info[other.name].source, "w3c");
-      assert.equal(info[other.name].trUrl, other.url);
-      assert.equal(info[other.name].edUrl, "https://w3c.github.io/presentation-api/");
-      assert.equal(info[other.name].title, "Presentation API");
+      assert.ok(info[other.shortname]);
+      assert.equal(info[other.shortname].source, "w3c");
+      assert.equal(info[other.shortname].release.url, other.url);
+      assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
+      assert.equal(info[other.shortname].title, "Presentation API");
     });
 
     it("throws when W3C API key is invalid", async () => {
@@ -75,13 +75,13 @@ describe("fetch-info module (with W3C API key)", function () {
     it("works on a WHATWG spec", async () => {
       const spec = {
         url: "https://dom.spec.whatwg.org/",
-        name: "dom"
+        shortname: "dom"
       };
       const info = await fetchInfo([spec], { w3cApiKey });
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "specref");
-      assert.equal(info[spec.name].edUrl, "https://dom.spec.whatwg.org/");
-      assert.equal(info[spec.name].title, "DOM Standard");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].nightly.url, "https://dom.spec.whatwg.org/");
+      assert.equal(info[spec.shortname].title, "DOM Standard");
     });
   });
 
@@ -91,28 +91,28 @@ describe("fetch-info module (with W3C API key)", function () {
       const w3c = getW3CSpec("presentation-api");
       const whatwg = {
         url: "https://html.spec.whatwg.org/multipage/",
-        name: "html"
+        shortname: "html"
       };
       const other = {
         url: "https://tabatkins.github.io/bikeshed/",
-        name: "bikeshed"
+        shortname: "bikeshed"
       };
       const info = await fetchInfo([w3c, whatwg, other], { w3cApiKey });
-      assert.ok(info[w3c.name]);
-      assert.equal(info[w3c.name].source, "w3c");
-      assert.equal(info[w3c.name].trUrl, w3c.url);
-      assert.equal(info[w3c.name].edUrl, "https://w3c.github.io/presentation-api/");
-      assert.equal(info[w3c.name].title, "Presentation API");
+      assert.ok(info[w3c.shortname]);
+      assert.equal(info[w3c.shortname].source, "w3c");
+      assert.equal(info[w3c.shortname].release.url, w3c.url);
+      assert.equal(info[w3c.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
+      assert.equal(info[w3c.shortname].title, "Presentation API");
 
-      assert.ok(info[whatwg.name]);
-      assert.equal(info[whatwg.name].source, "specref");
-      assert.equal(info[whatwg.name].edUrl, whatwg.url);
-      assert.equal(info[whatwg.name].title, "HTML Standard");
+      assert.ok(info[whatwg.shortname]);
+      assert.equal(info[whatwg.shortname].source, "specref");
+      assert.equal(info[whatwg.shortname].nightly.url, whatwg.url);
+      assert.equal(info[whatwg.shortname].title, "HTML Standard");
 
-      assert.ok(info[other.name]);
-      assert.equal(info[other.name].source, "spec");
-      assert.equal(info[other.name].edUrl, other.url);
-      assert.equal(info[other.name].title, "Bikeshed Documentation");      
+      assert.ok(info[other.shortname]);
+      assert.equal(info[other.shortname].source, "spec");
+      assert.equal(info[other.shortname].nightly.url, other.url);
+      assert.equal(info[other.shortname].title, "Bikeshed Documentation");      
     });
   });
 });

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -14,8 +14,8 @@ describe("fetch-info module (without W3C API key)", function () {
   this.slow(5000);
   this.timeout(30000);
 
-  function getW3CSpec(name) {
-    return { name, url: `https://www.w3.org/TR/${name}/` };
+  function getW3CSpec(shortname) {
+    return { shortname, url: `https://www.w3.org/TR/${shortname}/` };
   }
 
 
@@ -23,37 +23,37 @@ describe("fetch-info module (without W3C API key)", function () {
     it("works on a TR spec in the absence of W3C API key", async () => {
       const spec = getW3CSpec("presentation-api");
       const info = await fetchInfo([spec]);
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "specref");
-      assert.equal(info[spec.name].edUrl, "https://w3c.github.io/presentation-api/");
-      assert.equal(info[spec.name].title, "Presentation API");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
+      assert.equal(info[spec.shortname].title, "Presentation API");
     });
 
     it("works on a WHATWG spec", async () => {
       const spec = {
         url: "https://dom.spec.whatwg.org/",
-        name: "dom"
+        shortname: "dom"
       };
       const info = await fetchInfo([spec]);
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "specref");
-      assert.equal(info[spec.name].edUrl, "https://dom.spec.whatwg.org/");
-      assert.equal(info[spec.name].title, "DOM Standard");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].nightly.url, "https://dom.spec.whatwg.org/");
+      assert.equal(info[spec.shortname].title, "DOM Standard");
     });
 
     it("can operate on multiple specs at once", async () => {
       const spec = getW3CSpec("presentation-api");
       const other = getW3CSpec("hr-time-2");
       const info = await fetchInfo([spec, other]);
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "specref");
-      assert.equal(info[spec.name].edUrl, "https://w3c.github.io/presentation-api/");
-      assert.equal(info[spec.name].title, "Presentation API");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
+      assert.equal(info[spec.shortname].title, "Presentation API");
 
-      assert.ok(info[other.name]);
-      assert.equal(info[other.name].source, "specref");
-      assert.equal(info[other.name].edUrl, "https://w3c.github.io/hr-time/");
-      assert.equal(info[other.name].title, "High Resolution Time Level 2");
+      assert.ok(info[other.shortname]);
+      assert.equal(info[other.shortname].source, "specref");
+      assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/hr-time/");
+      assert.equal(info[other.shortname].title, "High Resolution Time Level 2");
     });
   });
 
@@ -62,25 +62,25 @@ describe("fetch-info module (without W3C API key)", function () {
     it("extracts spec info from a Bikeshed spec when needed", async () => {
       const spec = {
         url: "https://tabatkins.github.io/bikeshed/",
-        name: "bikeshed"
+        shortname: "bikeshed"
       };
       const info = await fetchInfo([spec]);
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "spec");
-      assert.equal(info[spec.name].edUrl, spec.url);
-      assert.equal(info[spec.name].title, "Bikeshed Documentation");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].nightly.url, spec.url);
+      assert.equal(info[spec.shortname].title, "Bikeshed Documentation");
     });
 
     it("extracts spec info from a Respec spec when needed", async () => {
       const spec = {
         url: "https://w3c.github.io/respec/examples/tpac_2019.html",
-        name: "respec"
+        shortname: "respec"
       };
       const info = await fetchInfo([spec]);
-      assert.ok(info[spec.name]);
-      assert.equal(info[spec.name].source, "spec");
-      assert.equal(info[spec.name].edUrl, spec.url);
-      assert.equal(info[spec.name].title, "TPAC 2019 - New Features");
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].nightly.url, spec.url);
+      assert.equal(info[spec.shortname].title, "TPAC 2019 - New Features");
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -20,55 +20,56 @@ describe("List of specs", () => {
   it("respects the JSON schema", () => {
     const validate = ajv.addSchema(dfnsSchema).compile(schema);
     const isValid = validate(specs, { format: "full" });
+    assert.strictEqual(validate.errors, null);
     assert.ok(isValid);
   });
 
-  it("is an array of objects with url, name, and shortname properties", () => {
-    const wrong = specs.filter(s => !(s.url && s.name && s.shortname));
+  it("is an array of objects with url, shortname, and series properties", () => {
+    const wrong = specs.filter(s => !(s.url && s.shortname && s.series));
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has level info for specs that have a previous link", () => {
-    const wrong = specs.filter(s => s.previousLevel && !s.level);
+    const wrong = specs.filter(s => s.previousInSeries && !s.seriesVersion);
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has previous links for all delta specs", () => {
     const wrong = specs.filter(s =>
-      s.levelComposition === "delta" && !s.previousLevel);
+      s.seriesComposition === "delta" && !s.previousInSeries);
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has previous links that can be resolved to a spec", () => {
     const wrong = specs.filter(s =>
-      s.previousLevel && !specs.find(p => p.name === s.previousLevel));
+      s.previousInSeries && !specs.find(p => p.shortname === s.previousInSeries));
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has next links that can be resolved to a spec", () => {
     const wrong = specs.filter(s =>
-      s.nextLevel && !specs.find(n => n.name === s.nextLevel));
+      s.nextInSeries && !specs.find(n => n.shortname === s.nextInSeries));
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has correct next links for specs targeted by a previous link", () => {
     const wrong = specs.filter(s => {
-      if (!s.previousLevel) {
+      if (!s.previousInSeries) {
         return false;
       }
-      const previous = specs.find(p => p.name === s.previousLevel);
-      return !previous || previous.nextLevel !== s.name;
+      const previous = specs.find(p => p.shortname === s.previousInSeries);
+      return !previous || previous.nextInSeries !== s.shortname;
     });
     assert.deepStrictEqual(wrong, []);
   });
 
   it("has correct previous links for specs targeted by a next link", () => {
     const wrong = specs.filter(s => {
-      if (!s.nextLevel) {
+      if (!s.nextInSeries) {
         return false;
       }
-      const next = specs.find(n => n.name === s.nextLevel);
-      return !next || next.previousLevel !== s.name;
+      const next = specs.find(n => n.shortname === s.nextInSeries);
+      return !next || next.previousInSeries !== s.shortname;
     });
     assert.deepStrictEqual(wrong, []);
   });

--- a/test/lint.js
+++ b/test/lint.js
@@ -51,10 +51,10 @@ describe("Linter", () => {
 
     it("lints a URL", () => {
       const specs = [
-        { "url": "https://example.org", "name": "test" }
+        { "url": "https://example.org", "shortname": "test" }
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
-        { "url": "https://example.org/", "name": "test" }
+        { "url": "https://example.org/", "shortname": "test" }
       ]));
     });
 
@@ -70,7 +70,7 @@ describe("Linter", () => {
     it("lints an object with only a URL and a delta flag to a string", () => {
       const specs = [
         "https://www.w3.org/TR/spec-1/",
-        { "url": "https://www.w3.org/TR/spec-2/", levelComposition: "delta" }
+        { "url": "https://www.w3.org/TR/spec-2/", seriesComposition: "delta" }
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec-1/",
@@ -111,7 +111,7 @@ describe("Linter", () => {
 
     it("lints an object with a 'full' flag", () => {
       const specs = [
-        { "url": "https://www.w3.org/TR/spec/", "levelComposition": "full" }
+        { "url": "https://www.w3.org/TR/spec/", "seriesComposition": "full" }
       ];
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec/"
@@ -214,7 +214,7 @@ describe("Linter", () => {
       const specs = [
         { url: "https://www.w3.org/TR/spec-1/" },
         { url: "https://www.w3.org/TR/spec-2/",
-          levelComposition: "delta", forceCurrent: true }
+          seriesComposition: "delta", forceCurrent: true }
       ];
       assert.throws(
         () => lintStr(toStr(specs)),


### PR DESCRIPTION
See #25.

Following exchanges with W3C API folks, this update aligns terms used in browser-specs with existing or upcoming terms in the W3C API, where it makes sense.

In practice, this update brings the following changes:
- `shortname` becomes `series.shortname`
- `name` becomes `shortname`
- `level` becomes `seriesVersion` and is now a string
- `levelComposition` becomes `seriesComposition`
- `currentLevel` becomes `series.currentSpecification`
- `previousLevel` becomes `previousInSeries`
- `nextLevel` becomes `nextInSeries`
- `edUrl` becomes `nightly.url` and is set for all specs
- `trUrl` becomes `release.url` and is only set for TR specs

Many lines of code changed, but it's all renaming...