### PR TITLE
Expose filename of the index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ cross-references, WebIDL, quality, etc.
   - [`seriesNext`](#seriesnext)
   - [`release`](#release)
     - [`release.url`](#releaseurl)
+    - [`release.filename`](#releasefilename)
     - [`release.pages`](#releasepages)
   - [`nightly`](#nightly)
     - [`nightly.url`](#nightlyurl)
+    - [`nightly.filename`](#nightlyfilename)
     - [`nightly.pages`](#nightlypages)
     - [`nightly.repository`](#nightlyrepository)
   - [`source`](#source)
@@ -86,11 +88,13 @@ Each specification in the list comes with the following properties:
   "seriesPrevious": "css-color-3",
   "seriesNext": "css-color-5",
   "release": {
-    "url": "https://www.w3.org/TR/css-color-4/"
+    "url": "https://www.w3.org/TR/css-color-4/",
+    "filename": "Overview.html"
   },
   "nightly": {
     "url": "https://drafts.csswg.org/css-color/",
-    "repository": "https://github.com/w3c/csswg-drafts"
+    "repository": "https://github.com/w3c/csswg-drafts",
+    "filename": "Overview.html"
   },
   "source": "w3c"
 }
@@ -224,6 +228,17 @@ URL (see [`url`](#url)).
 The `url` property is always set.
 
 
+#### `release.filename`
+
+The filename of the resource that gets served when the default URL is fetched.
+For instance, the filename for `https://www.w3.org/TR/presentation-api/` is
+`Overview.html`, meaning that the specification could also be retrieved from
+`https://www.w3.org/TR/presentation-api/Overview.html`. The filename may be
+useful to distinguish links to self in a spec.
+
+The `filename` property is always set.
+
+
 #### `release.pages`
 
 The list of absolute page URLs when the spec is a multipage spec.
@@ -250,6 +265,17 @@ neither exist in the W3C API nor in Specref. The [`source`](#source) property
 details the actual provenance.
 
 The `url` property is always set.
+
+
+#### `nightly.filename`
+
+The filename of the resource that gets served when the default URL is fetched.
+For instance, the filename for `https://w3c.github.io/presentation-api/` is
+`index.html`, meaning that the specification could also be retrieved from
+`https://w3c.github.io/presentation-api/index.html`. The filename may be
+useful to distinguish links to self in a spec.
+
+The `filename` property is always set.
 
 
 #### `nightly.pages`

--- a/index.json
+++ b/index.json
@@ -9,7 +9,8 @@
     },
     "nightly": {
       "url": "https://compat.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/compat"
+      "repository": "https://github.com/whatwg/compat",
+      "filename": "index.html"
     },
     "title": "Compatibility Standard",
     "source": "specref",
@@ -25,7 +26,8 @@
     },
     "nightly": {
       "url": "https://console.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/console"
+      "repository": "https://github.com/whatwg/console",
+      "filename": "index.html"
     },
     "title": "Console Standard",
     "source": "specref",
@@ -41,7 +43,8 @@
     },
     "nightly": {
       "url": "https://dom.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/dom"
+      "repository": "https://github.com/whatwg/dom",
+      "filename": "index.html"
     },
     "title": "DOM Standard",
     "source": "specref",
@@ -59,7 +62,8 @@
     "seriesPrevious": "css-typed-om-1",
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-typed-om-2/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Typed OM Level 2",
     "source": "spec",
@@ -76,7 +80,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "Font Metrics API Level 1",
     "source": "spec",
@@ -94,7 +99,8 @@
     "seriesPrevious": "css-animations-1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-animations-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Animations Level 2",
     "source": "spec",
@@ -112,7 +118,8 @@
     "seriesPrevious": "css-backgrounds-3",
     "nightly": {
       "url": "https://drafts.csswg.org/css-backgrounds-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Backgrounds and Borders Module Level 4",
     "source": "specref",
@@ -129,7 +136,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-env-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Environment Variables Module Level 1",
     "source": "spec",
@@ -146,7 +154,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-extensions-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Extensions",
     "source": "spec",
@@ -165,7 +174,8 @@
     "seriesPrevious": "css-gcpm-3",
     "nightly": {
       "url": "https://drafts.csswg.org/css-gcpm-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module Level 4",
     "source": "spec"
@@ -181,7 +191,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-highlight-api-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Custom Highlight API Module Level 1",
     "source": "spec",
@@ -200,7 +211,8 @@
     "seriesPrevious": "css-multicol-1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-multicol-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 2",
     "source": "spec"
@@ -216,7 +228,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-nesting-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Nesting Module",
     "source": "spec",
@@ -234,7 +247,8 @@
     "seriesPrevious": "css-page-3",
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Proposals for the future of CSS Paged Media",
     "source": "spec",
@@ -252,7 +266,8 @@
     "seriesPrevious": "css-shapes-1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-shapes-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Shapes Module Level 2",
     "source": "spec",
@@ -270,7 +285,8 @@
     "shortTitle": "CSS Size Adjustment 1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-size-adjust-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Mobile Text Size Adjustment Module Level 1",
     "source": "spec"
@@ -287,7 +303,8 @@
     "seriesPrevious": "css-transitions-1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-transitions-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Transitions Level 2",
     "source": "spec",
@@ -304,7 +321,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/scroll-animations-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Scroll-linked Animations",
     "source": "spec",
@@ -323,7 +341,8 @@
     "seriesPrevious": "compositing-1",
     "nightly": {
       "url": "https://drafts.fxtf.org/compositing-2/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 2",
     "source": "spec"
@@ -340,7 +359,8 @@
     "seriesPrevious": "filter-effects-1",
     "nightly": {
       "url": "https://drafts.fxtf.org/filter-effects-2/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Filter Effects Module Level 2",
     "source": "spec",
@@ -356,7 +376,8 @@
     },
     "nightly": {
       "url": "https://fetch.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/fetch"
+      "repository": "https://github.com/whatwg/fetch",
+      "filename": "index.html"
     },
     "title": "Fetch Standard",
     "source": "specref",
@@ -372,7 +393,8 @@
     },
     "nightly": {
       "url": "https://fullscreen.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/fullscreen"
+      "repository": "https://github.com/whatwg/fullscreen",
+      "filename": "index.html"
     },
     "title": "Fullscreen API Standard",
     "source": "specref",
@@ -388,7 +410,8 @@
     },
     "nightly": {
       "url": "https://gpuweb.github.io/gpuweb/",
-      "repository": "https://github.com/gpuweb/gpuweb"
+      "repository": "https://github.com/gpuweb/gpuweb",
+      "filename": "index.html"
     },
     "title": "WebGPU",
     "source": "spec",
@@ -465,7 +488,8 @@
         "https://html.spec.whatwg.org/multipage/indices.html",
         "https://html.spec.whatwg.org/multipage/references.html",
         "https://html.spec.whatwg.org/multipage/acknowledgements.html"
-      ]
+      ],
+      "filename": "Overview.html"
     },
     "title": "HTML Standard",
     "source": "specref",
@@ -481,7 +505,8 @@
     },
     "nightly": {
       "url": "https://immersive-web.github.io/anchors/",
-      "repository": "https://github.com/immersive-web/anchors"
+      "repository": "https://github.com/immersive-web/anchors",
+      "filename": "index.html"
     },
     "title": "WebXR Anchors Module",
     "source": "spec",
@@ -497,7 +522,8 @@
     },
     "nightly": {
       "url": "https://immersive-web.github.io/dom-overlays/",
-      "repository": "https://github.com/immersive-web/dom-overlays"
+      "repository": "https://github.com/immersive-web/dom-overlays",
+      "filename": "index.html"
     },
     "title": "WebXR DOM Overlays Module",
     "source": "spec",
@@ -513,7 +539,8 @@
     },
     "nightly": {
       "url": "https://immersive-web.github.io/hit-test/",
-      "repository": "https://github.com/immersive-web/hit-test"
+      "repository": "https://github.com/immersive-web/hit-test",
+      "filename": "index.html"
     },
     "title": "WebXR Hit Test Module",
     "source": "spec",
@@ -529,7 +556,8 @@
     },
     "nightly": {
       "url": "https://immersive-web.github.io/layers/",
-      "repository": "https://github.com/immersive-web/layers"
+      "repository": "https://github.com/immersive-web/layers",
+      "filename": "index.html"
     },
     "title": "WebXR Layers API Level 1",
     "source": "spec",
@@ -545,7 +573,8 @@
     },
     "nightly": {
       "url": "https://infra.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/infra"
+      "repository": "https://github.com/whatwg/infra",
+      "filename": "index.html"
     },
     "title": "Infra Standard",
     "source": "specref",
@@ -561,7 +590,8 @@
     },
     "nightly": {
       "url": "https://mathml-refresh.github.io/mathml-core/",
-      "repository": "https://github.com/mathml-refresh/mathml-core"
+      "repository": "https://github.com/mathml-refresh/mathml-core",
+      "filename": "index.html"
     },
     "title": "MathML Core",
     "source": "spec",
@@ -577,7 +607,8 @@
     },
     "nightly": {
       "url": "https://mimesniff.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/mimesniff"
+      "repository": "https://github.com/whatwg/mimesniff",
+      "filename": "index.html"
     },
     "title": "MIME Sniffing Standard",
     "source": "specref",
@@ -593,7 +624,8 @@
     },
     "nightly": {
       "url": "https://notifications.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/notifications"
+      "repository": "https://github.com/whatwg/notifications",
+      "filename": "index.html"
     },
     "title": "Notifications API Standard",
     "source": "specref",
@@ -609,7 +641,8 @@
     },
     "nightly": {
       "url": "https://privacycg.github.io/private-click-measurement/",
-      "repository": "https://github.com/privacycg/private-click-measurement"
+      "repository": "https://github.com/privacycg/private-click-measurement",
+      "filename": "index.html"
     },
     "title": "Private Click Measurement",
     "source": "spec",
@@ -625,7 +658,8 @@
     },
     "nightly": {
       "url": "https://privacycg.github.io/storage-access/",
-      "repository": "https://github.com/privacycg/storage-access"
+      "repository": "https://github.com/privacycg/storage-access",
+      "filename": "index.html"
     },
     "title": "The Storage Access API",
     "source": "spec",
@@ -641,7 +675,8 @@
     },
     "nightly": {
       "url": "https://quirks.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/quirks"
+      "repository": "https://github.com/whatwg/quirks",
+      "filename": "index.html"
     },
     "title": "Quirks Mode Standard",
     "source": "specref",
@@ -657,7 +692,8 @@
     },
     "nightly": {
       "url": "https://storage.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/storage"
+      "repository": "https://github.com/whatwg/storage",
+      "filename": "index.html"
     },
     "title": "Storage Standard",
     "source": "specref",
@@ -673,7 +709,8 @@
     },
     "nightly": {
       "url": "https://streams.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/streams"
+      "repository": "https://github.com/whatwg/streams",
+      "filename": "index.html"
     },
     "title": "Streams Standard",
     "source": "specref",
@@ -689,7 +726,8 @@
     },
     "nightly": {
       "url": "https://svgwg.org/specs/animations/",
-      "repository": "https://github.com/w3c/svgwg"
+      "repository": "https://github.com/w3c/svgwg",
+      "filename": "Overview.html"
     },
     "title": "SVG Animations Level 2",
     "source": "spec",
@@ -705,7 +743,8 @@
     },
     "nightly": {
       "url": "https://url.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/url"
+      "repository": "https://github.com/whatwg/url",
+      "filename": "index.html"
     },
     "title": "URL Standard",
     "source": "specref",
@@ -721,7 +760,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/badging/",
-      "repository": "https://github.com/w3c/badging"
+      "repository": "https://github.com/w3c/badging",
+      "filename": "index.html"
     },
     "title": "Badging API",
     "source": "specref",
@@ -737,7 +777,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/contentEditable/",
-      "repository": "https://github.com/w3c/contentEditable"
+      "repository": "https://github.com/w3c/contentEditable",
+      "filename": "index.html"
     },
     "title": "ContentEditable",
     "source": "spec",
@@ -753,7 +794,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/gamepad/extensions.html",
-      "repository": "https://github.com/w3c/gamepad"
+      "repository": "https://github.com/w3c/gamepad",
+      "filename": "extensions.html"
     },
     "title": "Gamepad Extensions",
     "source": "spec",
@@ -769,7 +811,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/mathml-aam/",
-      "repository": "https://github.com/w3c/mathml-aam"
+      "repository": "https://github.com/w3c/mathml-aam",
+      "filename": "index.html"
     },
     "title": "MathML Accessiblity API Mappings 1.0",
     "source": "spec",
@@ -785,7 +828,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/media-playback-quality/",
-      "repository": "https://github.com/w3c/media-playback-quality"
+      "repository": "https://github.com/w3c/media-playback-quality",
+      "filename": "index.html"
     },
     "title": "Media Playback Quality",
     "source": "specref",
@@ -801,7 +845,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/web-nfc/",
-      "repository": "https://github.com/w3c/web-nfc"
+      "repository": "https://github.com/w3c/web-nfc",
+      "filename": "index.html"
     },
     "title": "Web NFC API",
     "source": "specref",
@@ -817,7 +862,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/web-share-target/",
-      "repository": "https://github.com/w3c/web-share-target"
+      "repository": "https://github.com/w3c/web-share-target",
+      "filename": "index.html"
     },
     "title": "Web Share Target API",
     "source": "specref",
@@ -833,7 +879,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
-      "repository": "https://github.com/w3c/webappsec-trusted-types"
+      "repository": "https://github.com/w3c/webappsec-trusted-types",
+      "filename": "index.html"
     },
     "title": "Trusted Types",
     "source": "specref",
@@ -849,7 +896,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/webdriver-bidi/",
-      "repository": "https://github.com/w3c/webdriver-bidi"
+      "repository": "https://github.com/w3c/webdriver-bidi",
+      "filename": "index.html"
     },
     "title": "WebDriver BiDi",
     "source": "spec",
@@ -865,7 +913,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-ice/",
-      "repository": "https://github.com/w3c/webrtc-ice"
+      "repository": "https://github.com/w3c/webrtc-ice",
+      "filename": "index.html"
     },
     "title": "IceTransport Extensions for WebRTC",
     "source": "spec",
@@ -881,7 +930,8 @@
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-insertable-streams/",
-      "repository": "https://github.com/w3c/webrtc-insertable-streams"
+      "repository": "https://github.com/w3c/webrtc-insertable-streams",
+      "filename": "index.html"
     },
     "title": "WebRTC Insertable Media using Streams",
     "source": "spec",
