### PR TITLE
Add script to find list of specs potentially in scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,8 +2133,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "auto-changelog": "^1.16.4",
     "mocha": "^7.0.0",
     "release-it": "^13.5.1"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.0"
   }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -1,0 +1,45 @@
+{
+  "repos": {
+    "w3c/adpt": {
+      "comment": "not targeted at browsers"
+    },
+    "w3c/imsc": {
+      "comment": "not targeted at browsers"
+    },
+    "w3c/tt-module-karaoke": {
+      "comment": "not targeted at browsers"
+    },
+    "w3c/tt-module-live":{
+      "comment": "not targeted at browsers"
+    },
+    "w3c/ttml1": {
+      "comment": "not targeted at browsers"
+    },
+    "w3c/ttml2": {
+      "comment": "not targeted at browsers"
+    },
+    "w3c/ttml3": {
+      "comment": "not targeted at browsers"
+    },
+    "WICG/open-ui": {
+      "comment": "not targeted at browsers"
+    }
+  },
+  "specs": {
+    "https://www.w3.org/TR/ttml-imsc1.2/": {
+      "comment": "not targeted at browsers"
+    },
+    "https://www.w3.org/TR/ttml2/": {
+      "comment": "not targeted at browsers"
+    },
+    "https://www.w3.org/TR/html53/": {
+      "comment": "about to be deprecated"
+    },
+    "https://www.w3.org/TR/microdata/": {
+      "comment": "about to be deprecated"
+    },
+    "https://www.w3.org/TR/dom/": {
+      "comment": "about to be deprecated"
+    }
+  }
+}

--- a/src/data/monitor-repos.json
+++ b/src/data/monitor-repos.json
@@ -1,0 +1,42 @@
+{
+  "WICG/datacue": {
+    "comment": "mostly TODOs",
+    "lastreviewed": "2020-06-11"
+  },
+  "privacycg/storage-partitioning/": {
+    "comment": "mostly TODOs",
+    "lastreviewed": "2020-06-11"
+  },
+  "w3c/system-wake-lock": {
+    "comment": "no spec yet",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/audio-focus": {
+    "comment": "only an explainer",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/file-handling": {
+    "comment": "only points to explainer",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/first-party-sets": {
+    "comment": "no spec yet",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/indexed-db-observers": {
+    "comment": "no spec yet (but 3 years old?)",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/media-latency-hint": {
+    "comment": "empty spec",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/sw-launch": {
+    "comment": "no spec yet",
+    "lastreviewed": "2020-06-11"
+  },
+  "WICG/virtual-scroller": {
+    "comment": "no spec yet",
+    "lastreviewed": "2020-06-11"
+  }
+}

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -51,7 +51,6 @@ const urlIfExists = u => fetch(u).then(({ok, url}) => {
   if (ok) return url;
 });
 
-try {
 (async function() {
   const {groups, repos} = await fetch("https://w3c.github.io/validate-repos/report.json").then(r => r.json());
   const specRepos = await fetch("https://w3c.github.io/spec-dashboard/repo-map.json").then(r => r.json());
@@ -116,8 +115,7 @@ try {
         .filter(isUnknownSpec);
   console.log("URLs from WHATWG with no matching URL in spec list")
   console.log(whatwgUrls);
-})();
-} catch(e) {
+})().catch(e => {
   console.error(e);
   process.exit(1);
-}
+});

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -47,7 +47,7 @@ const isUnknownSpec = url => !specs.find(s => s.nightly.url === url
                                          || (s.release && s.release.url === url))
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
       && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));
-const urlIfValid = u => fetch(u).then(({ok, url}) => {
+const urlIfExists = u => fetch(u).then(({ok, url}) => {
   if (ok) return url;
 });
 
@@ -78,7 +78,7 @@ try {
   const wgUrls = (await Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
                                  .map(toGhUrl)
                                  .filter(isUnknownSpec)
-                                    .map(urlIfValid))).filter(x => x);
+                                  .map(urlIfExists))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
   console.log(wgUrls);
 
@@ -107,7 +107,7 @@ try {
   const cgUrls = (await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
                                    .map(toGhUrl)
                                    .filter(isUnknownSpec)
-                                    .map(urlIfValid))).filter(x => x);
+                                   .map(urlIfExists))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
   console.log(cgUrls);
 
