### PR TITLE
Force Service Worker spec shortname

### DIFF
--- a/index.json
+++ b/index.json
@@ -634,10 +634,10 @@
   {
     "url": "https://w3c.github.io/ServiceWorker/",
     "seriesComposition": "full",
-    "shortname": "ServiceWorker",
+    "shortname": "service-worker",
     "series": {
-      "shortname": "ServiceWorker",
-      "currentSpecification": "ServiceWorker"
+      "shortname": "service-worker",
+      "currentSpecification": "service-worker"
     },
     "nightly": {
       "url": "https://w3c.github.io/ServiceWorker/"

--- a/specs.json
+++ b/specs.json
@@ -42,7 +42,13 @@
   "https://w3c.github.io/gamepad/extensions.html",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/reporting/",
-  "https://w3c.github.io/ServiceWorker/",
+  {
+    "url": "https://w3c.github.io/ServiceWorker/",
+    "shortname": "service-worker",
+    "series": {
+      "shortname": "service-worker"
+    }
+  },
   "https://w3c.github.io/web-nfc/",
   "https://w3c.github.io/webappsec-feature-policy/",
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",


### PR DESCRIPTION
The list contains the nightly version of the spec, which makes sense but also generates a `ServiceWorker` shortname that should rather be `service-worker` (shortname used in /TR/).

This update forces the shortname to `service-worker`.