### PR TITLE
Add shortTitle property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,13 @@ property in `index.json`.
 - `seriesComposition`: same as the [`seriesVersion`](README.md#seriesversion)
 property in `index.json`. The property must only be set for delta spec (since
 full is the default).
-- `nightly`: same as the [`nightly`](REAMDE.md#nightly) property in
+- `nightly`: same as the [`nightly`](README.md#nightly) property in
 `index.json`. The property must only be set when the URL of the nightly spec
 returned by external sources would be wrong **and** when it cannot be fixed at
 the source.
+- `shortTitle`: same as the [`shortTitle`](README.md#shorttitle) property in
+`index.json`. The property must only be set when the short title computed
+automatically is not the expected one.
 - `forceCurrent`: a boolean flag to tell the code that the spec should be seen
 as the current spec in the series. The property must only be set when value is
 `true`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ cross-references, WebIDL, quality, etc.
   - [`url`](#url)
   - [`shortname`](#shortname)
   - [`title`](#title)
+  - [`shortTitle`](#shorttitle)
   - [`series`](#series)
     - [`series.shortname`](#seriesshortname)
     - [`series.currentSpecification`](#seriescurrentspecification)
@@ -121,6 +122,16 @@ The title of the spec. The title is either retrieved from the
 [`source`](#source) property details the actual provenance.
 
 The `title` property is always set.
+
+
+### `shortTitle`
+
+The short title of the spec. In most cases, the short title is generated from
+`title` by dropping terms such as "Module", "Level", or "Standard". In some
+cases, the short title is set manually.
+
+The `shortTitle` property is always set. When there is no meaningful short
+title, the property is set to the actual (possibly long) title of the spec.
 
 
 ### `series`

--- a/index.json
+++ b/index.json
@@ -1000,7 +1000,7 @@
     },
     "title": "CORS and RFC1918",
     "source": "specref",
-    "shortTitle": "CORS and RFC1918 1918"
+    "shortTitle": "CORS and RFC1918"
   },
   {
     "url": "https://wicg.github.io/crash-reporting/",

--- a/index.json
+++ b/index.json
@@ -12,7 +12,8 @@
       "repository": "https://github.com/whatwg/compat"
     },
     "title": "Compatibility Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Compatibility"
   },
   {
     "url": "https://console.spec.whatwg.org/",
@@ -27,7 +28,8 @@
       "repository": "https://github.com/whatwg/console"
     },
     "title": "Console Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Console"
   },
   {
     "url": "https://dom.spec.whatwg.org/",
@@ -42,7 +44,8 @@
       "repository": "https://github.com/whatwg/dom"
     },
     "title": "DOM Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "DOM"
   },
   {
     "url": "https://drafts.css-houdini.org/css-typed-om-2/",
@@ -59,7 +62,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Typed OM Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Typed OM 2"
   },
   {
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
@@ -75,7 +79,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "Font Metrics API Level 1",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Font Metrics API 1"
   },
   {
     "url": "https://drafts.csswg.org/css-animations-2/",
@@ -92,7 +97,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Animations Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Animations 2"
   },
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
@@ -109,7 +115,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Backgrounds and Borders Module Level 4",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "CSS Backgrounds and Borders 4"
   },
   {
     "url": "https://drafts.csswg.org/css-env-1/",
@@ -125,7 +132,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Environment Variables Module Level 1",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Environment Variables 1"
   },
   {
     "url": "https://drafts.csswg.org/css-extensions-1/",
@@ -141,7 +149,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Extensions",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Extensions"
   },
   {
     "url": "https://drafts.csswg.org/css-gcpm-4/",
@@ -158,7 +167,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Generated Content for Paged Media Module Level 4",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Generated Content for Paged Media 4"
   },
   {
     "url": "https://drafts.csswg.org/css-highlight-api-1/",
@@ -174,7 +184,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Custom Highlight API Module Level 1",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Custom Highlight API 1"
   },
   {
     "url": "https://drafts.csswg.org/css-multicol-2/",
@@ -191,7 +202,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Multi-column Layout Module Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Multi-column Layout 2"
   },
   {
     "url": "https://drafts.csswg.org/css-nesting-1/",
@@ -207,7 +219,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Nesting Module",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Nesting"
   },
   {
     "url": "https://drafts.csswg.org/css-page-4/",
@@ -224,7 +237,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Proposals for the future of CSS Paged Media",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Proposals for the future of CSS Paged Media"
   },
   {
     "url": "https://drafts.csswg.org/css-shapes-2/",
@@ -241,7 +255,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Shapes Module Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Shapes 2"
   },
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
@@ -257,7 +272,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Mobile Text Size Adjustment Module Level 1",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Mobile Text Size Adjustment 1"
   },
   {
     "url": "https://drafts.csswg.org/css-transitions-2/",
@@ -274,7 +290,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Transitions Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "CSS Transitions 2"
   },
   {
     "url": "https://drafts.csswg.org/scroll-animations-1/",
@@ -290,7 +307,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Scroll-linked Animations",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Scroll-linked Animations"
   },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",
@@ -307,7 +325,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Compositing and Blending Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Compositing and Blending 2"
   },
   {
     "url": "https://drafts.fxtf.org/filter-effects-2/",
@@ -324,7 +343,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Filter Effects Module Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Filter Effects 2"
   },
   {
     "url": "https://fetch.spec.whatwg.org/",
@@ -339,7 +359,8 @@
       "repository": "https://github.com/whatwg/fetch"
     },
     "title": "Fetch Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Fetch"
   },
   {
     "url": "https://fullscreen.spec.whatwg.org/",
@@ -354,7 +375,8 @@
       "repository": "https://github.com/whatwg/fullscreen"
     },
     "title": "Fullscreen API Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Fullscreen API"
   },
   {
     "url": "https://gpuweb.github.io/gpuweb/",
@@ -369,7 +391,8 @@
       "repository": "https://github.com/gpuweb/gpuweb"
     },
     "title": "WebGPU",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebGPU"
   },
   {
     "url": "https://html.spec.whatwg.org/multipage/",
@@ -384,7 +407,8 @@
       "repository": "https://github.com/whatwg/html"
     },
     "title": "HTML Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "HTML"
   },
   {
     "url": "https://immersive-web.github.io/anchors/",
@@ -399,7 +423,8 @@
       "repository": "https://github.com/immersive-web/anchors"
     },
     "title": "WebXR Anchors Module",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebXR Anchors"
   },
   {
     "url": "https://immersive-web.github.io/dom-overlays/",
@@ -414,7 +439,8 @@
       "repository": "https://github.com/immersive-web/dom-overlays"
     },
     "title": "WebXR DOM Overlays Module",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebXR DOM Overlays"
   },
   {
     "url": "https://immersive-web.github.io/hit-test/",
@@ -429,7 +455,8 @@
       "repository": "https://github.com/immersive-web/hit-test"
     },
     "title": "WebXR Hit Test Module",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebXR Hit Test"
   },
   {
     "url": "https://immersive-web.github.io/layers/",
@@ -444,7 +471,8 @@
       "repository": "https://github.com/immersive-web/layers"
     },
     "title": "WebXR Layers API Level 1",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebXR Layers API 1"
   },
   {
     "url": "https://infra.spec.whatwg.org/",
@@ -459,7 +487,8 @@
       "repository": "https://github.com/whatwg/infra"
     },
     "title": "Infra Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Infra"
   },
   {
     "url": "https://mathml-refresh.github.io/mathml-core/",
@@ -474,7 +503,8 @@
       "repository": "https://github.com/mathml-refresh/mathml-core"
     },
     "title": "MathML Core",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "MathML Core"
   },
   {
     "url": "https://mimesniff.spec.whatwg.org/",
@@ -489,7 +519,8 @@
       "repository": "https://github.com/whatwg/mimesniff"
     },
     "title": "MIME Sniffing Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "MIME Sniffing"
   },
   {
     "url": "https://notifications.spec.whatwg.org/",
@@ -504,7 +535,8 @@
       "repository": "https://github.com/whatwg/notifications"
     },
     "title": "Notifications API Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Notifications API"
   },
   {
     "url": "https://privacycg.github.io/private-click-measurement/",
@@ -519,7 +551,8 @@
       "repository": "https://github.com/privacycg/private-click-measurement"
     },
     "title": "Private Click Measurement",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Private Click Measurement"
   },
   {
     "url": "https://privacycg.github.io/storage-access/",
@@ -534,7 +567,8 @@
       "repository": "https://github.com/privacycg/storage-access"
     },
     "title": "The Storage Access API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "The Storage Access API"
   },
   {
     "url": "https://quirks.spec.whatwg.org/",
@@ -549,7 +583,8 @@
       "repository": "https://github.com/whatwg/quirks"
     },
     "title": "Quirks Mode Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Quirks Mode"
   },
   {
     "url": "https://storage.spec.whatwg.org/",
@@ -564,7 +599,8 @@
       "repository": "https://github.com/whatwg/storage"
     },
     "title": "Storage Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Storage"
   },
   {
     "url": "https://streams.spec.whatwg.org/",
@@ -579,7 +615,8 @@
       "repository": "https://github.com/whatwg/streams"
     },
     "title": "Streams Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Streams"
   },
   {
     "url": "https://svgwg.org/specs/animations/",
@@ -594,7 +631,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "SVG Animations Level 2",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "SVG Animations 2"
   },
   {
     "url": "https://url.spec.whatwg.org/",
@@ -609,7 +647,8 @@
       "repository": "https://github.com/whatwg/url"
     },
     "title": "URL Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "URL"
   },
   {
     "url": "https://w3c.github.io/badging/",
@@ -624,7 +663,8 @@
       "repository": "https://github.com/w3c/badging"
     },
     "title": "Badging API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Badging API"
   },
   {
     "url": "https://w3c.github.io/contentEditable/",
@@ -639,7 +679,8 @@
       "repository": "https://github.com/w3c/contentEditable"
     },
     "title": "ContentEditable",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "ContentEditable"
   },
   {
     "url": "https://w3c.github.io/gamepad/extensions.html",
@@ -654,7 +695,8 @@
       "repository": "https://github.com/w3c/gamepad"
     },
     "title": "Gamepad Extensions",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Gamepad Extensions"
   },
   {
     "url": "https://w3c.github.io/mathml-aam/",
@@ -669,7 +711,8 @@
       "repository": "https://github.com/w3c/mathml-aam"
     },
     "title": "MathML Accessiblity API Mappings 1.0",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "MathML Accessiblity API Mappings 1.0"
   },
   {
     "url": "https://w3c.github.io/media-playback-quality/",
@@ -684,7 +727,8 @@
       "repository": "https://github.com/w3c/media-playback-quality"
     },
     "title": "Media Playback Quality",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Media Playback Quality"
   },
   {
     "url": "https://w3c.github.io/web-nfc/",
@@ -699,7 +743,8 @@
       "repository": "https://github.com/w3c/web-nfc"
     },
     "title": "Web NFC API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web NFC API"
   },
   {
     "url": "https://w3c.github.io/web-share-target/",
@@ -714,7 +759,8 @@
       "repository": "https://github.com/w3c/web-share-target"
     },
     "title": "Web Share Target API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web Share Target API"
   },
   {
     "url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
@@ -729,7 +775,8 @@
       "repository": "https://github.com/w3c/webappsec-trusted-types"
     },
     "title": "Trusted Types",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Trusted Types"
   },
   {
     "url": "https://w3c.github.io/webdriver-bidi/",
@@ -744,7 +791,8 @@
       "repository": "https://github.com/w3c/webdriver-bidi"
     },
     "title": "WebDriver BiDi",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebDriver BiDi"
   },
   {
     "url": "https://w3c.github.io/webrtc-ice/",
@@ -759,7 +807,8 @@
       "repository": "https://github.com/w3c/webrtc-ice"
     },
     "title": "IceTransport Extensions for WebRTC",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "IceTransport Extensions for WebRTC"
   },
   {
     "url": "https://w3c.github.io/webrtc-insertable-streams/",
@@ -774,7 +823,8 @@
       "repository": "https://github.com/w3c/webrtc-insertable-streams"
     },
     "title": "WebRTC Insertable Media using Streams",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebRTC Insertable Media using Streams"
   },
   {
     "url": "https://webbluetoothcg.github.io/web-bluetooth/",
@@ -789,7 +839,8 @@
       "repository": "https://github.com/WebBluetoothCG/web-bluetooth"
     },
     "title": "Web Bluetooth",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web Bluetooth"
   },
   {
     "url": "https://wicg.github.io/background-fetch/",
@@ -804,7 +855,8 @@
       "repository": "https://github.com/WICG/background-fetch"
     },
     "title": "Background Fetch",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Background Fetch"
   },
   {
     "url": "https://wicg.github.io/background-sync/spec/",
@@ -819,7 +871,8 @@
       "repository": "https://github.com/WICG/background-sync"
     },
     "title": "Web Background Synchronization",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Web Background Synchronization"
   },
   {
     "url": "https://wicg.github.io/change-password-url/",
@@ -834,7 +887,8 @@
       "repository": "https://github.com/WICG/change-password-url"
     },
     "title": "A Well-Known URL for Changing Passwords",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "A Well-Known URL for Changing Passwords"
   },
   {
     "url": "https://wicg.github.io/client-hints-infrastructure/",
@@ -849,7 +903,8 @@
       "repository": "https://github.com/WICG/client-hints-infrastructure"
     },
     "title": "Client Hints Infrastructure",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Client Hints Infrastructure"
   },
   {
     "url": "https://wicg.github.io/compression/",
@@ -864,7 +919,8 @@
       "repository": "https://github.com/WICG/compression"
     },
     "title": "Compression Streams",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Compression Streams"
   },
   {
     "url": "https://wicg.github.io/construct-stylesheets/",
@@ -879,7 +935,8 @@
       "repository": "https://github.com/WICG/construct-stylesheets"
     },
     "title": "Constructable Stylesheet Objects",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Constructable Stylesheet Objects"
   },
   {
     "url": "https://wicg.github.io/contact-api/spec/",
@@ -894,7 +951,8 @@
       "repository": "https://github.com/WICG/contact-api"
     },
     "title": "Contact Picker API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Contact Picker API"
   },
   {
     "url": "https://wicg.github.io/content-index/spec/",
@@ -909,7 +967,8 @@
       "repository": "https://github.com/WICG/content-index"
     },
     "title": "Content Index",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Content Index"
   },
   {
     "url": "https://wicg.github.io/cookie-store/",
@@ -924,7 +983,8 @@
       "repository": "https://github.com/WICG/cookie-store"
     },
     "title": "Cookie Store API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Cookie Store API"
   },
   {
     "url": "https://wicg.github.io/cors-rfc1918/",
@@ -939,7 +999,8 @@
       "repository": "https://github.com/WICG/cors-rfc1918"
     },
     "title": "CORS and RFC1918",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "CORS and RFC1918 1918"
   },
   {
     "url": "https://wicg.github.io/crash-reporting/",
@@ -954,7 +1015,8 @@
       "repository": "https://github.com/WICG/crash-reporting"
     },
     "title": "Crash Reporting",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Crash Reporting"
   },
   {
     "url": "https://wicg.github.io/css-parser-api/",
@@ -969,7 +1031,8 @@
       "repository": "https://github.com/WICG/css-parser-api"
     },
     "title": "CSS Parser API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "CSS Parser API"
   },
   {
     "url": "https://wicg.github.io/custom-state-pseudo-class/",
@@ -984,7 +1047,8 @@
       "repository": "https://github.com/WICG/custom-state-pseudo-class"
     },
     "title": "Custom State Pseudo Class",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Custom State Pseudo Class"
   },
   {
     "url": "https://wicg.github.io/deprecation-reporting/",
@@ -999,7 +1063,8 @@
       "repository": "https://github.com/WICG/deprecation-reporting"
     },
     "title": "Deprecation Reporting",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Deprecation Reporting"
   },
   {
     "url": "https://wicg.github.io/element-timing/",
@@ -1014,7 +1079,8 @@
       "repository": "https://github.com/WICG/element-timing"
     },
     "title": "Element Timing API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Element Timing API"
   },
   {
     "url": "https://wicg.github.io/entries-api/",
@@ -1029,7 +1095,8 @@
       "repository": "https://github.com/WICG/entries-api"
     },
     "title": "File and Directory Entries API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "File and Directory Entries API"
   },
   {
     "url": "https://wicg.github.io/event-timing/",
@@ -1044,7 +1111,8 @@
       "repository": "https://github.com/WICG/event-timing"
     },
     "title": "Event Timing API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Event Timing API"
   },
   {
     "url": "https://wicg.github.io/frame-timing/",
@@ -1059,7 +1127,8 @@
       "repository": "https://github.com/WICG/frame-timing"
     },
     "title": "Frame Timing",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Frame Timing"
   },
   {
     "url": "https://wicg.github.io/get-installed-related-apps/spec/",
@@ -1074,7 +1143,8 @@
       "repository": "https://github.com/WICG/get-installed-related-apps"
     },
     "title": "Get Installed Related Apps API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Get Installed Related Apps API"
   },
   {
     "url": "https://wicg.github.io/import-maps/",
@@ -1089,7 +1159,8 @@
       "repository": "https://github.com/WICG/import-maps"
     },
     "title": "Import Maps",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Import Maps"
   },
   {
     "url": "https://wicg.github.io/input-device-capabilities/",
@@ -1104,7 +1175,8 @@
       "repository": "https://github.com/WICG/input-device-capabilities"
     },
     "title": "Input Device Capabilities",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Input Device Capabilities"
   },
   {
     "url": "https://wicg.github.io/intervention-reporting/",
@@ -1119,7 +1191,8 @@
       "repository": "https://github.com/WICG/intervention-reporting"
     },
     "title": "Intervention Reporting",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Intervention Reporting"
   },
   {
     "url": "https://wicg.github.io/is-input-pending/",
@@ -1134,7 +1207,8 @@
       "repository": "https://github.com/WICG/is-input-pending"
     },
     "title": "isInputPending",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "isInputPending"
   },
   {
     "url": "https://wicg.github.io/js-self-profiling/",
@@ -1149,7 +1223,8 @@
       "repository": "https://github.com/WICG/js-self-profiling"
     },
     "title": "JS Self-Profiling API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "JS Self-Profiling API"
   },
   {
     "url": "https://wicg.github.io/keyboard-lock/",
@@ -1164,7 +1239,8 @@
       "repository": "https://github.com/WICG/keyboard-lock"
     },
     "title": "Keyboard Lock",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Keyboard Lock"
   },
   {
     "url": "https://wicg.github.io/keyboard-map/",
@@ -1179,7 +1255,8 @@
       "repository": "https://github.com/WICG/keyboard-map"
     },
     "title": "Keyboard Map",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Keyboard Map"
   },
   {
     "url": "https://wicg.github.io/largest-contentful-paint/",
@@ -1194,7 +1271,8 @@
       "repository": "https://github.com/WICG/largest-contentful-paint"
     },
     "title": "Largest Contentful Paint",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Largest Contentful Paint"
   },
   {
     "url": "https://wicg.github.io/layout-instability/",
@@ -1209,7 +1287,8 @@
       "repository": "https://github.com/WICG/layout-instability"
     },
     "title": "Layout Instability",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Layout Instability"
   },
   {
     "url": "https://wicg.github.io/local-font-access/",
@@ -1224,7 +1303,8 @@
       "repository": "https://github.com/WICG/local-font-access"
     },
     "title": "Local Font Access API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Local Font Access API"
   },
   {
     "url": "https://wicg.github.io/media-feeds/",
@@ -1239,7 +1319,8 @@
       "repository": "https://github.com/WICG/media-feeds"
     },
     "title": "Media Feeds",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Media Feeds"
   },
   {
     "url": "https://wicg.github.io/native-file-system/",
@@ -1254,7 +1335,8 @@
       "repository": "https://github.com/WICG/native-file-system"
     },
     "title": "Native File System",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Native File System"
   },
   {
     "url": "https://wicg.github.io/netinfo/",
@@ -1269,7 +1351,8 @@
       "repository": "https://github.com/WICG/netinfo"
     },
     "title": "Network Information API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Network Information API"
   },
   {
     "url": "https://wicg.github.io/origin-policy/",
@@ -1284,7 +1367,8 @@
       "repository": "https://github.com/WICG/origin-policy"
     },
     "title": "Origin Policy",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Origin Policy"
   },
   {
     "url": "https://wicg.github.io/overscroll-scrollend-events/",
@@ -1299,7 +1383,8 @@
       "repository": "https://github.com/WICG/overscroll-scrollend-events"
     },
     "title": "overscroll and scrollend events",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "overscroll and scrollend events"
   },
   {
     "url": "https://wicg.github.io/page-lifecycle/",
@@ -1314,7 +1399,8 @@
       "repository": "https://github.com/WICG/page-lifecycle"
     },
     "title": "Page Lifecycle",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Page Lifecycle"
   },
   {
     "url": "https://wicg.github.io/periodic-background-sync/",
@@ -1329,7 +1415,8 @@
       "repository": "https://github.com/WICG/periodic-background-sync"
     },
     "title": "Web Periodic Background Synchronization",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web Periodic Background Synchronization"
   },
   {
     "url": "https://wicg.github.io/permissions-request/",
@@ -1344,7 +1431,8 @@
       "repository": "https://github.com/WICG/permissions-request"
     },
     "title": "Requesting Permissions",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Requesting Permissions"
   },
   {
     "url": "https://wicg.github.io/permissions-revoke/",
@@ -1359,7 +1447,8 @@
       "repository": "https://github.com/WICG/permissions-revoke"
     },
     "title": "Relinquishing Permissions",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Relinquishing Permissions"
   },
   {
     "url": "https://wicg.github.io/portals/",
@@ -1374,7 +1463,8 @@
       "repository": "https://github.com/WICG/portals"
     },
     "title": "Portals",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Portals"
   },
   {
     "url": "https://wicg.github.io/priority-hints/",
@@ -1389,7 +1479,8 @@
       "repository": "https://github.com/WICG/priority-hints"
     },
     "title": "Priority Hints",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Priority Hints"
   },
   {
     "url": "https://wicg.github.io/savedata/",
@@ -1404,7 +1495,8 @@
       "repository": "https://github.com/WICG/savedata"
     },
     "title": "Save Data API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Save Data API"
   },
   {
     "url": "https://wicg.github.io/scroll-to-text-fragment/",
@@ -1419,7 +1511,8 @@
       "repository": "https://github.com/WICG/scroll-to-text-fragment"
     },
     "title": "Text Fragments",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Text Fragments"
   },
   {
     "url": "https://wicg.github.io/serial/",
@@ -1434,7 +1527,8 @@
       "repository": "https://github.com/WICG/serial"
     },
     "title": "Serial API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Serial API"
   },
   {
     "url": "https://wicg.github.io/shape-detection-api/",
@@ -1449,7 +1543,8 @@
       "repository": "https://github.com/WICG/shape-detection-api"
     },
     "title": "Accelerated Shape Detection in Images",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Accelerated Shape Detection in Images"
   },
   {
     "url": "https://wicg.github.io/shape-detection-api/text.html",
@@ -1464,7 +1559,8 @@
       "repository": "https://github.com/WICG/shape-detection-api"
     },
     "title": "Accelerated Text Detection in Images",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Accelerated Text Detection in Images"
   },
   {
     "url": "https://wicg.github.io/sms-one-time-codes/",
@@ -1479,7 +1575,8 @@
       "repository": "https://github.com/WICG/sms-one-time-codes"
     },
     "title": "Origin-bound one-time codes delivered via SMS",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Origin-bound one-time codes delivered via SMS"
   },
   {
     "url": "https://wicg.github.io/speech-api/",
@@ -1494,7 +1591,8 @@
       "repository": "https://github.com/WICG/speech-api"
     },
     "title": "Web Speech API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web Speech API"
   },
   {
     "url": "https://wicg.github.io/ua-client-hints/",
@@ -1509,7 +1607,8 @@
       "repository": "https://github.com/WICG/ua-client-hints"
     },
     "title": "User-Agent Client Hints",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "User-Agent Client Hints"
   },
   {
     "url": "https://wicg.github.io/video-rvfc/",
@@ -1524,7 +1623,8 @@
       "repository": "https://github.com/WICG/video-rvfc"
     },
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "HTMLVideoElement.requestVideoFrameCallback()"
   },
   {
     "url": "https://wicg.github.io/visual-viewport/",
@@ -1539,7 +1639,8 @@
       "repository": "https://github.com/WICG/visual-viewport"
     },
     "title": "Visual Viewport API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Visual Viewport API"
   },
   {
     "url": "https://wicg.github.io/web-locks/",
@@ -1554,7 +1655,8 @@
       "repository": "https://github.com/WICG/web-locks"
     },
     "title": "Web Locks API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "Web Locks API"
   },
   {
     "url": "https://wicg.github.io/web-otp/",
@@ -1569,7 +1671,8 @@
       "repository": "https://github.com/WICG/web-otp"
     },
     "title": "Web OTP API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Web OTP API"
   },
   {
     "url": "https://wicg.github.io/web-transport/",
@@ -1584,7 +1687,8 @@
       "repository": "https://github.com/WICG/web-transport"
     },
     "title": "WebTransport",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebTransport"
   },
   {
     "url": "https://wicg.github.io/webhid/",
@@ -1599,7 +1703,8 @@
       "repository": "https://github.com/WICG/webhid"
     },
     "title": "WebHID API",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebHID API"
   },
   {
     "url": "https://wicg.github.io/webpackage/loading.html",
@@ -1614,7 +1719,8 @@
       "repository": "https://github.com/WICG/webpackage"
     },
     "title": "Loading Signed Exchanges",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "Loading Signed Exchanges"
   },
   {
     "url": "https://wicg.github.io/webusb/",
@@ -1629,7 +1735,8 @@
       "repository": "https://github.com/WICG/webusb"
     },
     "title": "WebUSB API",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "WebUSB API"
   },
   {
     "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
@@ -1645,7 +1752,8 @@
       "repository": "https://github.com/KhronosGroup/WebGL"
     },
     "title": "WebGL Specification",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebGL"
   },
   {
     "url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/",
@@ -1661,7 +1769,8 @@
       "repository": "https://github.com/KhronosGroup/WebGL"
     },
     "title": "WebGL 2.0 Specification",