@@ -119,4 +119,5 @@ try {
 })();
 } catch(e) {
   console.error(e);
+  process.exit(1);
 }

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -43,7 +43,7 @@ function canonicalizeTRUrl(url) {
 
 const toGhUrl = repo => `https://${repo.owner.login.toLowerCase()}.github.io/${repo.name}/`
 const matchRepoName = fullName => r => fullName === r.owner.login + '/' + r.name;
-const isUnknownSpec = url => !specs.find(s => s.nightly.url === url
+const isUnknownSpec = url => !specs.find(s => s.nightly.url.startsWith(url)
                                          || (s.release && s.release.url === url))
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
       && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -51,6 +51,7 @@ try {
 (async function() {
   const {groups, repos} = await fetch("https://w3c.github.io/validate-repos/report.json").then(r => r.json());
   const specRepos = await fetch("https://w3c.github.io/spec-dashboard/repo-map.json").then(r => r.json());
+  const whatwgSpecs = await fetch("https://raw.githubusercontent.com/whatwg/sg/master/db.json").then(r => r.json()).then(d => d.workstreams.map(w => w.standards).flat());
 
   const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
   const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));
@@ -104,6 +105,12 @@ try {
                                    .map(isOkUrl));
   console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
   console.log(cgUrls.filter(x => x));
+
+
+  const whatwgUrls = whatwgSpecs.map(s => s.href)
+        .filter(isUnknownSpec);
+  console.log("URLs from WHATWG no matching URL in spec list")
+  console.log(whatwgUrls);
 })();
 } catch(e) {
   console.error(e);

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -45,7 +45,7 @@ const isUnknownSpec = url => !specs.find(s => s.nightly.url === url
                                          || (s.release && s.release.url === url))
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
       && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));
-const isOkUrl = u => fetch(u).then(({ok, url}) => {
+const urlIfValid = u => fetch(u).then(({ok, url}) => {
   if (ok) return url;
 });
 
@@ -73,12 +73,12 @@ try {
              );
 
   // * look if those without a homepage URL have a match with their generated URL
-  const wgUrls = await Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
+  const wgUrls = (await Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
                                  .map(toGhUrl)
                                  .filter(isUnknownSpec)
-                                 .map(isOkUrl));
+                                    .map(urlIfValid))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
-  console.log(wgUrls.filter(x => x));
+  console.log(wgUrls);
 
   // Look which of the specRepos on recTrack from a browser-producing WG have no match
   console.log("TR specs from browser-producing WGs")
@@ -102,12 +102,12 @@ try {
               .filter(isUnknownSpec)
              );
   // * look if those without a homepage URL have a match with their generated URL
-  const cgUrls = await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
+  const cgUrls = (await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
                                    .map(toGhUrl)
                                    .filter(isUnknownSpec)
-                                   .map(isOkUrl));
+                                    .map(urlIfValid))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
-  console.log(cgUrls.filter(x => x));
+  console.log(cgUrls);
 
 
   const whatwgUrls = whatwgSpecs.map(s => s.href)

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -7,55 +7,67 @@ const watchedBrowserCgs = ["Web Platform Incubator Community Group", "Web Assemb
 
 const canonicalizeGhUrl = url => (url.indexOf("github.io") > 0 && url.split("/").length === 4 ? url + '/' : url).replace('http:', 'https:');
 
-fetch("https://w3c.github.io/validate-repos/report.json")
-  .then(r => r.json())
-  .then(({groups, repos}) => {
-    const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
-    const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));
+Promise.all(
+  ["https://w3c.github.io/validate-repos/report.json",
+   "https://w3c.github.io/spec-dashboard/repo-map.json"].map(
+     dataUrl => fetch(dataUrl)
+       .then(r => r.json())
+   )
+).then(([{groups, repos}, specRepos]) => {
+  const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
+  const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));
 
-    // WGs
-    // * check repos with w3c.json/repo-type includes rec-track
-    const wgRepos = [].concat(...wgs.map(g => g.repos.map(r => r.fullName)))
-          .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
-    const recTrackRepos = wgRepos.filter(r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'rec-track' || r.w3c["repo-type"].includes('rec-track')));
-    // * look if those with homepage URLs have a match in the list of specs
-    console.log("URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
-    console.log(recTrackRepos.filter(r => r.homepageUrl)
-                .map(r => canonicalizeGhUrl(r.homepageUrl))
-                .filter(u => !specs.find(s => s.nightly.url === u || (s.release && s.release.url === u)))
-               );
-    // * look if those without a homepage URL have a match with their generated URL
-    Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
-                .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
-                .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
-                .map(u => fetch(u).then(({status, url}) => {
-                  if (status !== 404) return url;
-                }))).then(urls => {
-                  console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
-                  console.log(urls.filter(x => x));
-                }
-                         );
+  // WGs
+  // * check repos with w3c.json/repo-type includes rec-track
+  const wgRepos = [].concat(...wgs.map(g => g.repos.map(r => r.fullName)))
+        .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+  const recTrackRepos = wgRepos.filter(r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'rec-track' || r.w3c["repo-type"].includes('rec-track')));
+  // * look if those with homepage URLs have a match in the list of specs
+  console.log("URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
+  console.log(recTrackRepos.filter(r => r.homepageUrl)
+              .map(r => canonicalizeGhUrl(r.homepageUrl))
+              .filter(u => !specs.find(s => s.nightly.url === u || (s.release && s.release.url === u)))
+             );
+  // * look if those without a homepage URL have a match with their generated URL
+  Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
+              .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
+              .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
+              .map(u => fetch(u).then(({status, url}) => {
+                if (status !== 404) return url;
+              }))).then(urls => {
+                console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
+                console.log(urls.filter(x => x));
+              }
+                       );
 
