### PR TITLE
Update CSS Parser API URL

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -60,7 +60,7 @@
   "https://wicg.github.io/contact-api/spec/",
   "https://wicg.github.io/cookie-store/",
   "https://wicg.github.io/cors-rfc1918/",
-  "https://wicg.github.io/CSS-Parser-API/",
+  "https://wicg.github.io/css-parser-api/",
   "https://wicg.github.io/element-timing/",
   "https://wicg.github.io/entries-api/",
   "https://wicg.github.io/event-timing/",


### PR DESCRIPTION
The repo was renamed, see https://github.com/WICG/admin/issues/112.