### PR TITLE
Update URL of Web Share Target spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -48,6 +48,7 @@
     }
   },
   "https://w3c.github.io/web-nfc/",
+  "https://w3c.github.io/web-share-target/",
   "https://w3c.github.io/webappsec-feature-policy/",
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
   "https://webbluetoothcg.github.io/web-bluetooth/",
@@ -95,7 +96,6 @@
   "https://wicg.github.io/video-rvfc/",
   "https://wicg.github.io/visual-viewport/",
   "https://wicg.github.io/web-locks/",
-  "https://wicg.github.io/web-share-target/",
   "https://wicg.github.io/web-transport/",
   "https://wicg.github.io/webusb/",
   {


### PR DESCRIPTION
Spec migrated to WebApps WG:
https://github.com/w3c/web-share-target/issues/87