### PR TITLE
Add Media Feeds spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -83,6 +83,7 @@
   "https://wicg.github.io/keyboard-map/",
   "https://wicg.github.io/largest-contentful-paint/",
   "https://wicg.github.io/layout-instability/",
+  "https://wicg.github.io/media-feeds/",
   "https://wicg.github.io/native-file-system/",
   "https://wicg.github.io/netinfo/",
   "https://wicg.github.io/origin-policy/",


### PR DESCRIPTION
Has an implementation in Chrome behind a flag https://www.chromestatus.com/features/5695114963845120

this should probably be handled similarly to our approach to #86 