### PR TITLE
Allow nightly URL in specs.json, adjust Service Workers entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ property in `index.json`.
 - `seriesComposition`: same as the [`seriesVersion`](README.md#seriesversion)
 property in `index.json`. The property must only be set for delta spec (since
 full is the default).
+- `nightly`: same as the [`nightly`](REAMDE.md#nightly) property in
+`index.json`. The property must only be set when the URL of the nightly spec
+returned by external sources would be wrong **and** when it cannot be fixed at
+the source.
 - `forceCurrent`: a boolean flag to tell the code that the spec should be seen
 as the current spec in the series. The property must only be set when value is
 `true`.

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -17,6 +17,7 @@
           "series": { "$ref": "definitions.json#/proptype/series" },
           "seriesVersion": { "$ref": "definitions.json#/proptype/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/proptype/seriesComposition" },
+          "nightly": { "$ref": "definitions.json#/proptype/release" },
           "forceCurrent": { "type": "boolean" }
         },
         "required": ["url"],

--- a/specs.json
+++ b/specs.json
@@ -44,13 +44,6 @@
   "https://w3c.github.io/gamepad/extensions.html",
   "https://w3c.github.io/mathml-aam/",
   "https://w3c.github.io/media-playback-quality/",
-  {
-    "url": "https://w3c.github.io/ServiceWorker/",
-    "shortname": "service-workers",
-    "series": {
-      "shortname": "service-workers"
-    }
-  },
   "https://w3c.github.io/web-nfc/",
   "https://w3c.github.io/web-share-target/",
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
@@ -310,6 +303,12 @@
   "https://www.w3.org/TR/selectors-4/",
   "https://www.w3.org/TR/selectors-nonelement-1/",
   "https://www.w3.org/TR/server-timing/",
+  {
+    "url": "https://www.w3.org/TR/service-workers-1/",
+    "nightly": {
+      "url": "https://w3c.github.io/ServiceWorker/"
+    }
+  },
   "https://www.w3.org/TR/SRI/",
   "https://www.w3.org/TR/svg-aam-1.0/",
   "https://www.w3.org/TR/svg-integration/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -52,10 +52,17 @@ const specs = require("../specs.json")
 
 
 // Fetch additional spec info from external sources and complete the list
+// Note on the "assign" call:
+// - `{}` is needed to avoid overriding spec
+// - `spec` appears first to impose the order of properties computed above in
+// the resulting object
+// - `specInfo[spec.shortname]` is the info we retrieved from the source
+// - final `spec` ensures that properties defined in specs.json override info
+// from the source.
 fetchInfo(specs, { w3cApiKey })
   .then(specInfo => {
     const index = specs
-      .map(spec => Object.assign(spec, specInfo[spec.shortname]));
+      .map(spec => Object.assign({}, spec, specInfo[spec.shortname], spec));
 
     // Return the resulting list
     console.log(JSON.stringify(index, null, 2));


### PR DESCRIPTION
Authors may now specify the nightly URL in `specs.json` through the `nightly` object.

The update also changes the Service Workers entry to use the /TR/ URL (and overrides the nightly URL)

Fixes #94.