-    // CGs
-    //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
-    const cgRepos = [].concat(...cgs.map(g => g.repos.map(r => r.fullName)))
-          .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
-    const cgSpecRepos = cgRepos.filter(r => !r.w3c || (r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'cg-report' || r.w3c["repo-type"].includes('cg-report'))));
-    // * look if those with homepage URLs have a match in the list of specs
-    console.log("URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
-    console.log(cgSpecRepos.filter(r => r.homepageUrl)
-                .map(r => canonicalizeGhUrl(r.homepageUrl))
-                .filter(u => !specs.find(s => s.nightly.url === u))
-               );
-    // * look if those without a homepage URL have a match with their generated URL
-    Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
-                .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
-                .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
-                .map(u => fetch(u).then(({status, url}) => {
-                  if (status !== 404) return url;
-                }))).then(urls => {
-                  console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
-                  console.log(urls.filter(x => x));
-                }
-                         );
-  });
+  // Look which of the specRepos on recTrack from a browser-producing WG have no match
+  console.log("TR specs from browser-producing WGs")
+  console.log(
+    [].concat(...Object.keys(specRepos).map(
+      r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => s.url)))
+      .filter(u  => !specs.find(s => s.release && s.release.url === u))
+  );
+
+  // CGs
+  //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
+  const cgRepos = [].concat(...cgs.map(g => g.repos.map(r => r.fullName)))
+        .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+  const cgSpecRepos = cgRepos.filter(r => !r.w3c || (r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'cg-report' || r.w3c["repo-type"].includes('cg-report'))));
+  // * look if those with homepage URLs have a match in the list of specs
+  console.log("URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
+  console.log(cgSpecRepos.filter(r => r.homepageUrl)
+              .map(r => canonicalizeGhUrl(r.homepageUrl))
+              .filter(u => !specs.find(s => s.nightly.url === u))
+             );
+  // * look if those without a homepage URL have a match with their generated URL
+  Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
+              .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
+              .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
+              .map(u => fetch(u).then(({status, url}) => {
+                if (status !== 404) return url;
+              }))).then(urls => {
+                console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
+                console.log(urls.filter(x => x));
+              }
+                       );
+});

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fetch = require("node-fetch");
 
 const specs = require("../index.json");
