### PR TITLE
Use plural for Service Workers shortname

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -44,9 +44,9 @@
   "https://w3c.github.io/reporting/",
   {
     "url": "https://w3c.github.io/ServiceWorker/",
-    "shortname": "service-worker",
+    "shortname": "service-workers",
     "series": {
-      "shortname": "service-worker"
+      "shortname": "service-workers"
     }
   },
   "https://w3c.github.io/web-nfc/",


### PR DESCRIPTION
Previous update (see #48) forced the shortname of the Service Workers spec but missed the
fact that the actual shortname uses a plural form: `service-workers`.