### PR TITLE
Use cg-report as a stronger hint of relevance

### DIFF
--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -26,3 +26,5 @@ jobs:
           ${{env.review_list}}
         assignees: tidoust, dontcallmedom
         draft: true
+        branch: monitor-update
+        branch-suffix: timestamp

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -21,3 +21,15 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         filename: .github/candidate-specs.md
+    - uses: peter-evans/create-pull-request@v2
+      if: ${{ env.monitor_list }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        title: Identify new monitored repos
+        commit-message: "List new repos to be monitored"
+        body: |
+          The following repos have been identified as possibly relevant:
+          ${{env.monitor_list}}
+        assignees: tidoust, dontcallmedom
+        draft: true

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -33,3 +33,5 @@ jobs:
           ${{env.monitor_list}}
         assignees: tidoust, dontcallmedom
         draft: true
+        branch: new-monitor
+        branch-suffix: timestamp

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -141,9 +141,17 @@ const hasExistingSpec = (candidate) => fetch(candidate.spec).then(({ok, url}) =>
               .map(canonicalizeGhUrl)
               .filter(hasUnknownSpec)
               .filter(hasRelevantSpec)
-             );
+                                );
+  // * look if those without homepage URLs but marked as a cg-report
+  // have a match in the list of specs
+  candidates = candidates.concat(cgSpecRepos.filter(r => !r.homepageUrl && hasRepoType('cg-report')(r))
+                                 .map(toGhUrl)
+                                 .filter(hasUnknownSpec)
+                                 .filter(hasRelevantSpec)
+                                );
+
   // * look if those without a homepage URL have a match with their generated URL
-  candidates = candidates.concat((await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl)
+  candidates = candidates.concat((await Promise.all(cgSpecRepos.filter(r => !r.homepageUrl && !hasRepoType('cg-report')(r))
                                                     .map(toGhUrl)
                                                     .filter(hasUnknownSpec)
                                                     .filter(hasRelevantSpec)


### PR DESCRIPTION
So far, find-specs would only use cg-report as a hint to look if the repo has a home page or not, and if not, would simply check if a generated page exists.

With this change, cg-report causes repos to be automatically flagged as relevant if they have a cg-report type. This identifies a bunch of new repos (and so closes #150). That being said, since these are repos which don't have github generated pages, it's not clear whether they're really ready for inclusion in browser-specs.