@@ -897,7 +947,8 @@
     },
     "nightly": {
       "url": "https://webbluetoothcg.github.io/web-bluetooth/",
-      "repository": "https://github.com/WebBluetoothCG/web-bluetooth"
+      "repository": "https://github.com/WebBluetoothCG/web-bluetooth",
+      "filename": "index.html"
     },
     "title": "Web Bluetooth",
     "source": "specref",
@@ -913,7 +964,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/background-fetch/",
-      "repository": "https://github.com/WICG/background-fetch"
+      "repository": "https://github.com/WICG/background-fetch",
+      "filename": "index.html"
     },
     "title": "Background Fetch",
     "source": "specref",
@@ -930,7 +982,8 @@
     "shortTitle": "Background Sync",
     "nightly": {
       "url": "https://wicg.github.io/background-sync/spec/",
-      "repository": "https://github.com/WICG/background-sync"
+      "repository": "https://github.com/WICG/background-sync",
+      "filename": "index.html"
     },
     "title": "Web Background Synchronization",
     "source": "spec"
@@ -945,7 +998,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/change-password-url/",
-      "repository": "https://github.com/WICG/change-password-url"
+      "repository": "https://github.com/WICG/change-password-url",
+      "filename": "index.html"
     },
     "title": "A Well-Known URL for Changing Passwords",
     "source": "spec",
@@ -961,7 +1015,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/client-hints-infrastructure/",
-      "repository": "https://github.com/WICG/client-hints-infrastructure"
+      "repository": "https://github.com/WICG/client-hints-infrastructure",
+      "filename": "index.html"
     },
     "title": "Client Hints Infrastructure",
     "source": "specref",
@@ -977,7 +1032,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/compression/",
-      "repository": "https://github.com/WICG/compression"
+      "repository": "https://github.com/WICG/compression",
+      "filename": "index.html"
     },
     "title": "Compression Streams",
     "source": "spec",
@@ -993,7 +1049,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/construct-stylesheets/",
-      "repository": "https://github.com/WICG/construct-stylesheets"
+      "repository": "https://github.com/WICG/construct-stylesheets",
+      "filename": "index.html"
     },
     "title": "Constructable Stylesheet Objects",
     "source": "spec",
@@ -1009,7 +1066,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/contact-api/spec/",
-      "repository": "https://github.com/WICG/contact-api"
+      "repository": "https://github.com/WICG/contact-api",
+      "filename": "index.html"
     },
     "title": "Contact Picker API",
     "source": "spec",
@@ -1025,7 +1083,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/content-index/spec/",
-      "repository": "https://github.com/WICG/content-index"
+      "repository": "https://github.com/WICG/content-index",
+      "filename": "index.html"
     },
     "title": "Content Index",
     "source": "spec",
@@ -1041,7 +1100,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/cookie-store/",
-      "repository": "https://github.com/WICG/cookie-store"
+      "repository": "https://github.com/WICG/cookie-store",
+      "filename": "index.html"
     },
     "title": "Cookie Store API",
     "source": "specref",
@@ -1057,7 +1117,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/cors-rfc1918/",
-      "repository": "https://github.com/WICG/cors-rfc1918"
+      "repository": "https://github.com/WICG/cors-rfc1918",
+      "filename": "index.html"
     },
     "title": "CORS and RFC1918",
     "source": "specref",
@@ -1073,7 +1134,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/crash-reporting/",
-      "repository": "https://github.com/WICG/crash-reporting"
+      "repository": "https://github.com/WICG/crash-reporting",
+      "filename": "index.html"
     },
     "title": "Crash Reporting",
     "source": "spec",
@@ -1089,7 +1151,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/css-parser-api/",
-      "repository": "https://github.com/WICG/css-parser-api"
+      "repository": "https://github.com/WICG/css-parser-api",
+      "filename": "index.html"
     },
     "title": "CSS Parser API",
     "source": "specref",
@@ -1105,7 +1168,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/custom-state-pseudo-class/",
-      "repository": "https://github.com/WICG/custom-state-pseudo-class"
+      "repository": "https://github.com/WICG/custom-state-pseudo-class",
+      "filename": "index.html"
     },
     "title": "Custom State Pseudo Class",
     "source": "spec",
@@ -1121,7 +1185,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/deprecation-reporting/",
-      "repository": "https://github.com/WICG/deprecation-reporting"
+      "repository": "https://github.com/WICG/deprecation-reporting",
+      "filename": "index.html"
     },
     "title": "Deprecation Reporting",
     "source": "spec",
@@ -1137,7 +1202,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/element-timing/",
-      "repository": "https://github.com/WICG/element-timing"
+      "repository": "https://github.com/WICG/element-timing",
+      "filename": "index.html"
     },
     "title": "Element Timing API",
     "source": "specref",
@@ -1153,7 +1219,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/entries-api/",
-      "repository": "https://github.com/WICG/entries-api"
+      "repository": "https://github.com/WICG/entries-api",
+      "filename": "index.html"
     },
     "title": "File and Directory Entries API",
     "source": "specref",
@@ -1169,7 +1236,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/event-timing/",
-      "repository": "https://github.com/WICG/event-timing"
+      "repository": "https://github.com/WICG/event-timing",
+      "filename": "index.html"
     },
     "title": "Event Timing API",
     "source": "specref",
@@ -1185,7 +1253,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/frame-timing/",
-      "repository": "https://github.com/WICG/frame-timing"
+      "repository": "https://github.com/WICG/frame-timing",
+      "filename": "index.html"
     },
     "title": "Frame Timing",
     "source": "specref",
@@ -1201,7 +1270,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/get-installed-related-apps/spec/",
-      "repository": "https://github.com/WICG/get-installed-related-apps"
+      "repository": "https://github.com/WICG/get-installed-related-apps",
+      "filename": "index.html"
     },
     "title": "Get Installed Related Apps API",
     "source": "spec",
@@ -1217,7 +1287,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/import-maps/",
-      "repository": "https://github.com/WICG/import-maps"
+      "repository": "https://github.com/WICG/import-maps",
+      "filename": "index.html"
     },
     "title": "Import Maps",
     "source": "spec",
@@ -1233,7 +1304,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/input-device-capabilities/",
-      "repository": "https://github.com/WICG/input-device-capabilities"
+      "repository": "https://github.com/WICG/input-device-capabilities",
+      "filename": "index.html"
     },
     "title": "Input Device Capabilities",
     "source": "specref",
@@ -1249,7 +1321,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/intervention-reporting/",
-      "repository": "https://github.com/WICG/intervention-reporting"
+      "repository": "https://github.com/WICG/intervention-reporting",
+      "filename": "index.html"
     },
     "title": "Intervention Reporting",
     "source": "spec",
@@ -1265,7 +1338,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/is-input-pending/",
-      "repository": "https://github.com/WICG/is-input-pending"
+      "repository": "https://github.com/WICG/is-input-pending",
+      "filename": "index.html"
     },
     "title": "isInputPending",
     "source": "spec",
@@ -1281,7 +1355,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/js-self-profiling/",
-      "repository": "https://github.com/WICG/js-self-profiling"
+      "repository": "https://github.com/WICG/js-self-profiling",
+      "filename": "index.html"
     },
     "title": "JS Self-Profiling API",
     "source": "specref",
@@ -1297,7 +1372,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/keyboard-lock/",
-      "repository": "https://github.com/WICG/keyboard-lock"
+      "repository": "https://github.com/WICG/keyboard-lock",
+      "filename": "index.html"
     },
     "title": "Keyboard Lock",
     "source": "specref",
@@ -1313,7 +1389,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/keyboard-map/",
-      "repository": "https://github.com/WICG/keyboard-map"
+      "repository": "https://github.com/WICG/keyboard-map",
+      "filename": "index.html"
     },
     "title": "Keyboard Map",
     "source": "specref",
@@ -1329,7 +1406,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/largest-contentful-paint/",
-      "repository": "https://github.com/WICG/largest-contentful-paint"
+      "repository": "https://github.com/WICG/largest-contentful-paint",
+      "filename": "index.html"
     },
     "title": "Largest Contentful Paint",
     "source": "specref",
@@ -1345,7 +1423,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/layout-instability/",
-      "repository": "https://github.com/WICG/layout-instability"
+      "repository": "https://github.com/WICG/layout-instability",
+      "filename": "index.html"
     },
     "title": "Layout Instability",
     "source": "specref",
@@ -1361,7 +1440,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/local-font-access/",
-      "repository": "https://github.com/WICG/local-font-access"
+      "repository": "https://github.com/WICG/local-font-access",
+      "filename": "index.html"
     },
     "title": "Local Font Access API",
     "source": "spec",
@@ -1377,7 +1457,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/media-feeds/",
-      "repository": "https://github.com/WICG/media-feeds"
+      "repository": "https://github.com/WICG/media-feeds",
+      "filename": "index.html"
     },
     "title": "Media Feeds",
     "source": "spec",
@@ -1393,7 +1474,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/native-file-system/",
-      "repository": "https://github.com/WICG/native-file-system"
+      "repository": "https://github.com/WICG/native-file-system",
+      "filename": "index.html"
     },
     "title": "Native File System",
     "source": "specref",
@@ -1409,7 +1491,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/netinfo/",
-      "repository": "https://github.com/WICG/netinfo"
+      "repository": "https://github.com/WICG/netinfo",
+      "filename": "index.html"
     },
     "title": "Network Information API",
     "source": "specref",
@@ -1425,7 +1508,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/origin-policy/",
-      "repository": "https://github.com/WICG/origin-policy"
+      "repository": "https://github.com/WICG/origin-policy",
+      "filename": "index.html"
     },
     "title": "Origin Policy",
     "source": "specref",
@@ -1441,7 +1525,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/overscroll-scrollend-events/",
-      "repository": "https://github.com/WICG/overscroll-scrollend-events"
+      "repository": "https://github.com/WICG/overscroll-scrollend-events",
+      "filename": "index.html"
     },
     "title": "overscroll and scrollend events",
     "source": "spec",
@@ -1457,7 +1542,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/page-lifecycle/",
-      "repository": "https://github.com/WICG/page-lifecycle"
+      "repository": "https://github.com/WICG/page-lifecycle",
+      "filename": "index.html"
     },
     "title": "Page Lifecycle",
     "source": "specref",
@@ -1473,7 +1559,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/periodic-background-sync/",
-      "repository": "https://github.com/WICG/periodic-background-sync"
+      "repository": "https://github.com/WICG/periodic-background-sync",
+      "filename": "index.html"
     },
     "title": "Web Periodic Background Synchronization",
     "source": "specref",
@@ -1489,7 +1576,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/permissions-request/",
-      "repository": "https://github.com/WICG/permissions-request"
+      "repository": "https://github.com/WICG/permissions-request",
+      "filename": "index.html"
     },
     "title": "Requesting Permissions",
     "source": "specref",
@@ -1505,7 +1593,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/permissions-revoke/",
-      "repository": "https://github.com/WICG/permissions-revoke"
+      "repository": "https://github.com/WICG/permissions-revoke",
+      "filename": "index.html"
     },
     "title": "Relinquishing Permissions",
     "source": "specref",
@@ -1521,7 +1610,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/portals/",
-      "repository": "https://github.com/WICG/portals"
+      "repository": "https://github.com/WICG/portals",
+      "filename": "index.html"
     },
     "title": "Portals",
     "source": "spec",
@@ -1537,7 +1627,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/priority-hints/",
-      "repository": "https://github.com/WICG/priority-hints"
+      "repository": "https://github.com/WICG/priority-hints",
+      "filename": "index.html"
     },
     "title": "Priority Hints",
     "source": "specref",
@@ -1553,7 +1644,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/savedata/",
-      "repository": "https://github.com/WICG/savedata"
+      "repository": "https://github.com/WICG/savedata",
+      "filename": "index.html"
     },
     "title": "Save Data API",
     "source": "spec",
@@ -1569,7 +1661,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/scroll-to-text-fragment/",
-      "repository": "https://github.com/WICG/scroll-to-text-fragment"
+      "repository": "https://github.com/WICG/scroll-to-text-fragment",
+      "filename": "index.html"
     },
     "title": "Text Fragments",
     "source": "spec",
@@ -1585,7 +1678,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/serial/",
-      "repository": "https://github.com/WICG/serial"
+      "repository": "https://github.com/WICG/serial",
+      "filename": "index.html"
     },
     "title": "Serial API",
     "source": "spec",
@@ -1601,7 +1695,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/shape-detection-api/",
-      "repository": "https://github.com/WICG/shape-detection-api"
+      "repository": "https://github.com/WICG/shape-detection-api",
+      "filename": "index.html"
     },
     "title": "Accelerated Shape Detection in Images",
     "source": "specref",
@@ -1617,7 +1712,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/shape-detection-api/text.html",
-      "repository": "https://github.com/WICG/shape-detection-api"
+      "repository": "https://github.com/WICG/shape-detection-api",
+      "filename": "text.html"
     },
     "title": "Accelerated Text Detection in Images",
     "source": "specref",
@@ -1634,7 +1730,8 @@
     "shortTitle": "SMS One-Time Codes",
     "nightly": {
       "url": "https://wicg.github.io/sms-one-time-codes/",
-      "repository": "https://github.com/WICG/sms-one-time-codes"
+      "repository": "https://github.com/WICG/sms-one-time-codes",
+      "filename": "index.html"
     },
     "title": "Origin-bound one-time codes delivered via SMS",
     "source": "specref"
@@ -1649,7 +1746,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/speech-api/",
-      "repository": "https://github.com/WICG/speech-api"
+      "repository": "https://github.com/WICG/speech-api",
+      "filename": "index.html"
     },
     "title": "Web Speech API",
     "source": "specref",
@@ -1665,7 +1763,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/ua-client-hints/",
-      "repository": "https://github.com/WICG/ua-client-hints"
+      "repository": "https://github.com/WICG/ua-client-hints",
+      "filename": "index.html"
     },
     "title": "User-Agent Client Hints",
     "source": "spec",
@@ -1681,7 +1780,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/video-rvfc/",
-      "repository": "https://github.com/WICG/video-rvfc"
+      "repository": "https://github.com/WICG/video-rvfc",
+      "filename": "index.html"
     },
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
     "source": "spec",
@@ -1697,7 +1797,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/visual-viewport/",
-      "repository": "https://github.com/WICG/visual-viewport"
+      "repository": "https://github.com/WICG/visual-viewport",
+      "filename": "index.html"
     },
     "title": "Visual Viewport API",
     "source": "specref",