-    "source": "spec"
+    "source": "spec",
+    "shortTitle": "WebGL 2.0"
   },
   {
     "url": "https://www.w3.org/TR/accelerometer/",
@@ -1679,7 +1788,8 @@
       "repository": "https://github.com/w3c/accelerometer"
     },
     "title": "Accelerometer",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Accelerometer"
   },
   {
     "url": "https://www.w3.org/TR/accname-1.2/",
@@ -1698,7 +1808,8 @@
       "repository": "https://github.com/w3c/accname"
     },
     "title": "Accessible Name and Description Computation 1.2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Accessible Name and Description Computation 1.2"
   },
   {
     "url": "https://www.w3.org/TR/ambient-light/",
@@ -1716,7 +1827,8 @@
       "repository": "https://github.com/w3c/ambient-light"
     },
     "title": "Ambient Light Sensor",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Ambient Light Sensor"
   },
   {
     "url": "https://www.w3.org/TR/appmanifest/",
@@ -1734,7 +1846,8 @@
       "repository": "https://github.com/w3c/manifest"
     },
     "title": "Web App Manifest",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web App Manifest"
   },
   {
     "url": "https://www.w3.org/TR/audio-output/",
@@ -1752,7 +1865,8 @@
       "repository": "https://github.com/w3c/mediacapture-output"
     },
     "title": "Audio Output Devices API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Audio Output Devices API"
   },
   {
     "url": "https://www.w3.org/TR/battery-status/",
@@ -1770,7 +1884,8 @@
       "repository": "https://github.com/w3c/battery"
     },
     "title": "Battery Status API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Battery Status API"
   },
   {
     "url": "https://www.w3.org/TR/beacon/",
@@ -1788,7 +1903,8 @@
       "repository": "https://github.com/w3c/beacon"
     },
     "title": "Beacon",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Beacon"
   },
   {
     "url": "https://www.w3.org/TR/clear-site-data/",
@@ -1806,7 +1922,8 @@
       "repository": "https://github.com/w3c/webappsec-clear-site-data"
     },
     "title": "Clear Site Data",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Clear Site Data"
   },
   {
     "url": "https://www.w3.org/TR/clipboard-apis/",
@@ -1824,7 +1941,8 @@
       "repository": "https://github.com/w3c/clipboard-apis"
     },
     "title": "Clipboard API and events",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Clipboard API and events"
   },
   {
     "url": "https://www.w3.org/TR/compositing-1/",
@@ -1844,7 +1962,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Compositing and Blending Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Compositing and Blending 1"
   },
   {
     "url": "https://www.w3.org/TR/core-aam-1.2/",
@@ -1863,7 +1982,8 @@
       "repository": "https://github.com/w3c/core-aam"
     },
     "title": "Core Accessibility API Mappings 1.2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Core Accessibility API Mappings 1.2"
   },
   {
     "url": "https://www.w3.org/TR/credential-management-1/",
@@ -1882,7 +2002,8 @@
       "repository": "https://github.com/w3c/webappsec-credential-management"
     },
     "title": "Credential Management Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Credential Management 1"
   },
   {
     "url": "https://www.w3.org/TR/csp-embedded-enforcement/",
@@ -1900,7 +2021,8 @@
       "repository": "https://github.com/w3c/webappsec-cspee"
     },
     "title": "Content Security Policy: Embedded Enforcement",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Content Security Policy: Embedded Enforcement"
   },
   {
     "url": "https://www.w3.org/TR/CSP3/",
@@ -1919,7 +2041,8 @@
       "repository": "https://github.com/w3c/webappsec-csp"
     },
     "title": "Content Security Policy Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Content Security Policy 3"
   },
   {
     "url": "https://www.w3.org/TR/css-align-3/",
@@ -1938,7 +2061,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Box Alignment Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Box Alignment 3"
   },
   {
     "url": "https://www.w3.org/TR/css-animation-worklet-1/",
@@ -1957,7 +2081,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Animation Worklet API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Animation Worklet API"
   },
   {
     "url": "https://www.w3.org/TR/css-animations-1/",
@@ -1977,7 +2102,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Animations Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Animations 1"
   },
   {
     "url": "https://www.w3.org/TR/css-backgrounds-3/",
@@ -1997,7 +2123,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Backgrounds and Borders Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Backgrounds and Borders 3"
   },
   {
     "url": "https://www.w3.org/TR/css-box-3/",
@@ -2017,7 +2144,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Box Model Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Box Model 3"
   },
   {
     "url": "https://www.w3.org/TR/css-box-4/",
@@ -2037,7 +2165,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Box Model Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Box Model 4"
   },
   {
     "url": "https://www.w3.org/TR/css-break-3/",
@@ -2057,7 +2186,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Fragmentation Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Fragmentation 3"
   },
   {
     "url": "https://www.w3.org/TR/css-break-4/",
@@ -2077,7 +2207,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Fragmentation Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Fragmentation 4"
   },
   {
     "url": "https://www.w3.org/TR/css-cascade-3/",
@@ -2097,7 +2228,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Cascading and Inheritance Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Cascading and Inheritance 3"
   },
   {
     "url": "https://www.w3.org/TR/css-cascade-4/",
@@ -2117,7 +2249,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Cascading and Inheritance Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Cascading and Inheritance 4"
   },
   {
     "url": "https://www.w3.org/TR/css-color-3/",
@@ -2137,7 +2270,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Color Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Color 3"
   },
   {
     "url": "https://www.w3.org/TR/css-color-4/",
@@ -2158,7 +2292,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Color Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Color 4"
   },
   {
     "url": "https://www.w3.org/TR/css-color-5/",
@@ -2178,7 +2313,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Color Module Level 5",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Color 5"
   },
   {
     "url": "https://www.w3.org/TR/css-color-adjust-1/",
@@ -2197,7 +2333,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Color Adjust Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Color Adjust 1"
   },
   {
     "url": "https://www.w3.org/TR/css-conditional-4/",
@@ -2217,7 +2354,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Conditional Rules Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Conditional Rules 4"
   },
   {
     "url": "https://www.w3.org/TR/css-contain-1/",
@@ -2237,7 +2375,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Containment Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Containment 1"
   },
   {
     "url": "https://www.w3.org/TR/css-contain-2/",
@@ -2257,7 +2396,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Containment Module Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Containment 2"
   },
   {
     "url": "https://www.w3.org/TR/css-content-3/",
@@ -2276,7 +2416,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Generated Content Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Generated Content 3"
   },
   {
     "url": "https://www.w3.org/TR/css-counter-styles-3/",
@@ -2295,7 +2436,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Counter Styles Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Counter Styles 3"
   },
   {
     "url": "https://www.w3.org/TR/css-device-adapt-1/",
@@ -2314,7 +2456,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Device Adaptation Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Device Adaptation 1"
   },
   {
     "url": "https://www.w3.org/TR/css-display-3/",
@@ -2333,7 +2476,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Display Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Display 3"
   },
   {
     "url": "https://www.w3.org/TR/css-easing-1/",
@@ -2352,7 +2496,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Easing Functions Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Easing Functions 1"
   },
   {
     "url": "https://www.w3.org/TR/css-flexbox-1/",
@@ -2371,7 +2516,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Flexible Box Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Flexible Box Layout 1"
   },
   {
     "url": "https://www.w3.org/TR/css-font-loading-3/",
@@ -2390,7 +2536,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Font Loading Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Font Loading 3"
   },
   {
     "url": "https://www.w3.org/TR/css-fonts-3/",
@@ -2410,7 +2557,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Fonts Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Fonts 3"
   },
   {
     "url": "https://www.w3.org/TR/css-fonts-4/",
@@ -2430,7 +2578,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Fonts Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Fonts 4"
   },
   {
     "url": "https://www.w3.org/TR/css-gcpm-3/",
@@ -2450,7 +2599,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Generated Content for Paged Media Module",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Generated Content for Paged Media"
   },
   {
     "url": "https://www.w3.org/TR/css-grid-1/",
@@ -2470,7 +2620,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Grid Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Grid Layout 1"
   },
   {
     "url": "https://www.w3.org/TR/css-grid-2/",
@@ -2490,7 +2641,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Grid Layout Module Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Grid Layout 2"
   },
   {
     "url": "https://www.w3.org/TR/css-images-3/",
@@ -2510,7 +2662,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Image Values and Replaced Content Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Image Values and Replaced Content 3"
   },
   {
     "url": "https://www.w3.org/TR/css-images-4/",
@@ -2530,7 +2683,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Image Values and Replaced Content Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Image Values and Replaced Content 4"
   },
   {
     "url": "https://www.w3.org/TR/css-inline-3/",
@@ -2549,7 +2703,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Inline Layout Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Inline Layout 3"
   },
   {
     "url": "https://www.w3.org/TR/css-layout-api-1/",
@@ -2568,7 +2723,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Layout API Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Layout API 1"
   },
   {
     "url": "https://www.w3.org/TR/css-line-grid-1/",
@@ -2587,7 +2743,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Line Grid Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Line Grid 1"
   },
   {
     "url": "https://www.w3.org/TR/css-lists-3/",
@@ -2606,7 +2763,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Lists and Counters Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Lists and Counters 3"
   },
   {
     "url": "https://www.w3.org/TR/css-logical-1/",
@@ -2625,7 +2783,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Logical Properties and Values Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Logical Properties and Values 1"
   },
   {
     "url": "https://www.w3.org/TR/css-masking-1/",
@@ -2644,7 +2803,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "CSS Masking Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Masking 1"
   },
   {
     "url": "https://www.w3.org/TR/css-multicol-1/",
@@ -2664,7 +2824,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Multi-column Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Multi-column Layout 1"
   },
   {
     "url": "https://www.w3.org/TR/css-namespaces-3/",
@@ -2683,7 +2844,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Namespaces Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Namespaces 3"
   },
   {
     "url": "https://www.w3.org/TR/css-nav-1/",
@@ -2702,7 +2864,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Spatial Navigation Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Spatial Navigation 1"
   },
   {
     "url": "https://www.w3.org/TR/css-overflow-3/",
@@ -2722,7 +2885,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Overflow Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Overflow 3"
   },
   {
     "url": "https://www.w3.org/TR/css-overflow-4/",
@@ -2742,7 +2906,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Overflow Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Overflow 4"
   },
   {
     "url": "https://www.w3.org/TR/css-overscroll-1/",
@@ -2761,7 +2926,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Overscroll Behavior Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Overscroll Behavior 1"
   },
   {
     "url": "https://www.w3.org/TR/css-page-3/",
@@ -2781,7 +2947,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Paged Media Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Paged Media 3"
   },
   {
     "url": "https://www.w3.org/TR/css-page-floats-3/",
@@ -2800,7 +2967,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Page Floats",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Page Floats"
   },
   {
     "url": "https://www.w3.org/TR/css-paint-api-1/",
@@ -2819,7 +2987,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Painting API Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Painting API 1"
   },
   {
     "url": "https://www.w3.org/TR/css-position-3/",
@@ -2838,7 +3007,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Positioned Layout Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Positioned Layout 3"
   },
   {
     "url": "https://www.w3.org/TR/css-properties-values-api-1/",
@@ -2857,7 +3027,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Properties and Values API Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Properties and Values API 1"
   },
   {
     "url": "https://www.w3.org/TR/css-pseudo-4/",
@@ -2876,7 +3047,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Pseudo-Elements Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Pseudo-Elements 4"
   },
   {
     "url": "https://www.w3.org/TR/css-regions-1/",
@@ -2895,7 +3067,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Regions Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Regions 1"
   },
   {
     "url": "https://www.w3.org/TR/css-rhythm-1/",
@@ -2914,7 +3087,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Rhythmic Sizing",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Rhythmic Sizing"
   },
   {
     "url": "https://www.w3.org/TR/css-round-display-1/",
@@ -2933,7 +3107,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Round Display Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Round Display 1"
   },
   {
     "url": "https://www.w3.org/TR/css-ruby-1/",
@@ -2952,7 +3127,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Ruby Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Ruby Layout 1"
   },
   {
     "url": "https://www.w3.org/TR/css-scoping-1/",
@@ -2971,7 +3147,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Scoping Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Scoping 1"
   },
   {
     "url": "https://www.w3.org/TR/css-scroll-anchoring-1/",
@@ -2990,7 +3167,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Scroll Anchoring Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Scroll Anchoring 1"
   },
   {
     "url": "https://www.w3.org/TR/css-scroll-snap-1/",
@@ -3009,7 +3187,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Scroll Snap Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Scroll Snap 1"
   },
   {
     "url": "https://www.w3.org/TR/css-scrollbars-1/",
@@ -3028,7 +3207,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Scrollbars Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Scrollbars 1"
   },
   {
     "url": "https://www.w3.org/TR/css-shadow-parts-1/",
@@ -3047,7 +3227,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Shadow Parts",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Shadow Parts"
   },
   {
     "url": "https://www.w3.org/TR/css-shapes-1/",
@@ -3067,7 +3248,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Shapes Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Shapes 1"
   },
   {
     "url": "https://www.w3.org/TR/css-sizing-3/",
@@ -3087,7 +3269,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Intrinsic & Extrinsic Sizing Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Intrinsic & Extrinsic Sizing 3"
   },
   {
     "url": "https://www.w3.org/TR/css-sizing-4/",
@@ -3107,7 +3290,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Box Sizing Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Box Sizing 4"
   },
   {
     "url": "https://www.w3.org/TR/css-speech-1/",
@@ -3126,7 +3310,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Speech Module",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Speech"
   },
   {
     "url": "https://www.w3.org/TR/css-style-attr/",
@@ -3144,7 +3329,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Style Attributes",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Style Attributes"
   },
   {
     "url": "https://www.w3.org/TR/css-syntax-3/",
@@ -3163,7 +3349,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Syntax Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Syntax 3"
   },
   {
     "url": "https://www.w3.org/TR/css-tables-3/",
@@ -3182,7 +3369,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Table Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Table 3"
   },
   {
     "url": "https://www.w3.org/TR/css-text-3/",
@@ -3202,7 +3390,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Text Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Text 3"
   },
   {
     "url": "https://www.w3.org/TR/css-text-4/",
@@ -3222,7 +3411,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Text Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Text 4"
   },
   {
     "url": "https://www.w3.org/TR/css-text-decor-3/",
@@ -3242,7 +3432,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Text Decoration Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Text Decoration 3"
   },
   {
     "url": "https://www.w3.org/TR/css-text-decor-4/",
@@ -3262,7 +3453,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Text Decoration Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Text Decoration 4"
   },
   {
     "url": "https://www.w3.org/TR/css-transforms-1/",
@@ -3282,7 +3474,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Transforms Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Transforms 1"
   },
   {
     "url": "https://www.w3.org/TR/css-transforms-2/",
@@ -3302,7 +3495,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Transforms Module Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Transforms 2"
   },
   {
     "url": "https://www.w3.org/TR/css-transitions-1/",
@@ -3322,7 +3516,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Transitions",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Transitions"
   },
   {
     "url": "https://www.w3.org/TR/css-typed-om-1/",
@@ -3342,7 +3537,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "CSS Typed OM Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Typed OM 1"
   },
   {
     "url": "https://www.w3.org/TR/css-ui-3/",
@@ -3362,7 +3558,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Basic User Interface Module Level 3 (CSS3 UI)",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS3 UI"
   },
   {
     "url": "https://www.w3.org/TR/css-ui-4/",
@@ -3382,7 +3579,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Basic User Interface Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Basic User Interface 4"
   },
   {
     "url": "https://www.w3.org/TR/css-values-3/",
@@ -3402,7 +3600,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Values and Units Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Values and Units 3"
   },
   {
     "url": "https://www.w3.org/TR/css-values-4/",
@@ -3422,7 +3621,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Values and Units Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Values and Units 4"
   },
   {
     "url": "https://www.w3.org/TR/css-variables-1/",
@@ -3441,7 +3641,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Custom Properties for Cascading Variables Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Custom Properties for Cascading Variables 1"
   },
   {
     "url": "https://www.w3.org/TR/css-will-change-1/",
@@ -3460,7 +3661,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Will Change Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Will Change 1"
   },
   {
     "url": "https://www.w3.org/TR/css-writing-modes-3/",
@@ -3480,7 +3682,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Writing Modes Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Writing Modes 3"
   },
   {
     "url": "https://www.w3.org/TR/css-writing-modes-4/",
@@ -3500,7 +3703,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Writing Modes Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Writing Modes 4"
   },
   {
     "url": "https://www.w3.org/TR/CSS2/",
@@ -3520,7 +3724,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS 2.1"
   },
   {
     "url": "https://www.w3.org/TR/CSS22/",
@@ -3540,7 +3745,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS 2.2"
   },
   {
     "url": "https://www.w3.org/TR/css3-conditional/",
@@ -3560,7 +3766,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Conditional Rules Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Conditional Rules 3"
   },
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",
@@ -3579,7 +3786,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Exclusions Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Exclusions 1"
   },
   {
     "url": "https://www.w3.org/TR/css3-mediaqueries/",
@@ -3599,7 +3807,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Media Queries",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Queries"
   },
   {
     "url": "https://www.w3.org/TR/cssom-1/",
@@ -3618,7 +3827,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSS Object Model (CSSOM)",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSSOM"
   },
   {
     "url": "https://www.w3.org/TR/cssom-view-1/",
@@ -3637,7 +3847,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "CSSOM View Module",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSSOM View"
   },
   {
     "url": "https://www.w3.org/TR/device-memory-1/",
@@ -3656,7 +3867,8 @@
       "repository": "https://github.com/w3c/device-memory"
     },
     "title": "Device Memory",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Device Memory"
   },
   {
     "url": "https://www.w3.org/TR/DOM-Parsing/",
@@ -3674,7 +3886,8 @@
       "repository": "https://github.com/w3c/DOM-Parsing"
     },
     "title": "DOM Parsing and Serialization",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "DOM Parsing and Serialization"
   },
   {
     "url": "https://www.w3.org/TR/encoding/",
@@ -3692,7 +3905,8 @@
       "repository": "https://github.com/whatwg/encoding"
     },
     "title": "Encoding",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Encoding"
   },
   {
     "url": "https://www.w3.org/TR/encrypted-media/",
@@ -3710,7 +3924,8 @@
       "repository": "https://github.com/w3c/encrypted-media"
     },
     "title": "Encrypted Media Extensions",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Encrypted Media Extensions"
   },
   {
     "url": "https://www.w3.org/TR/feature-policy-1/",
@@ -3729,7 +3944,8 @@
       "repository": "https://github.com/w3c/webappsec-feature-policy"
     },
     "title": "Feature Policy",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Feature Policy"
   },
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
@@ -3747,7 +3963,8 @@
       "repository": "https://github.com/w3c/webappsec-fetch-metadata"
     },
     "title": "Fetch Metadata Request Headers",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Fetch Metadata Request Headers"
   },
   {
     "url": "https://www.w3.org/TR/FileAPI/",
@@ -3765,7 +3982,8 @@
       "repository": "https://github.com/w3c/FileAPI"
     },
     "title": "File API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "File API"
   },
   {
     "url": "https://www.w3.org/TR/fill-stroke-3/",
@@ -3784,7 +4002,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "CSS Fill and Stroke Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "CSS Fill and Stroke 3"
   },
   {
     "url": "https://www.w3.org/TR/filter-effects-1/",
@@ -3804,7 +4023,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Filter Effects Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Filter Effects 1"
   },
   {
     "url": "https://www.w3.org/TR/gamepad/",
@@ -3822,7 +4042,8 @@
       "repository": "https://github.com/w3c/gamepad"
     },
     "title": "Gamepad",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Gamepad"
   },
   {
     "url": "https://www.w3.org/TR/generic-sensor/",
@@ -3840,7 +4061,8 @@
       "repository": "https://github.com/w3c/sensors"
     },
     "title": "Generic Sensor API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Generic Sensor API"
   },
   {
     "url": "https://www.w3.org/TR/geolocation-API/",
@@ -3858,7 +4080,8 @@
       "repository": "https://github.com/w3c/geolocation-api"
     },
     "title": "Geolocation API Specification 2nd Edition",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Geolocation API Specification 2nd Edition"
   },
   {
     "url": "https://www.w3.org/TR/geolocation-sensor/",
@@ -3876,7 +4099,8 @@
       "repository": "https://github.com/w3c/geolocation-sensor"
     },
     "title": "Geolocation Sensor",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Geolocation Sensor"
   },
   {
     "url": "https://www.w3.org/TR/geometry-1/",
@@ -3895,7 +4119,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Geometry Interfaces Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Geometry Interfaces 1"
   },
   {
     "url": "https://www.w3.org/TR/graphics-aam-1.0/",
@@ -3914,7 +4139,8 @@
       "repository": "https://github.com/w3c/graphics-aam"
     },
     "title": "Graphics Accessibility API Mappings",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Graphics Accessibility API Mappings"
   },
   {
     "url": "https://www.w3.org/TR/graphics-aria-1.0/",
@@ -3933,7 +4159,8 @@
       "repository": "https://github.com/w3c/graphics-aria"
     },
     "title": "WAI-ARIA Graphics Module",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WAI-ARIA Graphics"
   },
   {
     "url": "https://www.w3.org/TR/gyroscope/",
@@ -3951,7 +4178,8 @@
       "repository": "https://github.com/w3c/gyroscope"
     },
     "title": "Gyroscope",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Gyroscope"
   },
   {
     "url": "https://www.w3.org/TR/hr-time-3/",
@@ -3970,7 +4198,8 @@
       "repository": "https://github.com/w3c/hr-time"
     },
     "title": "High Resolution Time Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "High Resolution Time 3"
   },
   {
     "url": "https://www.w3.org/TR/html-aam-1.0/",
@@ -3989,7 +4218,8 @@
       "repository": "https://github.com/w3c/html-aam"
     },
     "title": "HTML Accessibility API Mappings 1.0",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "HTML Accessibility API Mappings 1.0"
   },
   {
     "url": "https://www.w3.org/TR/html-aria/",
@@ -4007,7 +4237,8 @@
       "repository": "https://github.com/w3c/html-aria"
     },
     "title": "ARIA in HTML",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "ARIA in HTML"
   },
   {
     "url": "https://www.w3.org/TR/html-media-capture/",
@@ -4025,7 +4256,8 @@
       "repository": "https://github.com/w3c/html-media-capture"
     },
     "title": "HTML Media Capture",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "HTML Media Capture"
   },
   {
     "url": "https://www.w3.org/TR/image-capture/",
@@ -4043,7 +4275,8 @@
       "repository": "https://github.com/w3c/mediacapture-image"
     },
     "title": "\"MediaStream Image Capture\"",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "\"MediaStream Image Capture\""
   },
   {
     "url": "https://www.w3.org/TR/image-resource/",
@@ -4061,7 +4294,8 @@
       "repository": "https://github.com/w3c/image-resource"
     },
     "title": "Image Resource",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Image Resource"
   },
   {
     "url": "https://www.w3.org/TR/IndexedDB-2/",
@@ -4080,7 +4314,8 @@
       "repository": "https://github.com/w3c/IndexedDB"
     },
     "title": "Indexed Database API 2.0",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Indexed Database API 2.0"
   },
   {
     "url": "https://www.w3.org/TR/input-events-2/",
@@ -4099,7 +4334,8 @@
       "repository": "https://github.com/w3c/input-events"
     },
     "title": "Input Events Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Input Events 2"
   },
   {
     "url": "https://www.w3.org/TR/intersection-observer/",
@@ -4117,7 +4353,8 @@
       "repository": "https://github.com/w3c/IntersectionObserver"
     },
     "title": "Intersection Observer",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Intersection Observer"
   },
   {
     "url": "https://www.w3.org/TR/longtasks-1/",
@@ -4136,7 +4373,8 @@
       "repository": "https://github.com/w3c/longtasks"
     },
     "title": "Long Tasks API 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Long Tasks API 1"
   },
   {
     "url": "https://www.w3.org/TR/magnetometer/",
@@ -4154,7 +4392,8 @@
       "repository": "https://github.com/w3c/magnetometer"
     },
     "title": "Magnetometer",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Magnetometer"
   },
   {
     "url": "https://www.w3.org/TR/media-capabilities/",
@@ -4172,7 +4411,8 @@
       "repository": "https://github.com/w3c/media-capabilities"
     },
     "title": "Media Capabilities",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Capabilities"
   },
   {
     "url": "https://www.w3.org/TR/media-source/",
@@ -4190,7 +4430,8 @@
       "repository": "https://github.com/w3c/media-source"
     },
     "title": "Media Source Extensions™",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Source Extensions™"
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-depth/",
@@ -4208,7 +4449,8 @@
       "repository": "https://github.com/w3c/mediacapture-depth"
     },
     "title": "Media Capture Depth Stream Extensions",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Capture Depth Stream Extensions"
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-fromelement/",
@@ -4226,7 +4468,8 @@
       "repository": "https://github.com/w3c/mediacapture-fromelement"
     },
     "title": "Media Capture from DOM Elements",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Capture from DOM Elements"
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-streams/",
@@ -4244,7 +4487,8 @@
       "repository": "https://github.com/w3c/mediacapture-main"
     },
     "title": "Media Capture and Streams",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Capture and Streams"
   },
   {
     "url": "https://www.w3.org/TR/mediaqueries-4/",
@@ -4265,7 +4509,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Media Queries Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Queries 4"
   },
   {
     "url": "https://www.w3.org/TR/mediaqueries-5/",
@@ -4285,7 +4530,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Media Queries Level 5",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Queries 5"
   },
   {
     "url": "https://www.w3.org/TR/mediasession/",
@@ -4303,7 +4549,8 @@
       "repository": "https://github.com/w3c/mediasession"
     },
     "title": "Media Session Standard",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Media Session"
   },
   {
     "url": "https://www.w3.org/TR/mediastream-recording/",
@@ -4321,7 +4568,8 @@
       "repository": "https://github.com/w3c/mediacapture-record"
     },
     "title": "MediaStream Recording",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "MediaStream Recording"
   },
   {
     "url": "https://www.w3.org/TR/mixed-content/",
@@ -4339,7 +4587,8 @@
       "repository": "https://github.com/w3c/webappsec-mixed-content"
     },
     "title": "Mixed Content",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Mixed Content"
   },
   {
     "url": "https://www.w3.org/TR/motion-1/",
@@ -4358,7 +4607,8 @@
       "repository": "https://github.com/w3c/fxtf-drafts"
     },
     "title": "Motion Path Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Motion Path 1"
   },
   {
     "url": "https://www.w3.org/TR/mst-content-hint/",
@@ -4376,7 +4626,8 @@
       "repository": "https://github.com/w3c/mst-content-hint"
     },
     "title": "MediaStreamTrack Content Hints",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "MediaStreamTrack Content Hints"
   },
   {
     "url": "https://www.w3.org/TR/navigation-timing-2/",
@@ -4395,7 +4646,8 @@
       "repository": "https://github.com/w3c/navigation-timing"
     },
     "title": "Navigation Timing Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Navigation Timing 2"
   },
   {
     "url": "https://www.w3.org/TR/network-error-logging-1/",
@@ -4414,7 +4666,8 @@
       "repository": "https://github.com/w3c/network-error-logging"
     },
     "title": "Network Error Logging",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Network Error Logging"
   },
   {
     "url": "https://www.w3.org/TR/orientation-event/",
@@ -4432,7 +4685,8 @@
       "repository": "https://github.com/w3c/deviceorientation"
     },
     "title": "DeviceOrientation Event Specification",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "DeviceOrientation Event"
   },
   {
     "url": "https://www.w3.org/TR/orientation-sensor/",
@@ -4450,7 +4704,8 @@
       "repository": "https://github.com/w3c/orientation-sensor"
     },
     "title": "Orientation Sensor",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Orientation Sensor"
   },
   {
     "url": "https://www.w3.org/TR/page-visibility-2/",
@@ -4469,7 +4724,8 @@
       "repository": "https://github.com/w3c/page-visibility"
     },
     "title": "Page Visibility Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Page Visibility 2"
   },
   {
     "url": "https://www.w3.org/TR/paint-timing/",
@@ -4487,7 +4743,8 @@
       "repository": "https://github.com/w3c/paint-timing"
     },
     "title": "Paint Timing 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Paint Timing 1"
   },
   {
     "url": "https://www.w3.org/TR/payment-handler/",
@@ -4505,7 +4762,8 @@
       "repository": "https://github.com/w3c/payment-handler"
     },
     "title": "Payment Handler API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Payment Handler API"
   },
   {
     "url": "https://www.w3.org/TR/payment-method-basic-card/",
@@ -4523,7 +4781,8 @@
       "repository": "https://github.com/w3c/payment-method-basic-card"
     },
     "title": "Payment Method: Basic Card",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Payment Method: Basic Card"
   },
   {
     "url": "https://www.w3.org/TR/payment-method-id/",
@@ -4541,7 +4800,8 @@
       "repository": "https://github.com/w3c/payment-method-id"
     },
     "title": "Payment Method Identifiers",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Payment Method Identifiers"
   },
   {
     "url": "https://www.w3.org/TR/payment-method-manifest/",
@@ -4559,7 +4819,8 @@
       "repository": "https://github.com/w3c/payment-method-manifest"
     },
     "title": "Payment Method Manifest",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Payment Method Manifest"
   },
   {
     "url": "https://www.w3.org/TR/payment-request/",
@@ -4577,7 +4838,8 @@
       "repository": "https://github.com/w3c/payment-request"
     },
     "title": "Payment Request API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Payment Request API"
   },
   {
     "url": "https://www.w3.org/TR/performance-timeline-2/",
@@ -4596,7 +4858,8 @@
       "repository": "https://github.com/w3c/performance-timeline"
     },
     "title": "Performance Timeline Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Performance Timeline 2"
   },
   {
     "url": "https://www.w3.org/TR/permissions/",
@@ -4614,7 +4877,8 @@
       "repository": "https://github.com/w3c/permissions"
     },
     "title": "Permissions",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Permissions"
   },
   {
     "url": "https://www.w3.org/TR/picture-in-picture/",
@@ -4632,7 +4896,8 @@
       "repository": "https://github.com/w3c/picture-in-picture"
     },
     "title": "Picture-in-Picture",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Picture-in-Picture"
   },
   {
     "url": "https://www.w3.org/TR/pointerevents3/",
@@ -4651,7 +4916,8 @@
       "repository": "https://github.com/w3c/pointerevents"
     },
     "title": "Pointer Events Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Pointer Events 3"
   },
   {
     "url": "https://www.w3.org/TR/pointerlock-2/",
@@ -4670,7 +4936,8 @@
       "repository": "https://github.com/w3c/pointerlock"
     },
     "title": "Pointer Lock 2.0",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Pointer Lock 2.0"
   },
   {
     "url": "https://www.w3.org/TR/preload/",
@@ -4688,7 +4955,8 @@
       "repository": "https://github.com/w3c/preload"
     },
     "title": "Preload",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Preload"
   },
   {
     "url": "https://www.w3.org/TR/presentation-api/",
@@ -4706,7 +4974,8 @@
       "repository": "https://github.com/w3c/presentation-api"
     },
     "title": "Presentation API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Presentation API"
   },
   {
     "url": "https://www.w3.org/TR/proximity/",
@@ -4724,7 +4993,8 @@
       "repository": "https://github.com/w3c/proximity"
     },
     "title": "Proximity Sensor",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Proximity Sensor"
   },
   {
     "url": "https://www.w3.org/TR/push-api/",
@@ -4742,7 +5012,8 @@
       "repository": "https://github.com/w3c/push-api"
     },
     "title": "Push API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Push API"
   },
   {
     "url": "https://www.w3.org/TR/referrer-policy/",
@@ -4760,7 +5031,8 @@
       "repository": "https://github.com/w3c/webappsec-referrer-policy"
     },
     "title": "Referrer Policy",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Referrer Policy"
   },
   {
     "url": "https://www.w3.org/TR/remote-playback/",
@@ -4778,7 +5050,8 @@
       "repository": "https://github.com/w3c/remote-playback"
     },
     "title": "Remote Playback API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Remote Playback API"
   },
   {
     "url": "https://www.w3.org/TR/reporting-1/",
@@ -4797,7 +5070,8 @@
       "repository": "https://github.com/w3c/reporting"
     },
     "title": "Reporting API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Reporting API"
   },
   {
     "url": "https://www.w3.org/TR/requestidlecallback/",
@@ -4815,7 +5089,8 @@
       "repository": "https://github.com/w3c/requestidlecallback"
     },
     "title": "Cooperative Scheduling of Background Tasks",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Cooperative Scheduling of Background Tasks"
   },
   {
     "url": "https://www.w3.org/TR/resize-observer-1/",
@@ -4834,7 +5109,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Resize Observer",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Resize Observer"
   },
   {
     "url": "https://www.w3.org/TR/resource-hints/",
@@ -4852,7 +5128,8 @@
       "repository": "https://github.com/w3c/resource-hints"
     },
     "title": "Resource Hints",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Resource Hints"
   },
   {
     "url": "https://www.w3.org/TR/resource-timing-2/",
@@ -4871,7 +5148,8 @@
       "repository": "https://github.com/w3c/resource-timing"
     },
     "title": "Resource Timing Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Resource Timing 2"
   },
   {
     "url": "https://www.w3.org/TR/screen-capture/",
@@ -4889,7 +5167,8 @@
       "repository": "https://github.com/w3c/mediacapture-screen-share"
     },
     "title": "Screen Capture",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Screen Capture"
   },
   {
     "url": "https://www.w3.org/TR/screen-orientation/",
@@ -4907,7 +5186,8 @@
       "repository": "https://github.com/w3c/screen-orientation"
     },
     "title": "The Screen Orientation API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "The Screen Orientation API"
   },
   {
     "url": "https://www.w3.org/TR/secure-contexts/",
@@ -4925,7 +5205,8 @@
       "repository": "https://github.com/w3c/webappsec-secure-contexts"
     },
     "title": "Secure Contexts",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Secure Contexts"
   },
   {
     "url": "https://www.w3.org/TR/selection-api/",
@@ -4943,7 +5224,8 @@
       "repository": "https://github.com/w3c/selection-api"
     },
     "title": "Selection API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Selection API"
   },
   {
     "url": "https://www.w3.org/TR/selectors-3/",
@@ -4963,7 +5245,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Selectors Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Selectors 3"
   },
   {
     "url": "https://www.w3.org/TR/selectors-4/",
@@ -4983,7 +5266,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Selectors Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Selectors 4"
   },
   {
     "url": "https://www.w3.org/TR/selectors-nonelement-1/",
@@ -5002,7 +5286,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Non-element Selectors Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Non-element Selectors 1"
   },
   {
     "url": "https://www.w3.org/TR/server-timing/",
@@ -5020,7 +5305,8 @@
       "repository": "https://github.com/w3c/server-timing"
     },
     "title": "Server Timing",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Server Timing"
   },
   {
     "url": "https://www.w3.org/TR/service-workers-1/",
@@ -5039,7 +5325,8 @@
       "url": "https://www.w3.org/TR/service-workers-1/"
     },
     "title": "Service Workers 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Service Workers 1"
   },
   {
     "url": "https://www.w3.org/TR/SRI/",
@@ -5057,7 +5344,8 @@
       "repository": "https://github.com/w3c/webappsec-subresource-integrity"
     },
     "title": "Subresource Integrity",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Subresource Integrity"
   },
   {
     "url": "https://www.w3.org/TR/svg-aam-1.0/",
@@ -5076,7 +5364,8 @@
       "repository": "https://github.com/w3c/svg-aam"
     },
     "title": "SVG Accessibility API Mappings",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG Accessibility API Mappings"
   },
   {
     "url": "https://www.w3.org/TR/svg-integration/",
@@ -5094,7 +5383,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "SVG Integration",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG Integration"
   },
   {
     "url": "https://www.w3.org/TR/svg-markers/",
@@ -5112,7 +5402,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "SVG Markers",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG Markers"
   },
   {
     "url": "https://www.w3.org/TR/svg-paths/",
@@ -5130,7 +5421,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "SVG Paths",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG Paths"
   },
   {
     "url": "https://www.w3.org/TR/svg-strokes/",
@@ -5148,7 +5440,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "SVG Strokes",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG Strokes"
   },
   {
     "url": "https://www.w3.org/TR/SVG2/",
@@ -5167,7 +5460,8 @@
       "repository": "https://github.com/w3c/svgwg"
     },
     "title": "Scalable Vector Graphics (SVG) 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVG 2"
   },
   {
     "url": "https://www.w3.org/TR/timing-entrytypes-registry/",
@@ -5185,7 +5479,8 @@
       "repository": "https://github.com/w3c/timing-entrytypes-registry"
     },
     "title": "Timing Entry Names Registry",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Timing Entry Names Registry"
   },
   {
     "url": "https://www.w3.org/TR/touch-events/",
@@ -5203,7 +5498,8 @@
       "repository": "https://github.com/w3c/touch-events"
     },
     "title": "Touch Events",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Touch Events"
   },
   {
     "url": "https://www.w3.org/TR/trace-context-1/",
@@ -5222,7 +5518,8 @@
       "repository": "https://github.com/w3c/trace-context"
     },
     "title": "Trace Context - Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Trace Context 1"
   },
   {
     "url": "https://www.w3.org/TR/uievents-code/",
@@ -5240,7 +5537,8 @@
       "repository": "https://github.com/w3c/uievents-code"
     },
     "title": "UI Events KeyboardEvent code Values",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "UI Events KeyboardEvent code Values"
   },
   {
     "url": "https://www.w3.org/TR/uievents-key/",
@@ -5258,7 +5556,8 @@
       "repository": "https://github.com/w3c/uievents-key"
     },
     "title": "UI Events KeyboardEvent key Values",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "UI Events KeyboardEvent key Values"
   },
   {
     "url": "https://www.w3.org/TR/uievents/",
@@ -5276,7 +5575,8 @@
       "repository": "https://github.com/w3c/uievents"
     },
     "title": "UI Events",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "UI Events"
   },
   {
     "url": "https://www.w3.org/TR/upgrade-insecure-requests/",
@@ -5294,7 +5594,8 @@
       "repository": "https://github.com/w3c/webappsec-upgrade-insecure-requests"
     },
     "title": "Upgrade Insecure Requests",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Upgrade Insecure Requests"
   },
   {
     "url": "https://www.w3.org/TR/user-timing-2/",
@@ -5314,7 +5615,8 @@
       "repository": "https://github.com/w3c/user-timing"
     },
     "title": "User Timing Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "User Timing 2"
   },
   {
     "url": "https://www.w3.org/TR/user-timing-3/",
@@ -5334,7 +5636,8 @@
       "repository": "https://github.com/w3c/user-timing"
     },
     "title": "User Timing Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "User Timing 3"
   },
   {
     "url": "https://www.w3.org/TR/vibration/",
@@ -5352,7 +5655,8 @@
       "repository": "https://github.com/w3c/vibration"
     },
     "title": "Vibration API (Second Edition)",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Vibration API"
   },
   {
     "url": "https://www.w3.org/TR/wai-aria-1.2/",
@@ -5371,7 +5675,8 @@
       "repository": "https://github.com/w3c/aria"
     },
     "title": "Accessible Rich Internet Applications (WAI-ARIA) 1.2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WAI-ARIA 1.2"
   },
   {
     "url": "https://www.w3.org/TR/wake-lock/",
@@ -5389,7 +5694,8 @@
       "repository": "https://github.com/w3c/screen-wake-lock"
     },
     "title": "Wake Lock API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Wake Lock API"
   },
   {
     "url": "https://www.w3.org/TR/wasm-core-1/",
@@ -5408,7 +5714,8 @@
       "repository": "https://github.com/WebAssembly/spec"
     },
     "title": "WebAssembly Core Specification",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebAssembly Core"
   },
   {
     "url": "https://www.w3.org/TR/wasm-js-api-1/",
@@ -5427,7 +5734,8 @@
       "repository": "https://github.com/WebAssembly/spec"
     },
     "title": "WebAssembly JavaScript Interface",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebAssembly JavaScript Interface"
   },
   {
     "url": "https://www.w3.org/TR/wasm-web-api-1/",
@@ -5446,7 +5754,8 @@
       "repository": "https://github.com/WebAssembly/spec"
     },
     "title": "WebAssembly Web API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebAssembly Web API"
   },
   {
     "url": "https://www.w3.org/TR/web-animations-1/",
@@ -5465,7 +5774,8 @@
       "repository": "https://github.com/w3c/csswg-drafts"
     },
     "title": "Web Animations",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web Animations"
   },
   {
     "url": "https://www.w3.org/TR/web-share/",
@@ -5483,7 +5793,8 @@
       "repository": "https://github.com/w3c/web-share"
     },
     "title": "Web Share API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web Share API"
   },
   {
     "url": "https://www.w3.org/TR/webaudio/",
@@ -5501,7 +5812,8 @@
       "repository": "https://github.com/WebAudio/web-audio-api"
     },
     "title": "Web Audio API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web Audio API"
   },
   {
     "url": "https://www.w3.org/TR/webauthn-2/",
@@ -5520,7 +5832,8 @@
       "repository": "https://github.com/w3c/webauthn"
     },
     "title": "Web Authentication:An API for accessing Public Key Credentials Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web Authentication:An API for accessing Public Key Credentials 2"
   },
   {
     "url": "https://www.w3.org/TR/WebCryptoAPI/",
@@ -5538,7 +5851,8 @@
       "repository": "https://github.com/w3c/webcrypto"
     },
     "title": "Web Cryptography API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web Cryptography API"
   },
   {
     "url": "https://www.w3.org/TR/webdriver2/",
@@ -5557,7 +5871,8 @@
       "repository": "https://github.com/w3c/webdriver"
     },
     "title": "WebDriver - Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebDriver 2"
   },
   {
     "url": "https://www.w3.org/TR/WebIDL-1/",
@@ -5576,7 +5891,8 @@
       "repository": "https://github.com/heycam/webidl"
     },
     "title": "WebIDL Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebIDL 1"
   },
   {
     "url": "https://www.w3.org/TR/webmidi/",
@@ -5594,7 +5910,8 @@
       "repository": "https://github.com/WebAudio/web-midi-api"
     },
     "title": "Web MIDI API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Web MIDI API"
   },
   {
     "url": "https://www.w3.org/TR/webrtc-identity/",
@@ -5612,7 +5929,8 @@
       "repository": "https://github.com/w3c/webrtc-identity"
     },
     "title": "Identity for WebRTC 1.0",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Identity for WebRTC 1.0"
   },
   {
     "url": "https://www.w3.org/TR/webrtc-priority/",
@@ -5630,7 +5948,8 @@
       "repository": "https://github.com/w3c/webrtc-priority"
     },
     "title": "WebRTC Priority Control API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebRTC Priority Control API"
   },
   {
     "url": "https://www.w3.org/TR/webrtc-stats/",
@@ -5648,7 +5967,8 @@
       "repository": "https://github.com/w3c/webrtc-stats"
     },
     "title": "Identifiers for WebRTC's Statistics API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Identifiers for WebRTC's Statistics API"
   },
   {
     "url": "https://www.w3.org/TR/webrtc-svc/",
@@ -5666,7 +5986,8 @@
       "repository": "https://github.com/w3c/webrtc-svc"
     },
     "title": "Scalable Video Coding (SVC) Extension for WebRTC",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "SVC"
   },
   {
     "url": "https://www.w3.org/TR/webrtc/",
@@ -5676,6 +5997,7 @@
       "shortname": "webrtc",
       "currentSpecification": "webrtc"
     },
