### PR TITLE
Ignore WebXR weekly repo and monitor Sanitizer API repo

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -63,6 +63,9 @@
     "immersive-web/homepage": {
       "comment": "not for spec"
     },
+    "immersive-web/immersive-web-weekly": {
+      "comment": "not for spec"
+    },
     "immersive-web/immersiveweb.dev": {
       "comment": "not for spec"
     },

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -32,6 +32,10 @@
       "comment": "empty spec",
       "lastreviewed": "2020-07-01"
     },
+    "WICG/sanitizer-api": {
+      "comment": "Early proposal, no clear implementation plans",
+      "lastreviewed": "2020-07-18"
+    },
     "WICG/sw-launch": {
       "comment": "no spec yet",
       "lastreviewed": "2020-07-01"


### PR DESCRIPTION
While the HTML Sanitizer API spec is already advanced (and under active development), there does not seem to be clear implementation plans yet. Adding the spec to monitor list as a result.

Fixes #132