@@ -1713,7 +1814,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/web-locks/",
-      "repository": "https://github.com/WICG/web-locks"
+      "repository": "https://github.com/WICG/web-locks",
+      "filename": "index.html"
     },
     "title": "Web Locks API",
     "source": "specref",
@@ -1729,7 +1831,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/web-otp/",
-      "repository": "https://github.com/WICG/web-otp"
+      "repository": "https://github.com/WICG/web-otp",
+      "filename": "index.html"
     },
     "title": "Web OTP API",
     "source": "spec",
@@ -1745,7 +1848,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/web-transport/",
-      "repository": "https://github.com/WICG/web-transport"
+      "repository": "https://github.com/WICG/web-transport",
+      "filename": "index.html"
     },
     "title": "WebTransport",
     "source": "spec",
@@ -1761,7 +1865,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/webhid/",
-      "repository": "https://github.com/WICG/webhid"
+      "repository": "https://github.com/WICG/webhid",
+      "filename": "index.html"
     },
     "title": "WebHID API",
     "source": "spec",
@@ -1777,7 +1882,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/webpackage/loading.html",
-      "repository": "https://github.com/WICG/webpackage"
+      "repository": "https://github.com/WICG/webpackage",
+      "filename": "loading.html"
     },
     "title": "Loading Signed Exchanges",
     "source": "spec",
@@ -1793,7 +1899,8 @@
     },
     "nightly": {
       "url": "https://wicg.github.io/webusb/",
-      "repository": "https://github.com/WICG/webusb"
+      "repository": "https://github.com/WICG/webusb",
+      "filename": "index.html"
     },
     "title": "WebUSB API",
     "source": "specref",
@@ -1810,7 +1917,8 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
-      "repository": "https://github.com/KhronosGroup/WebGL"
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "filename": "index.html"
     },
     "title": "WebGL Specification",
     "source": "spec",
@@ -1827,7 +1935,8 @@
     "seriesVersion": "2",
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/",
-      "repository": "https://github.com/KhronosGroup/WebGL"
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "filename": "index.html"
     },
     "title": "WebGL 2.0 Specification",
     "source": "spec",
@@ -1842,11 +1951,13 @@
       "currentSpecification": "accelerometer"
     },
     "release": {
-      "url": "https://www.w3.org/TR/accelerometer/"
+      "url": "https://www.w3.org/TR/accelerometer/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/accelerometer/",
-      "repository": "https://github.com/w3c/accelerometer"
+      "repository": "https://github.com/w3c/accelerometer",
+      "filename": "index.html"
     },
     "title": "Accelerometer",
     "source": "w3c",
@@ -1862,11 +1973,13 @@
     },
     "seriesVersion": "1.2",
     "release": {
-      "url": "https://www.w3.org/TR/accname-1.2/"
+      "url": "https://www.w3.org/TR/accname-1.2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/accname/",
-      "repository": "https://github.com/w3c/accname"
+      "repository": "https://github.com/w3c/accname",
+      "filename": "index.html"
     },
     "title": "Accessible Name and Description Computation 1.2",
     "source": "w3c",
@@ -1881,11 +1994,13 @@
       "currentSpecification": "ambient-light"
     },
     "release": {
-      "url": "https://www.w3.org/TR/ambient-light/"
+      "url": "https://www.w3.org/TR/ambient-light/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/ambient-light/",
-      "repository": "https://github.com/w3c/ambient-light"
+      "repository": "https://github.com/w3c/ambient-light",
+      "filename": "index.html"
     },
     "title": "Ambient Light Sensor",
     "source": "w3c",
@@ -1900,11 +2015,13 @@
       "currentSpecification": "appmanifest"
     },
     "release": {
-      "url": "https://www.w3.org/TR/appmanifest/"
+      "url": "https://www.w3.org/TR/appmanifest/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/manifest/",
-      "repository": "https://github.com/w3c/manifest"
+      "repository": "https://github.com/w3c/manifest",
+      "filename": "index.html"
     },
     "title": "Web App Manifest",
     "source": "w3c",
@@ -1919,11 +2036,13 @@
       "currentSpecification": "audio-output"
     },
     "release": {
-      "url": "https://www.w3.org/TR/audio-output/"
+      "url": "https://www.w3.org/TR/audio-output/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-output/",
-      "repository": "https://github.com/w3c/mediacapture-output"
+      "repository": "https://github.com/w3c/mediacapture-output",
+      "filename": "index.html"
     },
     "title": "Audio Output Devices API",
     "source": "w3c",
@@ -1938,11 +2057,13 @@
       "currentSpecification": "battery-status"
     },
     "release": {
-      "url": "https://www.w3.org/TR/battery-status/"
+      "url": "https://www.w3.org/TR/battery-status/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/battery/",
-      "repository": "https://github.com/w3c/battery"
+      "repository": "https://github.com/w3c/battery",
+      "filename": "index.html"
     },
     "title": "Battery Status API",
     "source": "w3c",
@@ -1957,11 +2078,13 @@
       "currentSpecification": "beacon"
     },
     "release": {
-      "url": "https://www.w3.org/TR/beacon/"
+      "url": "https://www.w3.org/TR/beacon/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/beacon/",
-      "repository": "https://github.com/w3c/beacon"
+      "repository": "https://github.com/w3c/beacon",
+      "filename": "index.html"
     },
     "title": "Beacon",
     "source": "w3c",
@@ -1976,11 +2099,13 @@
       "currentSpecification": "clear-site-data"
     },
     "release": {
-      "url": "https://www.w3.org/TR/clear-site-data/"
+      "url": "https://www.w3.org/TR/clear-site-data/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-clear-site-data/",
-      "repository": "https://github.com/w3c/webappsec-clear-site-data"
+      "repository": "https://github.com/w3c/webappsec-clear-site-data",
+      "filename": "index.html"
     },
     "title": "Clear Site Data",
     "source": "w3c",
@@ -1995,11 +2120,13 @@
       "currentSpecification": "clipboard-apis"
     },
     "release": {
-      "url": "https://www.w3.org/TR/clipboard-apis/"
+      "url": "https://www.w3.org/TR/clipboard-apis/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/clipboard-apis/",
-      "repository": "https://github.com/w3c/clipboard-apis"
+      "repository": "https://github.com/w3c/clipboard-apis",
+      "filename": "index.html"
     },
     "title": "Clipboard API and events",
     "source": "w3c",
@@ -2017,11 +2144,13 @@
     "shortTitle": "Compositing 1",
     "seriesNext": "compositing-2",
     "release": {
-      "url": "https://www.w3.org/TR/compositing-1/"
+      "url": "https://www.w3.org/TR/compositing-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/compositing-1/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 1",
     "source": "w3c"
@@ -2036,11 +2165,13 @@
     },
     "seriesVersion": "1.2",
     "release": {
-      "url": "https://www.w3.org/TR/core-aam-1.2/"
+      "url": "https://www.w3.org/TR/core-aam-1.2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/core-aam/",
-      "repository": "https://github.com/w3c/core-aam"
+      "repository": "https://github.com/w3c/core-aam",
+      "filename": "index.html"
     },
     "title": "Core Accessibility API Mappings 1.2",
     "source": "w3c",
@@ -2056,11 +2187,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/credential-management-1/"
+      "url": "https://www.w3.org/TR/credential-management-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-credential-management/",
-      "repository": "https://github.com/w3c/webappsec-credential-management"
+      "repository": "https://github.com/w3c/webappsec-credential-management",
+      "filename": "index.html"
     },
     "title": "Credential Management Level 1",
     "source": "w3c",
@@ -2075,11 +2208,13 @@
       "currentSpecification": "csp-embedded-enforcement"
     },
     "release": {
-      "url": "https://www.w3.org/TR/csp-embedded-enforcement/"
+      "url": "https://www.w3.org/TR/csp-embedded-enforcement/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-cspee/",
-      "repository": "https://github.com/w3c/webappsec-cspee"
+      "repository": "https://github.com/w3c/webappsec-cspee",
+      "filename": "index.html"
     },
     "title": "Content Security Policy: Embedded Enforcement",
     "source": "w3c",
@@ -2095,11 +2230,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/CSP3/"
+      "url": "https://www.w3.org/TR/CSP3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-csp/",
-      "repository": "https://github.com/w3c/webappsec-csp"
+      "repository": "https://github.com/w3c/webappsec-csp",
+      "filename": "index.html"
     },
     "title": "Content Security Policy Level 3",
     "source": "w3c",
@@ -2115,11 +2252,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-align-3/"
+      "url": "https://www.w3.org/TR/css-align-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-align/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Box Alignment Module Level 3",
     "source": "w3c",
@@ -2135,11 +2274,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-animation-worklet-1/"
+      "url": "https://www.w3.org/TR/css-animation-worklet-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-animationworklet-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Animation Worklet API",
     "source": "w3c",
@@ -2156,11 +2297,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-animations-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-animations-1/"
+      "url": "https://www.w3.org/TR/css-animations-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-animations/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Animations Level 1",
     "source": "w3c",
@@ -2178,11 +2321,13 @@
     "shortTitle": "CSS Backgrounds 3",
     "seriesNext": "css-backgrounds-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-backgrounds-3/"
+      "url": "https://www.w3.org/TR/css-backgrounds-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-backgrounds/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Backgrounds and Borders Module Level 3",
     "source": "w3c"
@@ -2198,11 +2343,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-box-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-box-3/"
+      "url": "https://www.w3.org/TR/css-box-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-box-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Box Model Module Level 3",
     "source": "w3c",
@@ -2219,11 +2366,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-box-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-box-4/"
+      "url": "https://www.w3.org/TR/css-box-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-box-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Box Model Module Level 4",
     "source": "w3c",
@@ -2240,11 +2389,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-break-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-break-3/"
+      "url": "https://www.w3.org/TR/css-break-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-break/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Fragmentation Module Level 3",
     "source": "w3c",
@@ -2261,11 +2412,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-break-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-break-4/"
+      "url": "https://www.w3.org/TR/css-break-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-break-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Fragmentation Module Level 4",
     "source": "w3c",
@@ -2283,11 +2436,13 @@
     "shortTitle": "CSS Cascading 3",
     "seriesNext": "css-cascade-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-cascade-3/"
+      "url": "https://www.w3.org/TR/css-cascade-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-cascade-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 3",
     "source": "w3c"
@@ -2304,11 +2459,13 @@
     "shortTitle": "CSS Cascading 4",
     "seriesPrevious": "css-cascade-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-cascade-4/"
+      "url": "https://www.w3.org/TR/css-cascade-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-cascade/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 4",
     "source": "w3c"
@@ -2324,11 +2481,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-color-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-color-3/"
+      "url": "https://www.w3.org/TR/css-color-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-color-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Color Module Level 3",
     "source": "w3c",