+    "shortTitle": "WebRTC 1.0",
     "release": {
       "url": "https://www.w3.org/TR/webrtc/"
     },
@@ -5703,7 +6025,8 @@
       "repository": "https://github.com/w3c/webvtt"
     },
     "title": "WebVTT: The Web Video Text Tracks Format",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebVTT: The Web Video Text Tracks Format"
   },
   {
     "url": "https://www.w3.org/TR/webxr-ar-module-1/",
@@ -5722,7 +6045,8 @@
       "repository": "https://github.com/immersive-web/webxr-ar-module"
     },
     "title": "WebXR Augmented Reality Module - Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebXR Augmented Reality 1"
   },
   {
     "url": "https://www.w3.org/TR/webxr-gamepads-module-1/",
@@ -5741,7 +6065,8 @@
       "repository": "https://github.com/immersive-web/webxr-gamepads-module"
     },
     "title": "WebXR Gamepads Module - Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebXR Gamepads 1"
   },
   {
     "url": "https://www.w3.org/TR/webxr/",
@@ -5759,7 +6084,8 @@
       "repository": "https://github.com/immersive-web/webxr"
     },
     "title": "WebXR Device API",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WebXR Device API"
   },
   {
     "url": "https://www.w3.org/TR/WOFF2/",
@@ -5778,7 +6104,8 @@
       "repository": "https://github.com/w3c/woff"
     },
     "title": "WOFF File Format 2.0",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "WOFF File Format 2.0"
   },
   {
     "url": "https://www.w3.org/TR/worklets-1/",
@@ -5797,7 +6124,8 @@
       "repository": "https://github.com/w3c/css-houdini-drafts"
     },
     "title": "Worklets Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "shortTitle": "Worklets 1"
   },
   {
     "url": "https://xhr.spec.whatwg.org/",
@@ -5812,6 +6140,7 @@
       "repository": "https://github.com/whatwg/xhr"
     },
     "title": "XMLHttpRequest Standard",
