### PR TITLE
Add CC0 license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "index.json"
   ],
+  "license": "CC0-1.0",
   "main": "index.json",
   "scripts": {
     "build": "node src/build-index.js > index.json",


### PR DESCRIPTION
The browser-specs "package" only contains the index.json file, so CC0 applies to it. The LICENSE.md file is clear that the rest of the code is licensed under the terms of the MIT license.