@@ -2346,11 +2505,13 @@
     "seriesPrevious": "css-color-3",
     "seriesNext": "css-color-5",
     "release": {
-      "url": "https://www.w3.org/TR/css-color-4/"
+      "url": "https://www.w3.org/TR/css-color-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-color/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Color Module Level 4",
     "source": "w3c",
@@ -2367,11 +2528,13 @@
     "seriesVersion": "5",
     "seriesPrevious": "css-color-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-color-5/"
+      "url": "https://www.w3.org/TR/css-color-5/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-color-5/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Color Module Level 5",
     "source": "w3c",
@@ -2387,11 +2550,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-color-adjust-1/"
+      "url": "https://www.w3.org/TR/css-color-adjust-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-color-adjust-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Color Adjust Module Level 1",
     "source": "w3c",
@@ -2409,11 +2574,13 @@
     "shortTitle": "CSS Conditional 4",
     "seriesPrevious": "css3-conditional",
     "release": {
-      "url": "https://www.w3.org/TR/css-conditional-4/"
+      "url": "https://www.w3.org/TR/css-conditional-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-conditional-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 4",
     "source": "w3c"
@@ -2429,11 +2596,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-contain-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-contain-1/"
+      "url": "https://www.w3.org/TR/css-contain-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-contain/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Containment Module Level 1",
     "source": "w3c",
@@ -2450,11 +2619,13 @@
     "seriesVersion": "2",
     "seriesPrevious": "css-contain-1",
     "release": {
-      "url": "https://www.w3.org/TR/css-contain-2/"
+      "url": "https://www.w3.org/TR/css-contain-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-contain-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Containment Module Level 2",
     "source": "w3c",
@@ -2470,11 +2641,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-content-3/"
+      "url": "https://www.w3.org/TR/css-content-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-content-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Generated Content Module Level 3",
     "source": "w3c",
@@ -2490,11 +2663,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-counter-styles-3/"
+      "url": "https://www.w3.org/TR/css-counter-styles-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-counter-styles/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Counter Styles Level 3",
     "source": "w3c",
@@ -2510,11 +2685,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-device-adapt-1/"
+      "url": "https://www.w3.org/TR/css-device-adapt-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-device-adapt/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Device Adaptation Module Level 1",
     "source": "w3c",
@@ -2530,11 +2707,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-display-3/"
+      "url": "https://www.w3.org/TR/css-display-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-display/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Display Module Level 3",
     "source": "w3c",
@@ -2550,11 +2729,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-easing-1/"
+      "url": "https://www.w3.org/TR/css-easing-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-easing/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Easing Functions Level 1",
     "source": "w3c",
@@ -2571,11 +2752,13 @@
     "seriesVersion": "1",
     "shortTitle": "CSS Flexbox 1",
     "release": {
-      "url": "https://www.w3.org/TR/css-flexbox-1/"
+      "url": "https://www.w3.org/TR/css-flexbox-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-flexbox-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Flexible Box Layout Module Level 1",
     "source": "w3c"
@@ -2590,11 +2773,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-font-loading-3/"
+      "url": "https://www.w3.org/TR/css-font-loading-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-font-loading/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Font Loading Module Level 3",
     "source": "w3c",
@@ -2611,11 +2796,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-fonts-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-fonts-3/"
+      "url": "https://www.w3.org/TR/css-fonts-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-fonts/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Fonts Module Level 3",
     "source": "w3c",
@@ -2632,11 +2819,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-fonts-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-fonts-4/"
+      "url": "https://www.w3.org/TR/css-fonts-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-fonts-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Fonts Module Level 4",
     "source": "w3c",
@@ -2654,11 +2843,13 @@
     "shortTitle": "CSS GCPM 3",
     "seriesNext": "css-gcpm-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-gcpm-3/"
+      "url": "https://www.w3.org/TR/css-gcpm-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-gcpm/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module",
     "source": "w3c"
@@ -2674,11 +2865,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-grid-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-grid-1/"
+      "url": "https://www.w3.org/TR/css-grid-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-grid/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Grid Layout Module Level 1",
     "source": "w3c",
@@ -2695,11 +2888,13 @@
     "seriesVersion": "2",
     "seriesPrevious": "css-grid-1",
     "release": {
-      "url": "https://www.w3.org/TR/css-grid-2/"
+      "url": "https://www.w3.org/TR/css-grid-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-grid-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Grid Layout Module Level 2",
     "source": "w3c",
@@ -2717,11 +2912,13 @@
     "shortTitle": "CSS Images 3",
     "seriesNext": "css-images-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-images-3/"
+      "url": "https://www.w3.org/TR/css-images-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-images-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Image Values and Replaced Content Module Level 3",
     "source": "w3c"
@@ -2738,11 +2935,13 @@
     "shortTitle": "CSS Images 4",
     "seriesPrevious": "css-images-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-images-4/"
+      "url": "https://www.w3.org/TR/css-images-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-images-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Image Values and Replaced Content Module Level 4",
     "source": "w3c"
@@ -2757,11 +2956,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-inline-3/"
+      "url": "https://www.w3.org/TR/css-inline-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-inline-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Inline Layout Module Level 3",
     "source": "w3c",
@@ -2777,11 +2978,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-layout-api-1/"
+      "url": "https://www.w3.org/TR/css-layout-api-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-layout-api-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Layout API Level 1",
     "source": "w3c",
@@ -2797,11 +3000,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-line-grid-1/"
+      "url": "https://www.w3.org/TR/css-line-grid-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-line-grid/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Line Grid Module Level 1",
     "source": "w3c",
@@ -2818,11 +3023,13 @@
     "seriesVersion": "3",
     "shortTitle": "CSS Lists 3",
     "release": {
-      "url": "https://www.w3.org/TR/css-lists-3/"
+      "url": "https://www.w3.org/TR/css-lists-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-lists-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Lists and Counters Module Level 3",
     "source": "w3c"
@@ -2838,11 +3045,13 @@
     "seriesVersion": "1",
     "shortTitle": "CSS Logical Properties 1",
     "release": {
-      "url": "https://www.w3.org/TR/css-logical-1/"
+      "url": "https://www.w3.org/TR/css-logical-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-logical-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Logical Properties and Values Level 1",
     "source": "w3c"
@@ -2857,11 +3066,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-masking-1/"
+      "url": "https://www.w3.org/TR/css-masking-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/css-masking-1/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Masking Module Level 1",
     "source": "w3c",
@@ -2879,11 +3090,13 @@
     "shortTitle": "CSS Multicol 1",
     "seriesNext": "css-multicol-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-multicol-1/"
+      "url": "https://www.w3.org/TR/css-multicol-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-multicol/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 1",
     "source": "w3c"
@@ -2898,11 +3111,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-namespaces-3/"
+      "url": "https://www.w3.org/TR/css-namespaces-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-namespaces/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Namespaces Module Level 3",
     "source": "w3c",
@@ -2918,11 +3133,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-nav-1/"
+      "url": "https://www.w3.org/TR/css-nav-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-nav-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Spatial Navigation Level 1",
     "source": "w3c",
@@ -2939,11 +3156,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-overflow-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-overflow-3/"
+      "url": "https://www.w3.org/TR/css-overflow-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-overflow-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Overflow Module Level 3",
     "source": "w3c",
@@ -2960,11 +3179,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-overflow-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-overflow-4/"
+      "url": "https://www.w3.org/TR/css-overflow-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-overflow-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Overflow Module Level 4",
     "source": "w3c",
@@ -2980,11 +3201,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-overscroll-1/"
+      "url": "https://www.w3.org/TR/css-overscroll-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-overscroll-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Overscroll Behavior Module Level 1",
     "source": "w3c",
@@ -3001,11 +3224,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-page-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-page-3/"
+      "url": "https://www.w3.org/TR/css-page-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Paged Media Module Level 3",
     "source": "w3c",
@@ -3021,11 +3246,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-page-floats-3/"
+      "url": "https://www.w3.org/TR/css-page-floats-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-floats/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Page Floats",
     "source": "w3c",
@@ -3041,11 +3268,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-paint-api-1/"
+      "url": "https://www.w3.org/TR/css-paint-api-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-paint-api-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Painting API Level 1",
     "source": "w3c",
@@ -3061,11 +3290,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-position-3/"
+      "url": "https://www.w3.org/TR/css-position-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-position/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Positioned Layout Module Level 3",
     "source": "w3c",
@@ -3081,11 +3312,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-properties-values-api-1/"
+      "url": "https://www.w3.org/TR/css-properties-values-api-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-properties-values-api-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Properties and Values API Level 1",
     "source": "w3c",
@@ -3101,11 +3334,13 @@
     },
     "seriesVersion": "4",
     "release": {
-      "url": "https://www.w3.org/TR/css-pseudo-4/"
+      "url": "https://www.w3.org/TR/css-pseudo-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-pseudo-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Pseudo-Elements Module Level 4",
     "source": "w3c",
@@ -3121,11 +3356,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-regions-1/"
+      "url": "https://www.w3.org/TR/css-regions-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-regions/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Regions Module Level 1",
     "source": "w3c",
@@ -3141,11 +3378,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-rhythm-1/"
+      "url": "https://www.w3.org/TR/css-rhythm-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-rhythm/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Rhythmic Sizing",
     "source": "w3c",
@@ -3161,11 +3400,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-round-display-1/"
+      "url": "https://www.w3.org/TR/css-round-display-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-round-display/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Round Display Level 1",
     "source": "w3c",
@@ -3181,11 +3422,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-ruby-1/"
+      "url": "https://www.w3.org/TR/css-ruby-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-ruby-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Ruby Layout Module Level 1",
     "source": "w3c",
@@ -3201,11 +3444,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-scoping-1/"
+      "url": "https://www.w3.org/TR/css-scoping-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-scoping/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Scoping Module Level 1",
     "source": "w3c",
@@ -3221,11 +3466,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-scroll-anchoring-1/"
+      "url": "https://www.w3.org/TR/css-scroll-anchoring-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-scroll-anchoring/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Scroll Anchoring Module Level 1",
     "source": "w3c",
@@ -3241,11 +3488,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-scroll-snap-1/"
+      "url": "https://www.w3.org/TR/css-scroll-snap-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-scroll-snap-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Scroll Snap Module Level 1",
     "source": "w3c",
@@ -3261,11 +3510,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-scrollbars-1/"
+      "url": "https://www.w3.org/TR/css-scrollbars-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-scrollbars/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Scrollbars Module Level 1",
     "source": "w3c",
@@ -3281,11 +3532,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-shadow-parts-1/"
+      "url": "https://www.w3.org/TR/css-shadow-parts-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-shadow-parts/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Shadow Parts",
     "source": "w3c",
@@ -3302,11 +3555,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-shapes-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-shapes-1/"
+      "url": "https://www.w3.org/TR/css-shapes-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-shapes/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Shapes Module Level 1",
     "source": "w3c",
@@ -3324,11 +3579,13 @@
     "shortTitle": "CSS Sizing 3",
     "seriesNext": "css-sizing-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-sizing-3/"
+      "url": "https://www.w3.org/TR/css-sizing-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-sizing-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Intrinsic & Extrinsic Sizing Module Level 3",
     "source": "w3c"
@@ -3345,11 +3602,13 @@
     "shortTitle": "CSS Sizing 4",
     "seriesPrevious": "css-sizing-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-sizing-4/"
+      "url": "https://www.w3.org/TR/css-sizing-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-sizing-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Box Sizing Module Level 4",
     "source": "w3c"
@@ -3364,11 +3623,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-speech-1/"
+      "url": "https://www.w3.org/TR/css-speech-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-speech-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Speech Module",
     "source": "w3c",
@@ -3383,11 +3644,13 @@
       "currentSpecification": "css-style-attr"
     },
     "release": {
-      "url": "https://www.w3.org/TR/css-style-attr/"
+      "url": "https://www.w3.org/TR/css-style-attr/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-style-attr/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Style Attributes",
     "source": "w3c",
@@ -3403,11 +3666,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-syntax-3/"
+      "url": "https://www.w3.org/TR/css-syntax-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-syntax/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Syntax Module Level 3",
     "source": "w3c",
@@ -3423,11 +3688,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css-tables-3/"
+      "url": "https://www.w3.org/TR/css-tables-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-tables-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Table Module Level 3",
     "source": "w3c",
@@ -3444,11 +3711,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-text-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-text-3/"
+      "url": "https://www.w3.org/TR/css-text-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Text Module Level 3",
     "source": "w3c",
@@ -3465,11 +3734,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-text-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-text-4/"
+      "url": "https://www.w3.org/TR/css-text-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Text Module Level 4",
     "source": "w3c",
@@ -3486,11 +3757,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-text-decor-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-text-decor-3/"
+      "url": "https://www.w3.org/TR/css-text-decor-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-decor-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Text Decoration Module Level 3",
     "source": "w3c",
@@ -3507,11 +3780,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-text-decor-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-text-decor-4/"
+      "url": "https://www.w3.org/TR/css-text-decor-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-decor-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Text Decoration Module Level 4",
     "source": "w3c",
@@ -3528,11 +3803,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-transforms-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-transforms-1/"
+      "url": "https://www.w3.org/TR/css-transforms-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-transforms/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Transforms Module Level 1",
     "source": "w3c",
@@ -3549,11 +3826,13 @@
     "seriesVersion": "2",
     "seriesPrevious": "css-transforms-1",
     "release": {
-      "url": "https://www.w3.org/TR/css-transforms-2/"
+      "url": "https://www.w3.org/TR/css-transforms-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-transforms-2/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Transforms Module Level 2",
     "source": "w3c",
@@ -3570,11 +3849,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-transitions-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-transitions-1/"
+      "url": "https://www.w3.org/TR/css-transitions-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-transitions/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Transitions",
     "source": "w3c",
@@ -3591,11 +3872,13 @@
     "seriesVersion": "1",
     "seriesNext": "css-typed-om-2",
     "release": {
-      "url": "https://www.w3.org/TR/css-typed-om-1/"
+      "url": "https://www.w3.org/TR/css-typed-om-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-typed-om-1/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Typed OM Level 1",
     "source": "w3c",
@@ -3613,11 +3896,13 @@
     "shortTitle": "CSS User Interface 3",
     "seriesNext": "css-ui-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-ui-3/"
+      "url": "https://www.w3.org/TR/css-ui-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-ui/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Basic User Interface Module Level 3 (CSS3 UI)",
     "source": "w3c"
@@ -3634,11 +3919,13 @@
     "shortTitle": "CSS User Interface 4",
     "seriesPrevious": "css-ui-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-ui-4/"
+      "url": "https://www.w3.org/TR/css-ui-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-ui-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Basic User Interface Module Level 4",
     "source": "w3c"
@@ -3655,11 +3942,13 @@
     "shortTitle": "CSS Values 3",
     "seriesNext": "css-values-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-values-3/"
+      "url": "https://www.w3.org/TR/css-values-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-values-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 3",
     "source": "w3c"
@@ -3676,11 +3965,13 @@
     "shortTitle": "CSS Values 4",
     "seriesPrevious": "css-values-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-values-4/"
+      "url": "https://www.w3.org/TR/css-values-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-values-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 4",
     "source": "w3c"
@@ -3696,11 +3987,13 @@
     "seriesVersion": "1",
     "shortTitle": "CSS Variables 1",
     "release": {
-      "url": "https://www.w3.org/TR/css-variables-1/"
+      "url": "https://www.w3.org/TR/css-variables-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-variables/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Custom Properties for Cascading Variables Module Level 1",
     "source": "w3c"
@@ -3715,11 +4008,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/css-will-change-1/"
+      "url": "https://www.w3.org/TR/css-will-change-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-will-change/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Will Change Module Level 1",
     "source": "w3c",
@@ -3736,11 +4031,13 @@
     "seriesVersion": "3",
     "seriesNext": "css-writing-modes-4",
     "release": {
-      "url": "https://www.w3.org/TR/css-writing-modes-3/"
+      "url": "https://www.w3.org/TR/css-writing-modes-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-writing-modes-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Writing Modes Level 3",
     "source": "w3c",
@@ -3757,11 +4054,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "css-writing-modes-3",
     "release": {
-      "url": "https://www.w3.org/TR/css-writing-modes-4/"
+      "url": "https://www.w3.org/TR/css-writing-modes-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-writing-modes-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Writing Modes Level 4",
     "source": "w3c",
@@ -3806,7 +4105,8 @@
         "https://www.w3.org/TR/CSS2/propidx.html",
         "https://www.w3.org/TR/CSS2/grammar.html",
         "https://www.w3.org/TR/CSS2/indexlist.html"
-      ]
+      ],
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css2/",
@@ -3838,7 +4138,8 @@
         "https://drafts.csswg.org/css2/propidx.html",
         "https://drafts.csswg.org/css2/grammar.html",
         "https://drafts.csswg.org/css2/indexlist.html"
-      ]
+      ],
+      "filename": "cover.html"
     },
     "title": "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification",
     "source": "w3c",
@@ -3883,7 +4184,8 @@
         "https://www.w3.org/TR/CSS22/propidx.html",
         "https://www.w3.org/TR/CSS22/grammar.html",
         "https://www.w3.org/TR/CSS22/indexlist.html"
-      ]
+      ],
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css2/",
@@ -3915,7 +4217,8 @@
         "https://drafts.csswg.org/css2/propidx.html",
         "https://drafts.csswg.org/css2/grammar.html",
         "https://drafts.csswg.org/css2/indexlist.html"
-      ]
+      ],
+      "filename": "cover.html"
     },
     "title": "Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification",
     "source": "w3c",
@@ -3933,11 +4236,13 @@
     "shortTitle": "CSS Conditional 3",
     "seriesNext": "css-conditional-4",
     "release": {
-      "url": "https://www.w3.org/TR/css3-conditional/"
+      "url": "https://www.w3.org/TR/css3-conditional/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-conditional-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 3",
     "source": "w3c"
@@ -3952,11 +4257,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/css3-exclusions/"
+      "url": "https://www.w3.org/TR/css3-exclusions/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/css-exclusions/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Exclusions Module Level 1",
     "source": "w3c",
@@ -3973,11 +4280,13 @@
     "seriesVersion": "3",
     "seriesNext": "mediaqueries-4",
     "release": {
-      "url": "https://www.w3.org/TR/css3-mediaqueries/"
+      "url": "https://www.w3.org/TR/css3-mediaqueries/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/mediaqueries-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Media Queries",
     "source": "w3c",
@@ -3993,11 +4302,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/cssom-1/"
+      "url": "https://www.w3.org/TR/cssom-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/cssom/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Object Model (CSSOM)",
     "source": "w3c",
@@ -4013,11 +4324,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/cssom-view-1/"
+      "url": "https://www.w3.org/TR/cssom-view-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/cssom-view/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSSOM View Module",
     "source": "w3c",
@@ -4033,11 +4346,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/device-memory-1/"
+      "url": "https://www.w3.org/TR/device-memory-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/device-memory/",
-      "repository": "https://github.com/w3c/device-memory"
+      "repository": "https://github.com/w3c/device-memory",
+      "filename": "index.html"
     },
     "title": "Device Memory",
     "source": "w3c",
@@ -4052,11 +4367,13 @@
       "currentSpecification": "DOM-Parsing"
     },
     "release": {
-      "url": "https://www.w3.org/TR/DOM-Parsing/"
+      "url": "https://www.w3.org/TR/DOM-Parsing/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/DOM-Parsing/",
-      "repository": "https://github.com/w3c/DOM-Parsing"
+      "repository": "https://github.com/w3c/DOM-Parsing",
+      "filename": "index.html"
     },
     "title": "DOM Parsing and Serialization",
     "source": "w3c",
@@ -4071,11 +4388,13 @@
       "currentSpecification": "encoding"
     },
     "release": {
-      "url": "https://www.w3.org/TR/encoding/"
+      "url": "https://www.w3.org/TR/encoding/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://encoding.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/encoding"
+      "repository": "https://github.com/whatwg/encoding",
+      "filename": "index.html"
     },
     "title": "Encoding",
     "source": "w3c",
@@ -4090,11 +4409,13 @@
       "currentSpecification": "encrypted-media"
     },
     "release": {
-      "url": "https://www.w3.org/TR/encrypted-media/"
+      "url": "https://www.w3.org/TR/encrypted-media/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/encrypted-media/",
-      "repository": "https://github.com/w3c/encrypted-media"
+      "repository": "https://github.com/w3c/encrypted-media",
+      "filename": "index.html"
     },
     "title": "Encrypted Media Extensions",
     "source": "w3c",