-    "source": "specref"
+    "source": "specref",
+    "shortTitle": "XMLHttpRequest"
   }
 ]

--- a/schema/index.json
+++ b/schema/index.json
@@ -16,11 +16,12 @@
       "nightly": { "$ref": "definitions.json#/proptype/nightly" },
       "release": { "$ref": "definitions.json#/proptype/release" },
       "title": { "$ref": "definitions.json#/proptype/title" },
+      "shortTitle": { "$ref": "definitions.json#/proptype/title" },
       "source": { "$ref": "definitions.json#/proptype/source" }
     },
     "required": [
       "url", "shortname", "series", "seriesComposition", "nightly",
-      "title", "source"
+      "title", "shortTitle", "source"
     ],
     "additionalProperties": false
   },

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -18,6 +18,7 @@
           "seriesVersion": { "$ref": "definitions.json#/proptype/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/proptype/seriesComposition" },
           "nightly": { "$ref": "definitions.json#/proptype/nightly" },
+          "shortTitle": { "$ref": "definitions.json#/proptype/title" },
           "forceCurrent": { "type": "boolean" }
         },
         "required": ["url"],

--- a/specs.json
+++ b/specs.json
@@ -352,7 +352,10 @@
   "https://www.w3.org/TR/webrtc-priority/",
   "https://www.w3.org/TR/webrtc-stats/",
   "https://www.w3.org/TR/webrtc-svc/",
