### PR TITLE
Release process: update changelog before commit

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,7 @@
 {
   "hooks": {
     "after:init": ["npm test", "npm run lint"],
-    "before:release": "npx auto-changelog --package --commit-limit false --template src/changelog.hbs --commit-url https://github.com/w3c/browser-specs/commit/{id} --issue-url https://github.com/w3c/browser-specs/issues/{id} --merge-url https://github.com/w3c/browser-specs/pull/{id} --compare-url https://github.com/w3c/browser-specs/compare/{from}...{to}"
+    "after:bump": "npx auto-changelog --package --commit-limit false --template src/changelog.hbs --commit-url https://github.com/w3c/browser-specs/commit/{id} --issue-url https://github.com/w3c/browser-specs/issues/{id} --merge-url https://github.com/w3c/browser-specs/pull/{id} --compare-url https://github.com/w3c/browser-specs/compare/{from}...{to}"
   },
   "git": {
     "commitMessage": "v${version}",


### PR DESCRIPTION
See #44.

The changelog was updated too late in the release process and the update wasn't included in the commit as a result. Using `after:bump` as specified in the documentation should fix the issue:
https://github.com/release-it/release-it/blob/master/docs/changelog.md#auto-changelog