### PR TITLE
Drop MediaStream Depth ED URL

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -41,7 +41,6 @@
   "https://w3c.github.io/contentEditable/",
   "https://w3c.github.io/gamepad/extensions.html",
   "https://w3c.github.io/media-playback-quality/",
-  "https://w3c.github.io/mediacapture-depth/",
   {
     "url": "https://w3c.github.io/ServiceWorker/",
     "shortname": "service-workers",


### PR DESCRIPTION
Spec already covered through a /TR/ URL.
See discussion in https://github.com/w3c/browser-specs/pull/90#issuecomment-644755268