@@ -4110,11 +4431,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/feature-policy-1/"
+      "url": "https://www.w3.org/TR/feature-policy-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-feature-policy/",
-      "repository": "https://github.com/w3c/webappsec-feature-policy"
+      "repository": "https://github.com/w3c/webappsec-feature-policy",
+      "filename": "index.html"
     },
     "title": "Feature Policy",
     "source": "w3c",
@@ -4130,11 +4453,13 @@
     },
     "shortTitle": "Fetch Metadata",
     "release": {
-      "url": "https://www.w3.org/TR/fetch-metadata/"
+      "url": "https://www.w3.org/TR/fetch-metadata/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-fetch-metadata/",
-      "repository": "https://github.com/w3c/webappsec-fetch-metadata"
+      "repository": "https://github.com/w3c/webappsec-fetch-metadata",
+      "filename": "index.html"
     },
     "title": "Fetch Metadata Request Headers",
     "source": "w3c"
@@ -4148,11 +4473,13 @@
       "currentSpecification": "FileAPI"
     },
     "release": {
-      "url": "https://www.w3.org/TR/FileAPI/"
+      "url": "https://www.w3.org/TR/FileAPI/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/FileAPI/",
-      "repository": "https://github.com/w3c/FileAPI"
+      "repository": "https://github.com/w3c/FileAPI",
+      "filename": "index.html"
     },
     "title": "File API",
     "source": "w3c",
@@ -4168,11 +4495,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/fill-stroke-3/"
+      "url": "https://www.w3.org/TR/fill-stroke-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/fill-stroke/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "CSS Fill and Stroke Module Level 3",
     "source": "w3c",
@@ -4189,11 +4518,13 @@
     "seriesVersion": "1",
     "seriesNext": "filter-effects-2",
     "release": {
-      "url": "https://www.w3.org/TR/filter-effects-1/"
+      "url": "https://www.w3.org/TR/filter-effects-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/filter-effects-1/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Filter Effects Module Level 1",
     "source": "w3c",
@@ -4208,11 +4539,13 @@
       "currentSpecification": "gamepad"
     },
     "release": {
-      "url": "https://www.w3.org/TR/gamepad/"
+      "url": "https://www.w3.org/TR/gamepad/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/gamepad/",
-      "repository": "https://github.com/w3c/gamepad"
+      "repository": "https://github.com/w3c/gamepad",
+      "filename": "index.html"
     },
     "title": "Gamepad",
     "source": "w3c",
@@ -4227,11 +4560,13 @@
       "currentSpecification": "generic-sensor"
     },
     "release": {
-      "url": "https://www.w3.org/TR/generic-sensor/"
+      "url": "https://www.w3.org/TR/generic-sensor/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/sensors/",
-      "repository": "https://github.com/w3c/sensors"
+      "repository": "https://github.com/w3c/sensors",
+      "filename": "index.html"
     },
     "title": "Generic Sensor API",
     "source": "w3c",
@@ -4246,11 +4581,13 @@
       "currentSpecification": "geolocation-API"
     },
     "release": {
-      "url": "https://www.w3.org/TR/geolocation-API/"
+      "url": "https://www.w3.org/TR/geolocation-API/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/geolocation-api/",
-      "repository": "https://github.com/w3c/geolocation-api"
+      "repository": "https://github.com/w3c/geolocation-api",
+      "filename": "index.html"
     },
     "title": "Geolocation API Specification 2nd Edition",
     "source": "w3c",
@@ -4265,11 +4602,13 @@
       "currentSpecification": "geolocation-sensor"
     },
     "release": {
-      "url": "https://www.w3.org/TR/geolocation-sensor/"
+      "url": "https://www.w3.org/TR/geolocation-sensor/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/geolocation-sensor/",
-      "repository": "https://github.com/w3c/geolocation-sensor"
+      "repository": "https://github.com/w3c/geolocation-sensor",
+      "filename": "index.html"
     },
     "title": "Geolocation Sensor",
     "source": "w3c",
@@ -4285,11 +4624,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/geometry-1/"
+      "url": "https://www.w3.org/TR/geometry-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/geometry/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Geometry Interfaces Module Level 1",
     "source": "w3c",
@@ -4305,11 +4646,13 @@
     },
     "seriesVersion": "1.0",
     "release": {
-      "url": "https://www.w3.org/TR/graphics-aam-1.0/"
+      "url": "https://www.w3.org/TR/graphics-aam-1.0/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/graphics-aam/",
-      "repository": "https://github.com/w3c/graphics-aam"
+      "repository": "https://github.com/w3c/graphics-aam",
+      "filename": "index.html"
     },
     "title": "Graphics Accessibility API Mappings",
     "source": "w3c",
@@ -4325,11 +4668,13 @@
     },
     "seriesVersion": "1.0",
     "release": {
-      "url": "https://www.w3.org/TR/graphics-aria-1.0/"
+      "url": "https://www.w3.org/TR/graphics-aria-1.0/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/graphics-aria/",
-      "repository": "https://github.com/w3c/graphics-aria"
+      "repository": "https://github.com/w3c/graphics-aria",
+      "filename": "index.html"
     },
     "title": "WAI-ARIA Graphics Module",
     "source": "w3c",
@@ -4344,11 +4689,13 @@
       "currentSpecification": "gyroscope"
     },
     "release": {
-      "url": "https://www.w3.org/TR/gyroscope/"
+      "url": "https://www.w3.org/TR/gyroscope/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/gyroscope/",
-      "repository": "https://github.com/w3c/gyroscope"
+      "repository": "https://github.com/w3c/gyroscope",
+      "filename": "index.html"
     },
     "title": "Gyroscope",
     "source": "w3c",
@@ -4364,11 +4711,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/hr-time-3/"
+      "url": "https://www.w3.org/TR/hr-time-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/hr-time/",
-      "repository": "https://github.com/w3c/hr-time"
+      "repository": "https://github.com/w3c/hr-time",
+      "filename": "index.html"
     },
     "title": "High Resolution Time Level 3",
     "source": "w3c",
@@ -4384,11 +4733,13 @@
     },
     "seriesVersion": "1.0",
     "release": {
-      "url": "https://www.w3.org/TR/html-aam-1.0/"
+      "url": "https://www.w3.org/TR/html-aam-1.0/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/html-aam/",
-      "repository": "https://github.com/w3c/html-aam"
+      "repository": "https://github.com/w3c/html-aam",
+      "filename": "index.html"
     },
     "title": "HTML Accessibility API Mappings 1.0",
     "source": "w3c",
@@ -4403,11 +4754,13 @@
       "currentSpecification": "html-aria"
     },
     "release": {
-      "url": "https://www.w3.org/TR/html-aria/"
+      "url": "https://www.w3.org/TR/html-aria/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/html-aria/",
-      "repository": "https://github.com/w3c/html-aria"
+      "repository": "https://github.com/w3c/html-aria",
+      "filename": "index.html"
     },
     "title": "ARIA in HTML",
     "source": "w3c",
@@ -4422,11 +4775,13 @@
       "currentSpecification": "html-media-capture"
     },
     "release": {
-      "url": "https://www.w3.org/TR/html-media-capture/"
+      "url": "https://www.w3.org/TR/html-media-capture/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/html-media-capture/",
-      "repository": "https://github.com/w3c/html-media-capture"
+      "repository": "https://github.com/w3c/html-media-capture",
+      "filename": "index.html"
     },
     "title": "HTML Media Capture",
     "source": "w3c",
@@ -4441,11 +4796,13 @@
       "currentSpecification": "image-capture"
     },
     "release": {
-      "url": "https://www.w3.org/TR/image-capture/"
+      "url": "https://www.w3.org/TR/image-capture/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-image/",
-      "repository": "https://github.com/w3c/mediacapture-image"
+      "repository": "https://github.com/w3c/mediacapture-image",
+      "filename": "index.html"
     },
     "title": "\"MediaStream Image Capture\"",
     "source": "w3c",
@@ -4460,11 +4817,13 @@
       "currentSpecification": "image-resource"
     },
     "release": {
-      "url": "https://www.w3.org/TR/image-resource/"
+      "url": "https://www.w3.org/TR/image-resource/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/image-resource/",
-      "repository": "https://github.com/w3c/image-resource"
+      "repository": "https://github.com/w3c/image-resource",
+      "filename": "index.html"
     },
     "title": "Image Resource",
     "source": "w3c",
@@ -4481,11 +4840,13 @@
     "seriesVersion": "2",
     "shortTitle": "Indexed DB 2.0",
     "release": {
-      "url": "https://www.w3.org/TR/IndexedDB-2/"
+      "url": "https://www.w3.org/TR/IndexedDB-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/IndexedDB/",
-      "repository": "https://github.com/w3c/IndexedDB"
+      "repository": "https://github.com/w3c/IndexedDB",
+      "filename": "index.html"
     },
     "title": "Indexed Database API 2.0",
     "source": "w3c"
@@ -4500,11 +4861,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/input-events-2/"
+      "url": "https://www.w3.org/TR/input-events-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/input-events/",
-      "repository": "https://github.com/w3c/input-events"
+      "repository": "https://github.com/w3c/input-events",
+      "filename": "index.html"
     },
     "title": "Input Events Level 2",
     "source": "w3c",
@@ -4519,11 +4882,13 @@
       "currentSpecification": "intersection-observer"
     },
     "release": {
-      "url": "https://www.w3.org/TR/intersection-observer/"
+      "url": "https://www.w3.org/TR/intersection-observer/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/IntersectionObserver/",
-      "repository": "https://github.com/w3c/IntersectionObserver"
+      "repository": "https://github.com/w3c/IntersectionObserver",
+      "filename": "index.html"
     },
     "title": "Intersection Observer",
     "source": "w3c",
@@ -4539,11 +4904,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/longtasks-1/"
+      "url": "https://www.w3.org/TR/longtasks-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/longtasks/",
-      "repository": "https://github.com/w3c/longtasks"
+      "repository": "https://github.com/w3c/longtasks",
+      "filename": "index.html"
     },
     "title": "Long Tasks API 1",
     "source": "w3c",
@@ -4558,11 +4925,13 @@
       "currentSpecification": "magnetometer"
     },
     "release": {
-      "url": "https://www.w3.org/TR/magnetometer/"
+      "url": "https://www.w3.org/TR/magnetometer/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/magnetometer/",
-      "repository": "https://github.com/w3c/magnetometer"
+      "repository": "https://github.com/w3c/magnetometer",
+      "filename": "index.html"
     },
     "title": "Magnetometer",
     "source": "w3c",
@@ -4577,11 +4946,13 @@
       "currentSpecification": "media-capabilities"
     },
     "release": {
-      "url": "https://www.w3.org/TR/media-capabilities/"
+      "url": "https://www.w3.org/TR/media-capabilities/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/media-capabilities/",
-      "repository": "https://github.com/w3c/media-capabilities"
+      "repository": "https://github.com/w3c/media-capabilities",
+      "filename": "index.html"
     },
     "title": "Media Capabilities",
     "source": "w3c",
@@ -4596,11 +4967,13 @@
       "currentSpecification": "media-source"
     },
     "release": {
-      "url": "https://www.w3.org/TR/media-source/"
+      "url": "https://www.w3.org/TR/media-source/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/media-source/",
-      "repository": "https://github.com/w3c/media-source"
+      "repository": "https://github.com/w3c/media-source",
+      "filename": "index.html"
     },
     "title": "Media Source Extensions™",
     "source": "w3c",
@@ -4615,11 +4988,13 @@
       "currentSpecification": "mediacapture-depth"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mediacapture-depth/"
+      "url": "https://www.w3.org/TR/mediacapture-depth/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-depth/",
-      "repository": "https://github.com/w3c/mediacapture-depth"
+      "repository": "https://github.com/w3c/mediacapture-depth",
+      "filename": "index.html"
     },
     "title": "Media Capture Depth Stream Extensions",
     "source": "w3c",
@@ -4634,11 +5009,13 @@
       "currentSpecification": "mediacapture-fromelement"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mediacapture-fromelement/"
+      "url": "https://www.w3.org/TR/mediacapture-fromelement/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-fromelement/",
-      "repository": "https://github.com/w3c/mediacapture-fromelement"
+      "repository": "https://github.com/w3c/mediacapture-fromelement",
+      "filename": "index.html"
     },
     "title": "Media Capture from DOM Elements",
     "source": "w3c",
