### PR TITLE
Move SVG Streaming to ignore list 

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -36,6 +36,7 @@
   "https://storage.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",
   "https://svgwg.org/specs/animations/",
+  "https://svgwg.org/specs/streaming/",
   "https://url.spec.whatwg.org/",
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contentEditable/",

--- a/specs.json
+++ b/specs.json
@@ -36,7 +36,6 @@
   "https://storage.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",
   "https://svgwg.org/specs/animations/",
-  "https://svgwg.org/specs/streaming/",
   "https://url.spec.whatwg.org/",
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contentEditable/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -77,6 +77,9 @@
     }
   },
   "specs": {
+    "https://svgwg.org/specs/streaming/": {
+      "comment": "early proposal with no current active work"
+    },
     "https://www.w3.org/TR/ttml-imsc1.2/": {
       "comment": "not targeted at browsers"
     },


### PR DESCRIPTION
Implementation plans aren't all that clear, but probably not substantively different from e.g. SVG Animations which is already in the list