### PR TITLE
Add script to assist in updating monitored specs

### DIFF
--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -1,0 +1,28 @@
+name: Monitor specs
+
+on:
+  schedule:
+    - cron: '0 0 1 */2 *'
+jobs:
+  find-specs:
+    name: Update the list of monitored specs and highlights those that have changed
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: node src/monitor-specs.js # sets review_list env variable
+    - uses: peter-evans/create-pull-request@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        title: Update review of monitored specs
+        commit-message: "Update review of monitored specs"
+        body: |
+          The following specs have been updated since the last review:
+          ${{env.review_list}}
+        assignees: tidoust, dontcallmedom
+        draft: true

--- a/src/monitor-specs.js
+++ b/src/monitor-specs.js
@@ -1,0 +1,41 @@
+'use strict';
+const fs = require("fs");
+
+const core = require('@actions/core');
+
+const fetch = require("node-fetch");
+
+const monitorList = require("./data/monitor.json");
+
+const toGhUrl = repo => `https://${repo.split("/")[0].toLowerCase()}.github.io/${repo.split("/")[1]}/`;
+
+const today = new Date().toJSON().slice(0, 10);
+
+(async function() {
+  // Check last-modified HTTP header for specs to highlight those that needs
+  // re-review
+  let review_needed = [];
+  const candidates = Object.keys(monitorList.repos).map(r => {return {...monitorList.repos[r], url: toGhUrl(r)};}).concat(
+    Object.keys(monitorList.specs).map(s => {return {...monitorList.specs[s], url: s};}));
+ for (let candidate of candidates) {
+   await fetch(candidate.url).then(({headers}) => {
+     if (new Date(headers.get('Last-Modified')) > new Date(candidate.lastreviewed)) {
+       review_needed.push({...candidate, lastupdated: new Date(headers.get('Last-Modified')).toJSON()});
+     }
+   });
+ }
+ const review_list = review_needed.map(c => `- [ ] ${c.url} updated on ${c.lastupdated}; last comment: “${c.comment}” made on ${c.lastreviewed}`).join("\n");
+ core.exportVariable("review_list", review_list);
+ console.log(review_list);
+
+  // Update monitor.json setting lastreviewed date today on all entries
+  // This will serve as input to the automated pull request
+  Object.values(monitorList.repos).forEach(r => r.lastreviewed = today);
+  Object.values(monitorList.specs).forEach(r => r.lastreviewed = today);
+ fs.writeFileSync("./src/data/monitor.json", JSON.stringify(monitorList, null, 2));
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});
+
+


### PR DESCRIPTION
The script checks the last-modified headers on the specs and highlights those that have changed since last review; it submits as a pull request (via a github action) the list of repos/specs to be monitored updated with a last review date of the day it is running on

See #113 for an example of what it produces.