@@ -4653,11 +5030,13 @@
       "currentSpecification": "mediacapture-streams"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mediacapture-streams/"
+      "url": "https://www.w3.org/TR/mediacapture-streams/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-main/",
-      "repository": "https://github.com/w3c/mediacapture-main"
+      "repository": "https://github.com/w3c/mediacapture-main",
+      "filename": "index.html"
     },
     "title": "Media Capture and Streams",
     "source": "w3c",
@@ -4675,11 +5054,13 @@
     "seriesPrevious": "css3-mediaqueries",
     "seriesNext": "mediaqueries-5",
     "release": {
-      "url": "https://www.w3.org/TR/mediaqueries-4/"
+      "url": "https://www.w3.org/TR/mediaqueries-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/mediaqueries-4/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Media Queries Level 4",
     "source": "w3c",
@@ -4696,11 +5077,13 @@
     "seriesVersion": "5",
     "seriesPrevious": "mediaqueries-4",
     "release": {
-      "url": "https://www.w3.org/TR/mediaqueries-5/"
+      "url": "https://www.w3.org/TR/mediaqueries-5/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/mediaqueries-5/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Media Queries Level 5",
     "source": "w3c",
@@ -4715,11 +5098,13 @@
       "currentSpecification": "mediasession"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mediasession/"
+      "url": "https://www.w3.org/TR/mediasession/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediasession/",
-      "repository": "https://github.com/w3c/mediasession"
+      "repository": "https://github.com/w3c/mediasession",
+      "filename": "index.html"
     },
     "title": "Media Session Standard",
     "source": "w3c",
@@ -4734,11 +5119,13 @@
       "currentSpecification": "mediastream-recording"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mediastream-recording/"
+      "url": "https://www.w3.org/TR/mediastream-recording/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-record/",
-      "repository": "https://github.com/w3c/mediacapture-record"
+      "repository": "https://github.com/w3c/mediacapture-record",
+      "filename": "index.html"
     },
     "title": "MediaStream Recording",
     "source": "w3c",
@@ -4753,11 +5140,13 @@
       "currentSpecification": "mixed-content"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mixed-content/"
+      "url": "https://www.w3.org/TR/mixed-content/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-mixed-content/",
-      "repository": "https://github.com/w3c/webappsec-mixed-content"
+      "repository": "https://github.com/w3c/webappsec-mixed-content",
+      "filename": "index.html"
     },
     "title": "Mixed Content",
     "source": "w3c",
@@ -4773,11 +5162,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/motion-1/"
+      "url": "https://www.w3.org/TR/motion-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.fxtf.org/motion-1/",
-      "repository": "https://github.com/w3c/fxtf-drafts"
+      "repository": "https://github.com/w3c/fxtf-drafts",
+      "filename": "Overview.html"
     },
     "title": "Motion Path Module Level 1",
     "source": "w3c",
@@ -4792,11 +5183,13 @@
       "currentSpecification": "mst-content-hint"
     },
     "release": {
-      "url": "https://www.w3.org/TR/mst-content-hint/"
+      "url": "https://www.w3.org/TR/mst-content-hint/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mst-content-hint/",
-      "repository": "https://github.com/w3c/mst-content-hint"
+      "repository": "https://github.com/w3c/mst-content-hint",
+      "filename": "index.html"
     },
     "title": "MediaStreamTrack Content Hints",
     "source": "w3c",
@@ -4812,11 +5205,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/navigation-timing-2/"
+      "url": "https://www.w3.org/TR/navigation-timing-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/navigation-timing/",
-      "repository": "https://github.com/w3c/navigation-timing"
+      "repository": "https://github.com/w3c/navigation-timing",
+      "filename": "index.html"
     },
     "title": "Navigation Timing Level 2",
     "source": "w3c",
@@ -4832,11 +5227,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/network-error-logging-1/"
+      "url": "https://www.w3.org/TR/network-error-logging-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/network-error-logging/",
-      "repository": "https://github.com/w3c/network-error-logging"
+      "repository": "https://github.com/w3c/network-error-logging",
+      "filename": "index.html"
     },
     "title": "Network Error Logging",
     "source": "w3c",
@@ -4851,11 +5248,13 @@
       "currentSpecification": "orientation-event"
     },
     "release": {
-      "url": "https://www.w3.org/TR/orientation-event/"
+      "url": "https://www.w3.org/TR/orientation-event/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/deviceorientation/",
-      "repository": "https://github.com/w3c/deviceorientation"
+      "repository": "https://github.com/w3c/deviceorientation",
+      "filename": "index.html"
     },
     "title": "DeviceOrientation Event Specification",
     "source": "w3c",
@@ -4870,11 +5269,13 @@
       "currentSpecification": "orientation-sensor"
     },
     "release": {
-      "url": "https://www.w3.org/TR/orientation-sensor/"
+      "url": "https://www.w3.org/TR/orientation-sensor/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/orientation-sensor/",
-      "repository": "https://github.com/w3c/orientation-sensor"
+      "repository": "https://github.com/w3c/orientation-sensor",
+      "filename": "index.html"
     },
     "title": "Orientation Sensor",
     "source": "w3c",
@@ -4890,11 +5291,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/page-visibility-2/"
+      "url": "https://www.w3.org/TR/page-visibility-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/page-visibility/",
-      "repository": "https://github.com/w3c/page-visibility"
+      "repository": "https://github.com/w3c/page-visibility",
+      "filename": "index.html"
     },
     "title": "Page Visibility Level 2",
     "source": "w3c",
@@ -4909,11 +5312,13 @@
       "currentSpecification": "paint-timing"
     },
     "release": {
-      "url": "https://www.w3.org/TR/paint-timing/"
+      "url": "https://www.w3.org/TR/paint-timing/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/paint-timing/",
-      "repository": "https://github.com/w3c/paint-timing"
+      "repository": "https://github.com/w3c/paint-timing",
+      "filename": "index.html"
     },
     "title": "Paint Timing 1",
     "source": "w3c",
@@ -4928,11 +5333,13 @@
       "currentSpecification": "payment-handler"
     },
     "release": {
-      "url": "https://www.w3.org/TR/payment-handler/"
+      "url": "https://www.w3.org/TR/payment-handler/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/payment-handler/",
-      "repository": "https://github.com/w3c/payment-handler"
+      "repository": "https://github.com/w3c/payment-handler",
+      "filename": "index.html"
     },
     "title": "Payment Handler API",
     "source": "w3c",
@@ -4948,11 +5355,13 @@
     },
     "shortTitle": "Basic Card",
     "release": {
-      "url": "https://www.w3.org/TR/payment-method-basic-card/"
+      "url": "https://www.w3.org/TR/payment-method-basic-card/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/payment-method-basic-card/",
-      "repository": "https://github.com/w3c/payment-method-basic-card"
+      "repository": "https://github.com/w3c/payment-method-basic-card",
+      "filename": "index.html"
     },
     "title": "Payment Method: Basic Card",
     "source": "w3c"
@@ -4966,11 +5375,13 @@
       "currentSpecification": "payment-method-id"
     },
     "release": {
-      "url": "https://www.w3.org/TR/payment-method-id/"
+      "url": "https://www.w3.org/TR/payment-method-id/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/payment-method-id/",
-      "repository": "https://github.com/w3c/payment-method-id"
+      "repository": "https://github.com/w3c/payment-method-id",
+      "filename": "index.html"
     },
     "title": "Payment Method Identifiers",
     "source": "w3c",
@@ -4985,11 +5396,13 @@
       "currentSpecification": "payment-method-manifest"
     },
     "release": {
-      "url": "https://www.w3.org/TR/payment-method-manifest/"
+      "url": "https://www.w3.org/TR/payment-method-manifest/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/payment-method-manifest/",
-      "repository": "https://github.com/w3c/payment-method-manifest"
+      "repository": "https://github.com/w3c/payment-method-manifest",
+      "filename": "index.html"
     },
     "title": "Payment Method Manifest",
     "source": "w3c",
@@ -5004,11 +5417,13 @@
       "currentSpecification": "payment-request"
     },
     "release": {
-      "url": "https://www.w3.org/TR/payment-request/"
+      "url": "https://www.w3.org/TR/payment-request/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/payment-request/",
-      "repository": "https://github.com/w3c/payment-request"
+      "repository": "https://github.com/w3c/payment-request",
+      "filename": "index.html"
     },
     "title": "Payment Request API",
     "source": "w3c",
@@ -5024,11 +5439,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/performance-timeline-2/"
+      "url": "https://www.w3.org/TR/performance-timeline-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/performance-timeline/",
-      "repository": "https://github.com/w3c/performance-timeline"
+      "repository": "https://github.com/w3c/performance-timeline",
+      "filename": "index.html"
     },
     "title": "Performance Timeline Level 2",
     "source": "w3c",
@@ -5043,11 +5460,13 @@
       "currentSpecification": "permissions"
     },
     "release": {
-      "url": "https://www.w3.org/TR/permissions/"
+      "url": "https://www.w3.org/TR/permissions/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/permissions/",
-      "repository": "https://github.com/w3c/permissions"
+      "repository": "https://github.com/w3c/permissions",
+      "filename": "index.html"
     },
     "title": "Permissions",
     "source": "w3c",
@@ -5062,11 +5481,13 @@
       "currentSpecification": "picture-in-picture"
     },
     "release": {
-      "url": "https://www.w3.org/TR/picture-in-picture/"
+      "url": "https://www.w3.org/TR/picture-in-picture/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/picture-in-picture/",
-      "repository": "https://github.com/w3c/picture-in-picture"
+      "repository": "https://github.com/w3c/picture-in-picture",
+      "filename": "index.html"
     },
     "title": "Picture-in-Picture",
     "source": "w3c",
@@ -5082,11 +5503,13 @@
     },
     "seriesVersion": "3",
     "release": {
-      "url": "https://www.w3.org/TR/pointerevents3/"
+      "url": "https://www.w3.org/TR/pointerevents3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/pointerevents/",
-      "repository": "https://github.com/w3c/pointerevents"
+      "repository": "https://github.com/w3c/pointerevents",
+      "filename": "index.html"
     },
     "title": "Pointer Events Level 3",
     "source": "w3c",
@@ -5102,11 +5525,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/pointerlock-2/"
+      "url": "https://www.w3.org/TR/pointerlock-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/pointerlock/",
-      "repository": "https://github.com/w3c/pointerlock"
+      "repository": "https://github.com/w3c/pointerlock",
+      "filename": "index.html"
     },
     "title": "Pointer Lock 2.0",
     "source": "w3c",
@@ -5121,11 +5546,13 @@
       "currentSpecification": "preload"
     },
     "release": {
-      "url": "https://www.w3.org/TR/preload/"
+      "url": "https://www.w3.org/TR/preload/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/preload/",
-      "repository": "https://github.com/w3c/preload"
+      "repository": "https://github.com/w3c/preload",
+      "filename": "index.html"
     },
     "title": "Preload",
     "source": "w3c",
@@ -5140,11 +5567,13 @@
       "currentSpecification": "presentation-api"
     },
     "release": {
-      "url": "https://www.w3.org/TR/presentation-api/"
+      "url": "https://www.w3.org/TR/presentation-api/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/presentation-api/",
-      "repository": "https://github.com/w3c/presentation-api"
+      "repository": "https://github.com/w3c/presentation-api",
+      "filename": "index.html"
     },
     "title": "Presentation API",
     "source": "w3c",
@@ -5159,11 +5588,13 @@
       "currentSpecification": "proximity"
     },
     "release": {
-      "url": "https://www.w3.org/TR/proximity/"
+      "url": "https://www.w3.org/TR/proximity/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/proximity/",
-      "repository": "https://github.com/w3c/proximity"
+      "repository": "https://github.com/w3c/proximity",
+      "filename": "index.html"
     },
     "title": "Proximity Sensor",
     "source": "w3c",
@@ -5178,11 +5609,13 @@
       "currentSpecification": "push-api"
     },
     "release": {
-      "url": "https://www.w3.org/TR/push-api/"
+      "url": "https://www.w3.org/TR/push-api/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/push-api/",
-      "repository": "https://github.com/w3c/push-api"
+      "repository": "https://github.com/w3c/push-api",
+      "filename": "index.html"
     },
     "title": "Push API",
     "source": "w3c",
@@ -5197,11 +5630,13 @@
       "currentSpecification": "referrer-policy"
     },
     "release": {
-      "url": "https://www.w3.org/TR/referrer-policy/"
+      "url": "https://www.w3.org/TR/referrer-policy/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-referrer-policy/",
-      "repository": "https://github.com/w3c/webappsec-referrer-policy"
+      "repository": "https://github.com/w3c/webappsec-referrer-policy",
+      "filename": "index.html"
     },
     "title": "Referrer Policy",
     "source": "w3c",
@@ -5216,11 +5651,13 @@
       "currentSpecification": "remote-playback"
     },
     "release": {
-      "url": "https://www.w3.org/TR/remote-playback/"
+      "url": "https://www.w3.org/TR/remote-playback/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/remote-playback/",
-      "repository": "https://github.com/w3c/remote-playback"
+      "repository": "https://github.com/w3c/remote-playback",
+      "filename": "index.html"
     },
     "title": "Remote Playback API",
     "source": "w3c",
@@ -5236,11 +5673,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/reporting-1/"
+      "url": "https://www.w3.org/TR/reporting-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/reporting/",
-      "repository": "https://github.com/w3c/reporting"
+      "repository": "https://github.com/w3c/reporting",
+      "filename": "index.html"
     },
     "title": "Reporting API",
     "source": "w3c",
@@ -5255,11 +5694,13 @@
       "currentSpecification": "requestidlecallback"
     },
     "release": {
-      "url": "https://www.w3.org/TR/requestidlecallback/"
+      "url": "https://www.w3.org/TR/requestidlecallback/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/requestidlecallback/",
-      "repository": "https://github.com/w3c/requestidlecallback"
+      "repository": "https://github.com/w3c/requestidlecallback",
+      "filename": "index.html"
     },
     "title": "Cooperative Scheduling of Background Tasks",
     "source": "w3c",
@@ -5275,11 +5716,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/resize-observer-1/"
+      "url": "https://www.w3.org/TR/resize-observer-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/resize-observer/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Resize Observer",
     "source": "w3c",
@@ -5294,11 +5737,13 @@
       "currentSpecification": "resource-hints"
     },
     "release": {
-      "url": "https://www.w3.org/TR/resource-hints/"
+      "url": "https://www.w3.org/TR/resource-hints/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/resource-hints/",
-      "repository": "https://github.com/w3c/resource-hints"
+      "repository": "https://github.com/w3c/resource-hints",
+      "filename": "index.html"
     },
     "title": "Resource Hints",
     "source": "w3c",
