### PR TITLE
Use CSS21 instead of CSS2 address

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -218,7 +218,7 @@
   "https://www.w3.org/TR/css-will-change-1/",
   "https://www.w3.org/TR/css-writing-modes-3/",
   "https://www.w3.org/TR/css-writing-modes-4/",
-  "https://www.w3.org/TR/CSS2/",
+  "https://www.w3.org/TR/CSS21/",
   "https://www.w3.org/TR/CSS22/",
   {
     "url": "https://www.w3.org/TR/css3-conditional/",


### PR DESCRIPTION
Shortname was fixed in W3C systems, and CSS2 is now an alias that redirects to CSS21.