### PR TITLE
Add tests to compare base URL with release/nightly URL

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -86,4 +86,14 @@ describe("List of specs", () => {
     });
     assert.deepStrictEqual(wrong, []);
   });
+
+  it("uses the release URL as base URL when there is a release URL", () => {
+    const wrong = specs.filter(s => s.release && s.url !== s.release.url);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("uses the nightly URL as base URL when there is no release URL", () => {
+    const wrong = specs.filter(s => !s.release && s.url !== s.nightly.url);
+    assert.deepStrictEqual(wrong, []);
+  });
 });


### PR DESCRIPTION
The base URL should either match the release URL if there is one or the nightly URL otherwise. New tests will fail when there are entries in `index.json` for which that is not the case.

The first test should also help with identification of situations where a FPWD was published, and is known to Specref but not to us (#62).

Note that, as opposed to other tests that only depend on internal code logic, the second test may fail because external sources (Specref in practice) need to be fixed to return the right nightly URL. Fixing the problem at the source may take some time. Making tests fail certainly creates a strong incentive to fix the problem upstream, but means we're going to be stuck in a "some tests fail" situation in the meantime.

Typically, the tests currently choke on:
- `https://www.w3.org/TR/webxr-ar-module/`: the W3C API says that the release URL is `https://www.w3.org/TR/webxr-ar-module-1/` but then the right shortname for the W3C API remains `webxr-ar-module`. If we add `-1` to the base URL, the code won't be able to retrieve the info from the W3C API. Trying to see if this can be fixed in W3C systems.
- `https://www.w3.org/TR/webxr-gamepads-module/`: same reason
- `https://drafts.csswg.org/css-backgrounds-4/`: Specref returns `https://drafts.csswg.org/css4-background/` for the nightly URL. Filed https://github.com/w3c/csswg-drafts/pull/5194 to address this at the source
- `https://wicg.github.io/badging/`: URL needs to be updated to `https://w3c.github.io/badging/` in specs.json
- `https://wicg.github.io/geolocation-sensor/`: URL needs to be updated to `https://www.w3.org/TR/geolocation-sensor/` in specs.json
- `https://wicg.github.io/frame-timing/`: spec was published as a /TR/ Note but moved back to WICG. The URL of the ED URL needs to be updated in W3C systems (request sent).

PR should not be merged until these get fixed.