-  "https://www.w3.org/TR/webrtc/",
+  {
+    "url": "https://www.w3.org/TR/webrtc/",
+    "shortTitle": "WebRTC 1.0"
+  },
   "https://www.w3.org/TR/webvtt1/",
   "https://www.w3.org/TR/webxr-ar-module-1/",
   "https://www.w3.org/TR/webxr-gamepads-module-1/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -10,6 +10,7 @@ const computeShortname = require("./compute-shortname.js");
 const computePrevNext = require("./compute-prevnext.js");
 const computeCurrentLevel = require("./compute-currentlevel.js");
 const computeRepository = require("./compute-repository.js");
+const computeShortTitle = require("./compute-shorttitle.js");
 const fetchInfo = require("./fetch-info.js");
 const { w3cApiKey } = require("../config.json");
 
@@ -63,6 +64,10 @@ const specs = require("../specs.json")
 fetchInfo(specs, { w3cApiKey })
   .then(specInfo => specs.map(spec =>
     Object.assign({}, spec, specInfo[spec.shortname], spec)))
+  .then(index => index.map(spec => {
+    spec.shortTitle = spec.shortTitle || computeShortTitle(spec.title);
+    return spec;
+  }))
   .then(index => computeRepository(index))
   .then(index => console.log(JSON.stringify(index, null, 2)))
   .catch(err => {

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -1,0 +1,42 @@
+/**
+ * Module that exports a function that takes a title as input and returns a
+ * meaningful short title out of it, or the full title if it cannot be
+ * abbreviated.
+ *
+ * For instance, given "CSS Conditional Rules Module Level 3" as a title, the
+ * function would return "CSS Conditional 3"
+ */
+
+
+/**
+ * Internal function that takes a URL as input and returns a name for it
+ * if the URL matches well-known patterns, or if the given parameter is actually
+ * already a name (meaning that it does not contains any "/").
+ *
+ * The function throws if it cannot compute a meaningful name from the URL.
+ */
+module.exports = function (title) {
+  if (!title) {
+    return title;
+  }
+
+  const level = title.match(/\d+(\.\d+)?$/);
+
+  const shortTitle = title
+    .replace(/\u00A0/g, ' ')            // Replace non-breaking spaces
+    .replace(/ \d+(\.\d+)?$/, '')       // Drop level number for now
+    .replace(/( -)? Level$/, '')        // Drop "Level"
+    .replace(/ Module$/, '')            // Drop "Module" (now followed by level)
+    .replace(/ Specification$/, '')     // Drop "Specification"
+    .replace(/ Standard$/, '')          // Drop "Standard" and "Living Standard"
+    .replace(/ Living$/, '')
+    .replace(/ \([^\)]+ Edition\)/, '') // Drop edition indication
+    .replace(/^.*\(([^\)]+)\).*$/, '$1'); // Use abbr between parentheses
+
+  if (level) {
+    return shortTitle + " " + level[0];
+  }
+  else {
+    return shortTitle;
+  }
+};

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -20,10 +20,10 @@ module.exports = function (title) {
     return title;
   }
 