@@ -5314,11 +5759,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/resource-timing-2/"
+      "url": "https://www.w3.org/TR/resource-timing-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/resource-timing/",
-      "repository": "https://github.com/w3c/resource-timing"
+      "repository": "https://github.com/w3c/resource-timing",
+      "filename": "index.html"
     },
     "title": "Resource Timing Level 2",
     "source": "w3c",
@@ -5333,11 +5780,13 @@
       "currentSpecification": "screen-capture"
     },
     "release": {
-      "url": "https://www.w3.org/TR/screen-capture/"
+      "url": "https://www.w3.org/TR/screen-capture/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-screen-share/",
-      "repository": "https://github.com/w3c/mediacapture-screen-share"
+      "repository": "https://github.com/w3c/mediacapture-screen-share",
+      "filename": "index.html"
     },
     "title": "Screen Capture",
     "source": "w3c",
@@ -5352,11 +5801,13 @@
       "currentSpecification": "screen-orientation"
     },
     "release": {
-      "url": "https://www.w3.org/TR/screen-orientation/"
+      "url": "https://www.w3.org/TR/screen-orientation/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/screen-orientation/",
-      "repository": "https://github.com/w3c/screen-orientation"
+      "repository": "https://github.com/w3c/screen-orientation",
+      "filename": "index.html"
     },
     "title": "The Screen Orientation API",
     "source": "w3c",
@@ -5371,11 +5822,13 @@
       "currentSpecification": "secure-contexts"
     },
     "release": {
-      "url": "https://www.w3.org/TR/secure-contexts/"
+      "url": "https://www.w3.org/TR/secure-contexts/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-secure-contexts/",
-      "repository": "https://github.com/w3c/webappsec-secure-contexts"
+      "repository": "https://github.com/w3c/webappsec-secure-contexts",
+      "filename": "index.html"
     },
     "title": "Secure Contexts",
     "source": "w3c",
@@ -5390,11 +5843,13 @@
       "currentSpecification": "selection-api"
     },
     "release": {
-      "url": "https://www.w3.org/TR/selection-api/"
+      "url": "https://www.w3.org/TR/selection-api/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/selection-api/",
-      "repository": "https://github.com/w3c/selection-api"
+      "repository": "https://github.com/w3c/selection-api",
+      "filename": "index.html"
     },
     "title": "Selection API",
     "source": "w3c",
@@ -5411,11 +5866,13 @@
     "seriesVersion": "3",
     "seriesNext": "selectors-4",
     "release": {
-      "url": "https://www.w3.org/TR/selectors-3/"
+      "url": "https://www.w3.org/TR/selectors-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/selectors-3/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Selectors Level 3",
     "source": "w3c",
@@ -5432,11 +5889,13 @@
     "seriesVersion": "4",
     "seriesPrevious": "selectors-3",
     "release": {
-      "url": "https://www.w3.org/TR/selectors-4/"
+      "url": "https://www.w3.org/TR/selectors-4/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/selectors/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Selectors Level 4",
     "source": "w3c",
@@ -5452,11 +5911,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/selectors-nonelement-1/"
+      "url": "https://www.w3.org/TR/selectors-nonelement-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/selectors-nonelement/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Non-element Selectors Module Level 1",
     "source": "w3c",
@@ -5471,11 +5932,13 @@
       "currentSpecification": "server-timing"
     },
     "release": {
-      "url": "https://www.w3.org/TR/server-timing/"
+      "url": "https://www.w3.org/TR/server-timing/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/server-timing/",
-      "repository": "https://github.com/w3c/server-timing"
+      "repository": "https://github.com/w3c/server-timing",
+      "filename": "index.html"
     },
     "title": "Server Timing",
     "source": "w3c",
@@ -5492,10 +5955,12 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://w3c.github.io/ServiceWorker/",
-      "repository": "https://github.com/w3c/ServiceWorker"
+      "repository": "https://github.com/w3c/ServiceWorker",
+      "filename": "index.html"
     },
     "release": {
-      "url": "https://www.w3.org/TR/service-workers-1/"
+      "url": "https://www.w3.org/TR/service-workers-1/",
+      "filename": "Overview.html"
     },
     "title": "Service Workers 1",
     "source": "w3c",
@@ -5511,11 +5976,13 @@
     },
     "shortTitle": "SRI",
     "release": {
-      "url": "https://www.w3.org/TR/SRI/"
+      "url": "https://www.w3.org/TR/SRI/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-subresource-integrity/",
-      "repository": "https://github.com/w3c/webappsec-subresource-integrity"
+      "repository": "https://github.com/w3c/webappsec-subresource-integrity",
+      "filename": "index.html"
     },
     "title": "Subresource Integrity",
     "source": "w3c"
@@ -5530,11 +5997,13 @@
     },
     "seriesVersion": "1.0",
     "release": {
-      "url": "https://www.w3.org/TR/svg-aam-1.0/"
+      "url": "https://www.w3.org/TR/svg-aam-1.0/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/svg-aam/",
-      "repository": "https://github.com/w3c/svg-aam"
+      "repository": "https://github.com/w3c/svg-aam",
+      "filename": "index.html"
     },
     "title": "SVG Accessibility API Mappings",
     "source": "w3c",
@@ -5549,11 +6018,13 @@
       "currentSpecification": "svg-integration"
     },
     "release": {
-      "url": "https://www.w3.org/TR/svg-integration/"
+      "url": "https://www.w3.org/TR/svg-integration/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://svgwg.org/specs/integration/",
-      "repository": "https://github.com/w3c/svgwg"
+      "repository": "https://github.com/w3c/svgwg",
+      "filename": "Overview.html"
     },
     "title": "SVG Integration",
     "source": "w3c",
@@ -5568,11 +6039,13 @@
       "currentSpecification": "svg-markers"
     },
     "release": {
-      "url": "https://www.w3.org/TR/svg-markers/"
+      "url": "https://www.w3.org/TR/svg-markers/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://svgwg.org/specs/markers/",
-      "repository": "https://github.com/w3c/svgwg"
+      "repository": "https://github.com/w3c/svgwg",
+      "filename": "Overview.html"
     },
     "title": "SVG Markers",
     "source": "w3c",
@@ -5587,11 +6060,13 @@
       "currentSpecification": "svg-paths"
     },
     "release": {
-      "url": "https://www.w3.org/TR/svg-paths/"
+      "url": "https://www.w3.org/TR/svg-paths/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://svgwg.org/specs/paths/",
-      "repository": "https://github.com/w3c/svgwg"
+      "repository": "https://github.com/w3c/svgwg",
+      "filename": "Overview.html"
     },
     "title": "SVG Paths",
     "source": "w3c",
@@ -5606,11 +6081,13 @@
       "currentSpecification": "svg-strokes"
     },
     "release": {
-      "url": "https://www.w3.org/TR/svg-strokes/"
+      "url": "https://www.w3.org/TR/svg-strokes/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://svgwg.org/specs/strokes/",
-      "repository": "https://github.com/w3c/svgwg"
+      "repository": "https://github.com/w3c/svgwg",
+      "filename": "Overview.html"
     },
     "title": "SVG Strokes",
     "source": "w3c",
@@ -5655,7 +6132,8 @@
         "https://www.w3.org/TR/SVG2/idlindex.html",
         "https://www.w3.org/TR/SVG2/mimereg.html",
         "https://www.w3.org/TR/SVG2/changes.html"
-      ]
+      ],
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://svgwg.org/svg2-draft/",
@@ -5688,7 +6166,8 @@
         "https://svgwg.org/svg2-draft/idlindex.html",
         "https://svgwg.org/svg2-draft/mimereg.html",
         "https://svgwg.org/svg2-draft/changes.html"
-      ]
+      ],
+      "filename": "Overview.html"
     },
     "title": "Scalable Vector Graphics (SVG) 2",
     "source": "w3c",
@@ -5703,11 +6182,13 @@
       "currentSpecification": "timing-entrytypes-registry"
     },
     "release": {
-      "url": "https://www.w3.org/TR/timing-entrytypes-registry/"
+      "url": "https://www.w3.org/TR/timing-entrytypes-registry/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/timing-entrytypes-registry/",
-      "repository": "https://github.com/w3c/timing-entrytypes-registry"
+      "repository": "https://github.com/w3c/timing-entrytypes-registry",
+      "filename": "index.html"
     },
     "title": "Timing Entry Names Registry",
     "source": "w3c",
@@ -5722,11 +6203,13 @@
       "currentSpecification": "touch-events"
     },
     "release": {
-      "url": "https://www.w3.org/TR/touch-events/"
+      "url": "https://www.w3.org/TR/touch-events/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/touch-events/",
-      "repository": "https://github.com/w3c/touch-events"
+      "repository": "https://github.com/w3c/touch-events",
+      "filename": "index.html"
     },
     "title": "Touch Events",
     "source": "w3c",
@@ -5742,11 +6225,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/trace-context-1/"
+      "url": "https://www.w3.org/TR/trace-context-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/trace-context/",
-      "repository": "https://github.com/w3c/trace-context"
+      "repository": "https://github.com/w3c/trace-context",
+      "filename": "index.html"
     },
     "title": "Trace Context - Level 1",
     "source": "w3c",
@@ -5761,11 +6246,13 @@
       "currentSpecification": "uievents-code"
     },
     "release": {
-      "url": "https://www.w3.org/TR/uievents-code/"
+      "url": "https://www.w3.org/TR/uievents-code/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/uievents-code/",
-      "repository": "https://github.com/w3c/uievents-code"
+      "repository": "https://github.com/w3c/uievents-code",
+      "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent code Values",
     "source": "w3c",
@@ -5780,11 +6267,13 @@
       "currentSpecification": "uievents-key"
     },
     "release": {
-      "url": "https://www.w3.org/TR/uievents-key/"
+      "url": "https://www.w3.org/TR/uievents-key/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/uievents-key/",
-      "repository": "https://github.com/w3c/uievents-key"
+      "repository": "https://github.com/w3c/uievents-key",
+      "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent key Values",
     "source": "w3c",
@@ -5799,11 +6288,13 @@
       "currentSpecification": "uievents"
     },
     "release": {
-      "url": "https://www.w3.org/TR/uievents/"
+      "url": "https://www.w3.org/TR/uievents/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/uievents/",
-      "repository": "https://github.com/w3c/uievents"
+      "repository": "https://github.com/w3c/uievents",
+      "filename": "index.html"
     },
     "title": "UI Events",
     "source": "w3c",
@@ -5818,11 +6309,13 @@
       "currentSpecification": "upgrade-insecure-requests"
     },
     "release": {
-      "url": "https://www.w3.org/TR/upgrade-insecure-requests/"
+      "url": "https://www.w3.org/TR/upgrade-insecure-requests/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-upgrade-insecure-requests/",
-      "repository": "https://github.com/w3c/webappsec-upgrade-insecure-requests"
+      "repository": "https://github.com/w3c/webappsec-upgrade-insecure-requests",
+      "filename": "index.html"
     },
     "title": "Upgrade Insecure Requests",
     "source": "w3c",
@@ -5839,11 +6332,13 @@
     "seriesVersion": "2",
     "seriesNext": "user-timing-3",
     "release": {
-      "url": "https://www.w3.org/TR/user-timing-2/"
+      "url": "https://www.w3.org/TR/user-timing-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/user-timing/",
-      "repository": "https://github.com/w3c/user-timing"
+      "repository": "https://github.com/w3c/user-timing",
+      "filename": "index.html"
     },
     "title": "User Timing Level 2",
     "source": "w3c",
@@ -5860,11 +6355,13 @@
     "seriesVersion": "3",
     "seriesPrevious": "user-timing-2",
     "release": {
-      "url": "https://www.w3.org/TR/user-timing-3/"
+      "url": "https://www.w3.org/TR/user-timing-3/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/user-timing/",
-      "repository": "https://github.com/w3c/user-timing"
+      "repository": "https://github.com/w3c/user-timing",
+      "filename": "index.html"
     },
     "title": "User Timing Level 3",
     "source": "w3c",
@@ -5879,11 +6376,13 @@
       "currentSpecification": "vibration"
     },
     "release": {
-      "url": "https://www.w3.org/TR/vibration/"
+      "url": "https://www.w3.org/TR/vibration/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/vibration/",
-      "repository": "https://github.com/w3c/vibration"
+      "repository": "https://github.com/w3c/vibration",
+      "filename": "index.html"
     },
     "title": "Vibration API (Second Edition)",
     "source": "w3c",
@@ -5899,11 +6398,13 @@
     },
     "seriesVersion": "1.2",
     "release": {
-      "url": "https://www.w3.org/TR/wai-aria-1.2/"
+      "url": "https://www.w3.org/TR/wai-aria-1.2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/aria/",
-      "repository": "https://github.com/w3c/aria"
+      "repository": "https://github.com/w3c/aria",
+      "filename": "index.html"
     },
     "title": "Accessible Rich Internet Applications (WAI-ARIA) 1.2",
     "source": "w3c",
@@ -5918,11 +6419,13 @@
       "currentSpecification": "wake-lock"
     },
     "release": {
-      "url": "https://www.w3.org/TR/wake-lock/"
+      "url": "https://www.w3.org/TR/wake-lock/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/screen-wake-lock/",
-      "repository": "https://github.com/w3c/screen-wake-lock"
+      "repository": "https://github.com/w3c/screen-wake-lock",
+      "filename": "index.html"
     },
     "title": "Wake Lock API",
     "source": "w3c",
@@ -5938,11 +6441,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/wasm-core-1/"
+      "url": "https://www.w3.org/TR/wasm-core-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://webassembly.github.io/spec/core/bikeshed/",
-      "repository": "https://github.com/WebAssembly/spec"
+      "repository": "https://github.com/WebAssembly/spec",
+      "filename": "index.html"
     },
     "title": "WebAssembly Core Specification",
     "source": "w3c",
@@ -5958,11 +6463,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/wasm-js-api-1/"
+      "url": "https://www.w3.org/TR/wasm-js-api-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://webassembly.github.io/spec/js-api/",
-      "repository": "https://github.com/WebAssembly/spec"
+      "repository": "https://github.com/WebAssembly/spec",
+      "filename": "index.html"
     },
     "title": "WebAssembly JavaScript Interface",
     "source": "w3c",
