### PR TITLE
Use previous filename when it cannot be determined

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "CC0-1.0",
   "main": "index.json",
   "scripts": {
-    "build": "node src/build-index.js > index.json",
+    "build": "node src/build-index.js",
     "lint": "node src/lint.js",
     "lint-fix": "node src/lint.js --fix",
     "test": "mocha",


### PR DESCRIPTION
CSS drafts server does not seem to like it when it receives too many requests in a row (see #130). This makes the `filename` info switch back and forth between `null` and its correct value.

To avoid this, this update re-uses the previous information as a fallback. The update also makes the code sleep 50ms between requests (this means the generation takes about 20s more than it used to).

Also, note that the generation logic had to be changed slightly to avoid having a `> index.json` command in `package.json`, since that was resetting the `index.json` file right away (and in particular before the code could load it).