-  const level = title.match(/\d+(\.\d+)?$/);
+  const level = title.match(/\s(\d+(\.\d+)?)$/);
 
   const shortTitle = title
-    .replace(/\u00A0/g, ' ')            // Replace non-breaking spaces
+    .replace(/\s/g, ' ')                // Replace non-breaking spaces
     .replace(/ \d+(\.\d+)?$/, '')       // Drop level number for now
     .replace(/( -)? Level$/, '')        // Drop "Level"
     .replace(/ Module$/, '')            // Drop "Module" (now followed by level)
@@ -34,7 +34,7 @@ module.exports = function (title) {
     .replace(/^.*\(([^\)]+)\).*$/, '$1'); // Use abbr between parentheses
 
   if (level) {
-    return shortTitle + " " + level[0];
+    return shortTitle + " " + level[1];
   }
   else {
     return shortTitle;

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -1,0 +1,81 @@
+const assert = require("assert");
+const computeShortTitle = require("../src/compute-shorttitle.js");
+
+describe("compute-shorttitle module", () => {
+  function assertTitle(title, expected) {
+    const shortTitle = computeShortTitle(title);
+    assert.equal(shortTitle, expected);
+  }
+
+  it("finds abbreviation for main CSS spec", () => {
+    assertTitle(
+      "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification",
+      "CSS 2.1");
+  });
+
+  it("does not choke on non-breaking spaces", () => {
+    assertTitle(
+      "CSS Backgrounds and Borders Module Level\u00A04",
+      "CSS Backgrounds and Borders 4");
+  });
+
+  it("finds abbreviation for WAI-ARIA title", () => {
+    assertTitle(
+      "Accessible Rich Internet Applications (WAI-ARIA) 1.2",
+      "WAI-ARIA 1.2");
+  });
+
+  it("drops 'Level' from title but keeps level number", () => {
+    assertTitle(
+      "CSS Foo Level 42",
+      "CSS Foo 42");
+  });
+
+  it("drops 'Module' from title but keeps level number", () => {
+    assertTitle(
+      "CSS Foo Module Level 42",
+      "CSS Foo 42");
+  });
+
+  it("drops '- Level' from title", () => {
+    assertTitle(
+      "Foo - Level 2",
+      "Foo 2");
+  });
+
+  it("drops 'Module - Level' from title", () => {
+    assertTitle(
+      "Foo Module - Level 3",
+      "Foo 3");
+  });
+
+  it("drops 'Specification' from end of title", () => {
+    assertTitle(
+      "Foo Specification",
+      "Foo");
+  });
+
+  it("drops 'Standard' from end of title", () => {
+    assertTitle(
+      "Foo Standard",
+      "Foo");
+  });
+
+  it("drops 'Living Standard' from end of title", () => {
+    assertTitle(
+      "Foo Living Standard",
+      "Foo");
+  });
+
+  it("drops edition indications", () => {
+    assertTitle(
+      "Foo (Second Edition) Bar",
+      "Foo Bar");
+  });
+
+  it("preserves title when needed", () => {
+    assertTitle(
+      "Edition Module Standard Foo",
+      "Edition Module Standard Foo");
+  });
+});

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -19,6 +19,12 @@ describe("compute-shorttitle module", () => {
       "CSS Backgrounds and Borders 4");
   });
 
+  it("does not choke on levels that are not levels", () => {
+    assertTitle(
+      "CORS and RFC1918",
+      "CORS and RFC1918");
+  });
+
   it("finds abbreviation for WAI-ARIA title", () => {
     assertTitle(
       "Accessible Rich Internet Applications (WAI-ARIA) 1.2",


### PR DESCRIPTION
See #12. The shortTitle property gets computed from the full title by dropping common terms and applying a few additional regular expressions. The shortTitle property may be specified in specs.json.

There should be ~25 specs for which we'll likely have to maintain the short title manually in specs.json. I haven't included them in the pull request so that we can first check that the automatic generation does not produce weird results.