@@ -25,7 +27,7 @@ const watchedBrowserCgs = [
 ];
 
 function canonicalizeGhUrl(r) {
-  url = new URL(r.homepageUrl);
+  const url = new URL(r.homepageUrl);
   url.protocol = 'https:';
   if (url.pathname.lastIndexOf('/') === 0 && url.pathname.length > 1) {
       url.pathname += '/';

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -112,7 +112,7 @@ try {
 
   const whatwgUrls = whatwgSpecs.map(s => s.href)
         .filter(isUnknownSpec);
-  console.log("URLs from WHATWG no matching URL in spec list")
+  console.log("URLs from WHATWG with no matching URL in spec list")
   console.log(whatwgUrls);
 })();
 } catch(e) {

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -51,7 +51,7 @@ Promise.all(
 
   // WGs
   // * check repos with w3c.json/repo-type including rec-track
-  const wgRepos = [].concat(...wgs.map(g => g.repos.map(r => r.fullName)))
+  const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
         .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
   const recTrackRepos = wgRepos.filter(r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'rec-track' || r.w3c["repo-type"].includes('rec-track')));
   // * look if those with homepage URLs have a match in the list of specs
@@ -75,14 +75,15 @@ Promise.all(
   // Look which of the specRepos on recTrack from a browser-producing WG have no match
   console.log("TR specs from browser-producing WGs")
   console.log(
-    [].concat(...Object.keys(specRepos).map(
-      r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => canonicalizeTRUrl(s.url))))
+    Object.keys(specRepos).map(
+      r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => canonicalizeTRUrl(s.url)))
+      .flat()
       .filter(u  => !specs.find(s => s.release && s.release.url === u))
   );
 
   // CGs
   //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
-  const cgRepos = [].concat(...cgs.map(g => g.repos.map(r => r.fullName)))
+  const cgRepos = cgs.map(g => g.repos.map(r => r.fullName)).flat()
         .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
   const cgSpecRepos = cgRepos.filter(r => !r.w3c || (r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'cg-report' || r.w3c["repo-type"].includes('cg-report'))));
   // * look if those with homepage URLs have a match in the list of specs

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -1,0 +1,61 @@
+const fetch = require("node-fetch");
+
+const specs = require("../index.json");
+
+const nonBrowserSpecWgs = ["Accessibility Guidelines Working Group", "Accessible Platform Architectures Working Group", "Automotive Working Group", "Dataset Exchange Working Group", "Decentralized Identifier Working Group", "Distributed Tracing Working Group", "Education and Outreach Working Group", "JSON-LD Working Group", "Publishing Working Group", "Verifiable Credentials Working Group", "Web of Things Working Group"];
+const watchedBrowserCgs = ["Web Platform Incubator Community Group", "Web Assembly Community Group", "Immersive Web Community Group", "Audio Community Group", "Privacy Community Group", "GPU for the Web Community Group"];
+
+const canonicalizeGhUrl = url => (url.indexOf("github.io") > 0 && url.split("/").length === 4 ? url + '/' : url).replace('http:', 'https:');
+
+fetch("https://w3c.github.io/validate-repos/report.json")
+  .then(r => r.json())
+  .then(({groups, repos}) => {
+    const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
+    const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));
+
+    // WGs
+    // * check repos with w3c.json/repo-type includes rec-track
+    const wgRepos = [].concat(...wgs.map(g => g.repos.map(r => r.fullName)))
+          .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+    const recTrackRepos = wgRepos.filter(r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'rec-track' || r.w3c["repo-type"].includes('rec-track')));
+    // * look if those with homepage URLs have a match in the list of specs
+    console.log("URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
+    console.log(recTrackRepos.filter(r => r.homepageUrl)
+                .map(r => canonicalizeGhUrl(r.homepageUrl))
+                .filter(u => !specs.find(s => s.nightly.url === u || (s.release && s.release.url === u)))
+               );
+    // * look if those without a homepage URL have a match with their generated URL
+    Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
+                .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
+                .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
+                .map(u => fetch(u).then(({status, url}) => {
+                  if (status !== 404) return url;
+                }))).then(urls => {
+                  console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
+                  console.log(urls.filter(x => x));
+                }
+                         );
+
+    // CGs
+    //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
+    const cgRepos = [].concat(...cgs.map(g => g.repos.map(r => r.fullName)))
+          .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+    const cgSpecRepos = cgRepos.filter(r => !r.w3c || (r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'cg-report' || r.w3c["repo-type"].includes('cg-report'))));
+    // * look if those with homepage URLs have a match in the list of specs
+    console.log("URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
+    console.log(cgSpecRepos.filter(r => r.homepageUrl)
+                .map(r => canonicalizeGhUrl(r.homepageUrl))
+                .filter(u => !specs.find(s => s.nightly.url === u))
+               );
+    // * look if those without a homepage URL have a match with their generated URL
+    Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
+                .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
+                .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
+                .map(u => fetch(u).then(({status, url}) => {
+                  if (status !== 404) return url;
+                }))).then(urls => {
+                  console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
+                  console.log(urls.filter(x => x));
+                }
+                         );
+  });

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -6,6 +6,7 @@ const nonBrowserSpecWgs = ["Accessibility Guidelines Working Group", "Accessible
 const watchedBrowserCgs = ["Web Platform Incubator Community Group", "Web Assembly Community Group", "Immersive Web Community Group", "Audio Community Group", "Privacy Community Group", "GPU for the Web Community Group"];
 
 const canonicalizeGhUrl = url => (url.indexOf("github.io") > 0 && url.split("/").length === 4 ? url + '/' : url).replace('http:', 'https:');
+const canonicalizeTRUrl = url => url.replace('http:', 'https:');
 
 Promise.all(
   ["https://w3c.github.io/validate-repos/report.json",
@@ -44,7 +45,7 @@ Promise.all(
   console.log("TR specs from browser-producing WGs")
   console.log(
     [].concat(...Object.keys(specRepos).map(
-      r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => s.url)))
+      r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => canonicalizeTRUrl(s.url))))
       .filter(u  => !specs.find(s => s.release && s.release.url === u))
   );
 

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -39,38 +39,39 @@ function canonicalizeTRUrl(url) {
   return url.toString();
 }
 
