### PR TITLE
Remove Web Budget API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -54,7 +54,6 @@
   "https://wicg.github.io/background-fetch/",
   "https://wicg.github.io/background-sync/spec/",
   "https://wicg.github.io/badging/",
-  "https://wicg.github.io/budget-api/",
   "https://wicg.github.io/client-hints-infrastructure/",
   "https://wicg.github.io/compression/",
   "https://wicg.github.io/construct-stylesheets/",


### PR DESCRIPTION
https://wicg.github.io/budget-api/ "is not being actively maintained"

The implementation was removed from Chromium:
https://groups.google.com/a/chromium.org/d/msg/blink-dev/18r3whCBv0I/b8qrtFTsDAAJ