@@ -5978,11 +6485,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/wasm-web-api-1/"
+      "url": "https://www.w3.org/TR/wasm-web-api-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://webassembly.github.io/spec/web-api/",
-      "repository": "https://github.com/WebAssembly/spec"
+      "repository": "https://github.com/WebAssembly/spec",
+      "filename": "index.html"
     },
     "title": "WebAssembly Web API",
     "source": "w3c",
@@ -5998,11 +6507,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/web-animations-1/"
+      "url": "https://www.w3.org/TR/web-animations-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.csswg.org/web-animations-1/",
-      "repository": "https://github.com/w3c/csswg-drafts"
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
     },
     "title": "Web Animations",
     "source": "w3c",
@@ -6017,11 +6528,13 @@
       "currentSpecification": "web-share"
     },
     "release": {
-      "url": "https://www.w3.org/TR/web-share/"
+      "url": "https://www.w3.org/TR/web-share/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/web-share/",
-      "repository": "https://github.com/w3c/web-share"
+      "repository": "https://github.com/w3c/web-share",
+      "filename": "index.html"
     },
     "title": "Web Share API",
     "source": "w3c",
@@ -6036,11 +6549,13 @@
       "currentSpecification": "webaudio"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webaudio/"
+      "url": "https://www.w3.org/TR/webaudio/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://webaudio.github.io/web-audio-api/",
-      "repository": "https://github.com/WebAudio/web-audio-api"
+      "repository": "https://github.com/WebAudio/web-audio-api",
+      "filename": "index.html"
     },
     "title": "Web Audio API",
     "source": "w3c",
@@ -6056,11 +6571,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/webauthn-2/"
+      "url": "https://www.w3.org/TR/webauthn-2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webauthn/",
-      "repository": "https://github.com/w3c/webauthn"
+      "repository": "https://github.com/w3c/webauthn",
+      "filename": "index.html"
     },
     "title": "Web Authentication:An API for accessing Public Key Credentials Level 2",
     "source": "w3c",
@@ -6075,11 +6592,13 @@
       "currentSpecification": "WebCryptoAPI"
     },
     "release": {
-      "url": "https://www.w3.org/TR/WebCryptoAPI/"
+      "url": "https://www.w3.org/TR/WebCryptoAPI/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webcrypto/Overview.html",
-      "repository": "https://github.com/w3c/webcrypto"
+      "repository": "https://github.com/w3c/webcrypto",
+      "filename": "Overview.html"
     },
     "title": "Web Cryptography API",
     "source": "w3c",
@@ -6095,11 +6614,13 @@
     },
     "seriesVersion": "2",
     "release": {
-      "url": "https://www.w3.org/TR/webdriver2/"
+      "url": "https://www.w3.org/TR/webdriver2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webdriver/",
-      "repository": "https://github.com/w3c/webdriver"
+      "repository": "https://github.com/w3c/webdriver",
+      "filename": "index.html"
     },
     "title": "WebDriver - Level 2",
     "source": "w3c",
@@ -6115,11 +6636,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/WebIDL-1/"
+      "url": "https://www.w3.org/TR/WebIDL-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://heycam.github.io/webidl/",
-      "repository": "https://github.com/heycam/webidl"
+      "repository": "https://github.com/heycam/webidl",
+      "filename": "index.html"
     },
     "title": "WebIDL Level 1",
     "source": "w3c",
@@ -6134,11 +6657,13 @@
       "currentSpecification": "webmidi"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webmidi/"
+      "url": "https://www.w3.org/TR/webmidi/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://webaudio.github.io/web-midi-api/",
-      "repository": "https://github.com/WebAudio/web-midi-api"
+      "repository": "https://github.com/WebAudio/web-midi-api",
+      "filename": "index.html"
     },
     "title": "Web MIDI API",
     "source": "w3c",
@@ -6153,11 +6678,13 @@
       "currentSpecification": "webrtc-identity"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webrtc-identity/"
+      "url": "https://www.w3.org/TR/webrtc-identity/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-identity/identity.html",
-      "repository": "https://github.com/w3c/webrtc-identity"
+      "repository": "https://github.com/w3c/webrtc-identity",
+      "filename": "identity.html"
     },
     "title": "Identity for WebRTC 1.0",
     "source": "w3c",
@@ -6172,11 +6699,13 @@
       "currentSpecification": "webrtc-priority"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webrtc-priority/"
+      "url": "https://www.w3.org/TR/webrtc-priority/",
+      "filename": "index.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-priority/",
-      "repository": "https://github.com/w3c/webrtc-priority"
+      "repository": "https://github.com/w3c/webrtc-priority",
+      "filename": "index.html"
     },
     "title": "WebRTC Priority Control API",
     "source": "w3c",
@@ -6192,11 +6721,13 @@
     },
     "shortTitle": "WebRTC Statistics",
     "release": {
-      "url": "https://www.w3.org/TR/webrtc-stats/"
+      "url": "https://www.w3.org/TR/webrtc-stats/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-stats/",
-      "repository": "https://github.com/w3c/webrtc-stats"
+      "repository": "https://github.com/w3c/webrtc-stats",
+      "filename": "index.html"
     },
     "title": "Identifiers for WebRTC's Statistics API",
     "source": "w3c"
@@ -6210,11 +6741,13 @@
       "currentSpecification": "webrtc-svc"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webrtc-svc/"
+      "url": "https://www.w3.org/TR/webrtc-svc/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-svc/",
-      "repository": "https://github.com/w3c/webrtc-svc"
+      "repository": "https://github.com/w3c/webrtc-svc",
+      "filename": "index.html"
     },
     "title": "Scalable Video Coding (SVC) Extension for WebRTC",
     "source": "w3c",
@@ -6230,11 +6763,13 @@
     },
     "shortTitle": "WebRTC 1.0",
     "release": {
-      "url": "https://www.w3.org/TR/webrtc/"
+      "url": "https://www.w3.org/TR/webrtc/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webrtc-pc/",
-      "repository": "https://github.com/w3c/webrtc-pc"
+      "repository": "https://github.com/w3c/webrtc-pc",
+      "filename": "index.html"
     },
     "title": "WebRTC 1.0: Real-time Communication Between Browsers",
     "source": "w3c"
@@ -6249,11 +6784,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/webvtt1/"
+      "url": "https://www.w3.org/TR/webvtt1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/webvtt/",
-      "repository": "https://github.com/w3c/webvtt"
+      "repository": "https://github.com/w3c/webvtt",
+      "filename": "index.html"
     },
     "title": "WebVTT: The Web Video Text Tracks Format",
     "source": "w3c",
@@ -6269,11 +6806,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/webxr-ar-module-1/"
+      "url": "https://www.w3.org/TR/webxr-ar-module-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://immersive-web.github.io/webxr-ar-module/",
-      "repository": "https://github.com/immersive-web/webxr-ar-module"
+      "repository": "https://github.com/immersive-web/webxr-ar-module",
+      "filename": "index.html"
     },
     "title": "WebXR Augmented Reality Module - Level 1",
     "source": "w3c",
@@ -6289,11 +6828,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/webxr-gamepads-module-1/"
+      "url": "https://www.w3.org/TR/webxr-gamepads-module-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://immersive-web.github.io/webxr-gamepads-module/",
-      "repository": "https://github.com/immersive-web/webxr-gamepads-module"
+      "repository": "https://github.com/immersive-web/webxr-gamepads-module",
+      "filename": "index.html"
     },
     "title": "WebXR Gamepads Module - Level 1",
     "source": "w3c",
@@ -6308,11 +6849,13 @@
       "currentSpecification": "webxr"
     },
     "release": {
-      "url": "https://www.w3.org/TR/webxr/"
+      "url": "https://www.w3.org/TR/webxr/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://immersive-web.github.io/webxr/",
-      "repository": "https://github.com/immersive-web/webxr"
+      "repository": "https://github.com/immersive-web/webxr",
+      "filename": "index.html"
     },
     "title": "WebXR Device API",
     "source": "w3c",
@@ -6329,11 +6872,13 @@
     "seriesVersion": "2",
     "shortTitle": "WOFF 2.0",
     "release": {
-      "url": "https://www.w3.org/TR/WOFF2/"
+      "url": "https://www.w3.org/TR/WOFF2/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://w3c.github.io/woff/woff2/",
-      "repository": "https://github.com/w3c/woff"
+      "repository": "https://github.com/w3c/woff",
+      "filename": "index.html"
     },
     "title": "WOFF File Format 2.0",
     "source": "w3c"
@@ -6348,11 +6893,13 @@
     },
     "seriesVersion": "1",
     "release": {
-      "url": "https://www.w3.org/TR/worklets-1/"
+      "url": "https://www.w3.org/TR/worklets-1/",
+      "filename": "Overview.html"
     },
     "nightly": {
       "url": "https://drafts.css-houdini.org/worklets/",
-      "repository": "https://github.com/w3c/css-houdini-drafts"
+      "repository": "https://github.com/w3c/css-houdini-drafts",
+      "filename": "Overview.html"
     },
     "title": "Worklets Level 1",
     "source": "w3c",
@@ -6368,7 +6915,8 @@
     },
     "nightly": {
       "url": "https://xhr.spec.whatwg.org/",
-      "repository": "https://github.com/whatwg/xhr"
+      "repository": "https://github.com/whatwg/xhr",
+      "filename": "index.html"
     },
     "title": "XMLHttpRequest Standard",
     "source": "specref",

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -8,6 +8,11 @@
       "format": "uri"
     },
 
+    "filename": {
+      "type": "string",
+      "pattern": "^\\w+\\.html$"
+    },
+
     "shortname": {
       "type": "string",
       "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
@@ -53,6 +58,7 @@
       "type": "object",
       "properties": {
         "url": { "$ref": "#/proptype/url" },
+        "filename": { "$ref": "#/proptype/filename" },
         "pages": {
           "type": "array",
           "items": { "$ref": "#/proptype/url" }
@@ -66,6 +72,7 @@
       "type": "object",
       "properties": {
         "url": { "$ref": "#/proptype/url" },
+        "filename": { "$ref": "#/proptype/filename" },
         "pages": {
           "type": "array",
           "items": { "$ref": "#/proptype/url" }

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -11,6 +11,7 @@ const computePrevNext = require("./compute-prevnext.js");
 const computeCurrentLevel = require("./compute-currentlevel.js");
 const computeRepository = require("./compute-repository.js");
 const computeShortTitle = require("./compute-shorttitle.js");
+const determineFilename = require("./determine-filename.js");
 const extractPages = require("./extract-pages.js");
 const fetchInfo = require("./fetch-info.js");
 const { w3cApiKey } = require("../config.json");
@@ -89,6 +90,17 @@ fetchInfo(specs, { w3cApiKey })
           spec.nightly.pages = await extractPages(spec.nightly.url);
         }
         delete spec.multipage;
+      }
+      return spec;
+    })
+  ))
+
+  // Complete with filename
+  .then(index => Promise.all(
+    index.map(async spec => {
+      spec.nightly.filename = await determineFilename(spec.nightly.url);
+      if (spec.release) {
+        spec.release.filename = await determineFilename(spec.release.url);
       }
       return spec;
     })

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -1,0 +1,42 @@
+/**
+ * Module that takes the URL of the index page of a spec as input, possibly
+ * without a filename, and that tries to determine the underlying filename.
+ *
+ * For instance:
+ * - given "https://w3c.github.io/webrtc-identity/identity.html", the function
+ * would return "identity.html"
+ * - given "https://compat.spec.whatwg.org/", the function would determine that
+ * the filename is "index.html".
+ */
+
+const fetch = require("node-fetch");
+
+module.exports = async function (url) {
+  // Extract filename directly from the URL when possible
+  const match = url.match(/\/([^/]+\.html)$/);
+  if (match) {
+    return match[1];
+  }
+
+  // Make sure that url ends with a "/"
+  const urlWithSlash = url.endsWith("/") ? url : url + "/";
+
+  // Check common candidates
+  const candidates = [
+    "Overview.html",
+    "index.html",
+    "cover.html"
+  ];
+
+  for (const candidate of candidates) {
+    const res = await fetch(urlWithSlash + candidate, { method: "HEAD" });
+    if (res.status === 200) {
+      return candidate;
+    }
+  }
+
+  // Not found? Look at Content-Location header
+  const res = await fetch(url, { method: "HEAD" });
+  const filename = res.headers.get("Content-Location");
+  return filename;
+}

--- a/test/determine-filename.js
+++ b/test/determine-filename.js
@@ -1,0 +1,32 @@
+const assert = require("assert");
+const determineFilename = require("../src/determine-filename.js");
+
+describe("determine-filename module", function () {
+  // Tests need to send network requests
+  this.slow(5000);
+  this.timeout(30000);
+
+  it("extracts filename from URL", async () => {
+    const url = "https://example.org/spec/filename.html";
+    const filename = await determineFilename(url);
+    assert.equal(filename, "filename.html");
+  });
+
+  it("finds index.html filenames", async () => {
+    const url = "https://w3c.github.io/presentation-api/";
+    const filename = await determineFilename(url);
+    assert.equal(filename, "index.html");
+  });
+
+  it("finds Overview.html filenames", async () => {
+    const url = "https://www.w3.org/TR/presentation-api/";
+    const filename = await determineFilename(url);
+    assert.equal(filename, "Overview.html");
+  });
+
+  it("finds cover.html filenames", async () => {
+    const url = "https://drafts.csswg.org/css2/";
+    const filename = await determineFilename(url);
+    assert.equal(filename, "cover.html");
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -91,4 +91,14 @@ describe("List of specs", () => {
     const wrong = specs.filter(s => !s.nightly.repository);
     assert.deepStrictEqual(wrong, []);
   });
+
+  it("contains filenames for all nightly URLs", () => {
+    const wrong = specs.filter(s => !s.nightly.filename);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("contains filenames for all release URLs", () => {
+    const wrong = specs.filter(s => s.release && !s.release.filename);
+    assert.deepStrictEqual(wrong, []);
+  });
 });


### PR DESCRIPTION
This update adds a `filename` property to `release` and `nightly` to report the actual filename of the index page, with a view to allowing external code to identify all links to self.

The code extracts the filename from the URL if it already appears there. For instance, it extracts the filename `identity.html` from
`https://w3c.github.io/webrtc-identity/identity.html`.

If the filename is not in the URL, the code uses a trial and error approach: it appends `Overview.html` (most common filename) to the URL and fetches the resulting URL. If that fails, it tries with `index.html` (second most common filename). If that also fails, it tries with `cover.html` (which is essentially only used for the main CSS spec). So far, this is enough to cover all existing specs but note the code also looks at the `Content-Location` header as last resort.

Fixes #16.