-Promise.all(
-  ["https://w3c.github.io/validate-repos/report.json",
-   "https://w3c.github.io/spec-dashboard/repo-map.json"].map(
-     dataUrl => fetch(dataUrl)
-       .then(r => r.json())
-   )
-).then(([{groups, repos}, specRepos]) => {
+const toGhUrl = repo => `https://${repo.owner.login.toLowerCase()}.github.io/${repo.name}/`
+const matchRepoName = fullName => r => fullName === r.owner.login + '/' + r.name;
+const isUnknownSpec = url => !specs.find(s => s.nightly.url === url || (s.release && s.release.url === url))
+try {
+(async function() {
+  const {groups, repos} = await fetch("https://w3c.github.io/validate-repos/report.json").then(r => r.json());
+  const specRepos = await fetch("https://w3c.github.io/spec-dashboard/repo-map.json").then(r => r.json());
+
   const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
   const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));
 
   // WGs
   // * check repos with w3c.json/repo-type including rec-track
   const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
-        .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+        .map(fullName => repos.find(matchRepoName(fullName)));
   const recTrackRepos = wgRepos.filter(r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'rec-track' || r.w3c["repo-type"].includes('rec-track')));
+
   // * look if those with homepage URLs have a match in the list of specs
   console.log("URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
   console.log(recTrackRepos.filter(r => r.homepageUrl)
               .map(r => canonicalizeGhUrl(r.homepageUrl))
-              .filter(u => !specs.find(s => s.nightly.url === u || (s.release && s.release.url === u)))
+              .filter(isUnknownSpec)
              );
+
   // * look if those without a homepage URL have a match with their generated URL
-  Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
-              .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
-              .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
-              .map(u => fetch(u).then(({ok, url}) => {
-                if (ok) return url;
-              }))).then(urls => {
-                console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
-                console.log(urls.filter(x => x));
-              }
-                       );
+  const urls = await Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
+                                 .map(toGhUrl)
+                                 .filter(isUnknownSpec)
+                                 .map(u => fetch(u).then(({ok, url}) => {
+                                   if (ok) return url;
+                                 })));
+  console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
+  console.log(urls.filter(x => x));
 
   // Look which of the specRepos on recTrack from a browser-producing WG have no match
   console.log("TR specs from browser-producing WGs")
@@ -78,29 +79,30 @@ Promise.all(
     Object.keys(specRepos).map(
       r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => canonicalizeTRUrl(s.url)))
       .flat()
-      .filter(u  => !specs.find(s => s.release && s.release.url === u))
+      .filter(isUnknownSpec)
   );
 
   // CGs
   //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
   const cgRepos = cgs.map(g => g.repos.map(r => r.fullName)).flat()
