### PR TITLE
CSS2 ED switched to Bikeshed, no longer multipage

### DIFF
--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -24,8 +24,7 @@ module.exports = async function (url) {
   // Check common candidates
   const candidates = [
     "Overview.html",
-    "index.html",
-    "cover.html"
+    "index.html"
   ];
 
   for (const candidate of candidates) {

--- a/test/determine-filename.js
+++ b/test/determine-filename.js
@@ -23,10 +23,4 @@ describe("determine-filename module", function () {
     const filename = await determineFilename(url);
     assert.equal(filename, "Overview.html");
   });
-
-  it("finds cover.html filenames", async () => {
-    const url = "https://drafts.csswg.org/css2/";
-    const filename = await determineFilename(url);
-    assert.equal(filename, "cover.html");
-  });
 });

--- a/test/extract-pages.js
+++ b/test/extract-pages.js
@@ -18,8 +18,8 @@ describe("extract-pages module", function () {
     assert.ok(pages.length > 20);
   });
 
-  it("extracts pages from the CSS 2.2 spec", async () => {
-    const url = "https://drafts.csswg.org/css2/";
+  it("extracts pages from the CSS 2.1 spec", async () => {
+    const url = "https://www.w3.org/TR/CSS21/";
     const pages = await extractPages(url);
     assert.ok(pages.length > 20);
   });


### PR DESCRIPTION
The Editor's Draft of CSS2 was converted to Bikeshed recently:
https://github.com/w3c/csswg-drafts/pull/5196

This means that the spec becomes single page for now (at least until Bikeshed
supports multipage specs).

This update drops `cover.html` as "common" filename, since it was only used
there, and adjusts tests to only expect multiple page from the published
CSS 2.1 version.

Note the published version of CSS 2.2 still has multiple pages, so the spec
still needs to retain the `multipage` flag in `specs.json`.