### PR TITLE
Update URL of requestVideoFrameCallback spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -82,7 +82,7 @@
   "https://wicg.github.io/serial/",
   "https://wicg.github.io/shape-detection-api/",
   "https://wicg.github.io/speech-api/",
-  "https://wicg.github.io/video-raf/",
+  "https://wicg.github.io/video-rvfc/",
   "https://wicg.github.io/visual-viewport/",
   "https://wicg.github.io/web-locks/",
   "https://wicg.github.io/web-share-target/",


### PR DESCRIPTION
The spec used to be called `video.requestAnimationFrame()`. It is now called `HTMLVideoElement.requestVideoFrameCallback()` and its URL has changed.