-        .map(fullName => repos.find(r => fullName === r.owner.login + '/' + r.name));
+        .map(fullName => repos.find(matchRepoName(fullName)));
   const cgSpecRepos = cgRepos.filter(r => !r.w3c || (r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === 'cg-report' || r.w3c["repo-type"].includes('cg-report'))));
   // * look if those with homepage URLs have a match in the list of specs
   console.log("URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
   console.log(cgSpecRepos.filter(r => r.homepageUrl)
               .map(r => canonicalizeGhUrl(r.homepageUrl))
-              .filter(u => !specs.find(s => s.nightly.url === u))
+              .filter(isUnknownSpec)
              );
   // * look if those without a homepage URL have a match with their generated URL
-  Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
-              .map(r => `https://${r.owner.login.toLowerCase()}.github.io/${r.name}/`)
-              .filter(u => !specs.find(s => s.nightly.url === u))
-              .map(u => fetch(u).then(({status, url}) => {
-                if (status !== 404) return url;
-              }))).then(urls => {
-                console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
-                console.log(urls.filter(x => x));
-              }
-                       );
-});
+  const cgUrls = await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
+                                   .map(toGhUrl)
+                                   .filter(isUnknownSpec)
+              .map(u => fetch(u).then(({ok, url}) => {
+                if (ok) return url;
+              })));
+  console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
+  console.log(cgUrls.filter(x => x));
+})();
+} catch(e) {
+  console.error(e);
+}

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -3,6 +3,8 @@
 const fetch = require("node-fetch");
 
 const specs = require("../index.json");
