### PR TITLE
Adjust a couple of TR URLs to match W3C API shortnames

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -147,6 +147,7 @@
   "https://www.w3.org/TR/css-gcpm-3/",
   "https://www.w3.org/TR/css-grid-1/",
   "https://www.w3.org/TR/css-grid-2/ delta",
+  "https://www.w3.org/TR/css-images-3/",
   "https://www.w3.org/TR/css-images-4/ delta",
   "https://www.w3.org/TR/css-inline-3/",
   "https://www.w3.org/TR/css-layout-api-1/",
@@ -205,10 +206,6 @@
   },
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",
-    "seriesVersion": "3"
-  },
-  {
-    "url": "https://www.w3.org/TR/css3-images/",
     "seriesVersion": "3"
   },
   {
@@ -293,7 +290,7 @@
   "https://www.w3.org/TR/SVG2/",
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
-  "https://www.w3.org/TR/trace-context/",
+  "https://www.w3.org/TR/trace-context-1/",
   "https://www.w3.org/TR/uievents-code/",
   "https://www.w3.org/TR/uievents-key/",
   "https://www.w3.org/TR/uievents/",


### PR DESCRIPTION
Recent release of the W3C API includes adjustments to default shortnames for some of the specs. A couple of updates were needed for the CSS Images Module Level 3 and Trace Context.

The W3C API returns a 301 redirect when a non default shortname is used, which the code in `fetch-info.js` currently does not support (which explains why update is crashing for now). That should probably be fixed, but it seems a good thing in any case to align default shortnames with those of the W3C API.