+const ignored = require("./data/ignore.json");
+const monitoredRepos = require("./data/monitor-repos.json");
 
 const nonBrowserSpecWgs = [
   "Accessibility Guidelines Working Group",
@@ -43,6 +45,8 @@ function canonicalizeTRUrl(url) {
 
 const toGhUrl = repo => `https://${repo.owner.login.toLowerCase()}.github.io/${repo.name}/`
 const matchRepoName = fullName => r => fullName === r.owner.login + '/' + r.name;
+const isNotIgnorableRepo = fullName => !Object.keys(ignored.repos).includes(fullName) && !Object.keys(monitoredRepos).includes(fullName);
+const isNotIgnorableSpec = url => !Object.keys(ignored.specs).includes(url);
 const isUnknownSpec = url => !specs.find(s => s.nightly.url.startsWith(url)
                                          || (s.release && s.release.url === url))
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
@@ -63,6 +67,7 @@ const urlIfExists = u => fetch(u).then(({ok, url}) => {
   // WGs
   // * check repos with w3c.json/repo-type including rec-track
   const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
+        .filter(isNotIgnorableRepo)
         .map(fullName => repos.find(matchRepoName(fullName)));
   const recTrackRepos = wgRepos.filter(hasRepoType('rec-track'));
 
@@ -71,13 +76,15 @@ const urlIfExists = u => fetch(u).then(({ok, url}) => {
   console.log(recTrackRepos.filter(r => r.homepageUrl)
               .map(canonicalizeGhUrl)
               .filter(isUnknownSpec)
+              .filter(isNotIgnorableSpec)
              );
 
   // * look if those without a homepage URL have a match with their generated URL
   const wgUrls = (await Promise.all(recTrackRepos.filter(r => !r.homepageUrl)
-                                 .map(toGhUrl)
-                                 .filter(isUnknownSpec)
-                                  .map(urlIfExists))).filter(x => x);
+                                    .map(toGhUrl)
+                                    .filter(isUnknownSpec)
+                                    .filter(isNotIgnorableSpec)
+                                    .map(urlIfExists))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing WG with no matching URL in spec list")
   console.log(wgUrls);
 
@@ -88,12 +95,15 @@ const urlIfExists = u => fetch(u).then(({ok, url}) => {
       r => specRepos[r].filter(s => s.recTrack && wgs.find(g => g.id === s.group)).map(s => canonicalizeTRUrl(s.url)))
       .flat()
       .filter(isUnknownSpec)
+      .filter(isNotIgnorableSpec)
   );
 
   // CGs
   //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
   const cgRepos = cgs.map(g => g.repos.map(r => r.fullName)).flat()
+        .filter(isNotIgnorableRepo)
         .map(fullName => repos.find(matchRepoName(fullName)));
+
   const cgSpecRepos = cgRepos.filter(r => !r.w3c
                                      || hasRepoType('cg-report')(r));
   // * look if those with homepage URLs have a match in the list of specs
@@ -101,18 +111,21 @@ const urlIfExists = u => fetch(u).then(({ok, url}) => {
   console.log(cgSpecRepos.filter(r => r.homepageUrl)
               .map(canonicalizeGhUrl)
               .filter(isUnknownSpec)
+              .filter(isNotIgnorableSpec)
              );
   // * look if those without a homepage URL have a match with their generated URL
   const cgUrls = (await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
-                                   .map(toGhUrl)
-                                   .filter(isUnknownSpec)
-                                   .map(urlIfExists))).filter(x => x);
+                                    .map(toGhUrl)
+                                    .filter(isUnknownSpec)
+                                    .filter(isNotIgnorableSpec)
+                                    .map(urlIfExists))).filter(x => x);
   console.log("Unadvertized URLs from a repo of a browser-spec producing CG with no matching URL in spec list")
   console.log(cgUrls);
 
 
   const whatwgUrls = whatwgSpecs.map(s => s.href)
-        .filter(isUnknownSpec);
+        .filter(isUnknownSpec)
+        .filter(isNotIgnorableSpec);
   console.log("URLs from WHATWG with no matching URL in spec list")
   console.log(whatwgUrls);
 })().catch(e => {

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -62,8 +62,8 @@ Promise.all(
              );
   // * look if those without a homepage URL have a match with their generated URL
   Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
-              .map(r => `https://${r.owner.login}.github.io/${r.name}/`)
-              .filter(u => !specs.find(s => s.nightly.url.startsWith(u)))
+              .map(r => `https://${r.owner.login.toLowerCase()}.github.io/${r.name}/`)
+              .filter(u => !specs.find(s => s.nightly.url === u))
               .map(u => fetch(u).then(({status, url}) => {
                 if (status !== 404) return url;
               }))).then(urls => {

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -41,8 +41,10 @@ function canonicalizeTRUrl(url) {
 
 const toGhUrl = repo => `https://${repo.owner.login.toLowerCase()}.github.io/${repo.name}/`
 const matchRepoName = fullName => r => fullName === r.owner.login + '/' + r.name;
-const isUnknownSpec = url => !specs.find(s => s.nightly.url === url || (s.release && s.release.url === url))
-const hasRepoType = type => r => r.w3c && r.w3c["repo-type"] && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type))
+const isUnknownSpec = url => !specs.find(s => s.nightly.url === url
+                                         || (s.release && s.release.url === url))
+const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
+      && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));
 const isOkUrl = u => fetch(u).then(({ok, url}) => {
   if (ok) return url;
 });
@@ -51,7 +53,8 @@ try {
 (async function() {
   const {groups, repos} = await fetch("https://w3c.github.io/validate-repos/report.json").then(r => r.json());
   const specRepos = await fetch("https://w3c.github.io/spec-dashboard/repo-map.json").then(r => r.json());
-  const whatwgSpecs = await fetch("https://raw.githubusercontent.com/whatwg/sg/master/db.json").then(r => r.json()).then(d => d.workstreams.map(w => w.standards).flat());
+  const whatwgSpecs = await fetch("https://raw.githubusercontent.com/whatwg/sg/master/db.json").then(r => r.json())
+        .then(d => d.workstreams.map(w => w.standards).flat());
 
   const wgs = Object.values(groups).filter(g => g.type === "working group" && !nonBrowserSpecWgs.includes(g.name));
   const cgs = Object.values(groups).filter(g => g.type === "community group" && watchedBrowserCgs.includes(g.name));


### PR DESCRIPTION
per #50
Looks into the report from validate-repo for repos associated with browser-spec producing WGs and well-known browser-spec producing CGs (both lists curated manually) and match that list of repos with URLs known in browser-spec