### PR TITLE
Drop superseded CSS Recommendations

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -459,6 +459,7 @@
   "https://www.w3.org/TR/uievents-key/",
   "https://www.w3.org/TR/uievents/",
   "https://www.w3.org/TR/upgrade-insecure-requests/",
+  "https://www.w3.org/TR/user-timing-2/",
   "https://www.w3.org/TR/user-timing-3/",
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/wai-aria-1.2/",

--- a/specs.json
+++ b/specs.json
@@ -229,7 +229,6 @@
     "shortTitle": "CSS Cascading 4",
     "forceCurrent": true
   },
-  "https://www.w3.org/TR/css-color-3/",
   "https://www.w3.org/TR/css-color-4/",
   "https://www.w3.org/TR/css-color-5/ delta",
   "https://www.w3.org/TR/css-color-adjust-1/",
@@ -238,7 +237,6 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Conditional 4"
   },
-  "https://www.w3.org/TR/css-contain-1/",
   "https://www.w3.org/TR/css-contain-2/",
   "https://www.w3.org/TR/css-content-3/",
   "https://www.w3.org/TR/css-counter-styles-3/",
@@ -250,7 +248,6 @@
     "shortTitle": "CSS Flexbox 1"
   },
   "https://www.w3.org/TR/css-font-loading-3/",
-  "https://www.w3.org/TR/css-fonts-3/",
   "https://www.w3.org/TR/css-fonts-4/",
   {
     "url": "https://www.w3.org/TR/css-gcpm-3/",
@@ -325,10 +322,6 @@
   "https://www.w3.org/TR/css-transitions-1/",
   "https://www.w3.org/TR/css-typed-om-1/",
   {
-    "url": "https://www.w3.org/TR/css-ui-3/",
-    "shortTitle": "CSS User Interface 3"
-  },
-  {
     "url": "https://www.w3.org/TR/css-ui-4/",
     "shortTitle": "CSS User Interface 4"
   },
@@ -345,7 +338,6 @@
     "shortTitle": "CSS Variables 1"
   },
   "https://www.w3.org/TR/css-will-change-1/",
-  "https://www.w3.org/TR/css-writing-modes-3/",
   "https://www.w3.org/TR/css-writing-modes-4/",
   "https://www.w3.org/TR/CSS21/ multipage",
   "https://www.w3.org/TR/CSS22/ multipage",
@@ -357,13 +349,6 @@
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",
     "seriesVersion": "3"
-  },
-  {
-    "url": "https://www.w3.org/TR/css3-mediaqueries/",
-    "seriesVersion": "3",
-    "series": {
-      "shortname": "mediaqueries"
-    }
   },
   "https://www.w3.org/TR/cssom-1/",
   "https://www.w3.org/TR/cssom-view-1/",
@@ -448,7 +433,6 @@
   "https://www.w3.org/TR/screen-wake-lock/",
   "https://www.w3.org/TR/secure-contexts/",
   "https://www.w3.org/TR/selection-api/",
-  "https://www.w3.org/TR/selectors-3/",
   "https://www.w3.org/TR/selectors-4/",
   "https://www.w3.org/TR/selectors-nonelement-1/",
   "https://www.w3.org/TR/server-timing/",
@@ -475,7 +459,6 @@
   "https://www.w3.org/TR/uievents-key/",
   "https://www.w3.org/TR/uievents/",
   "https://www.w3.org/TR/upgrade-insecure-requests/",
-  "https://www.w3.org/TR/user-timing-2/",
   "https://www.w3.org/TR/user-timing-3/",
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/wai-aria-1.2/",


### PR DESCRIPTION
Several CSS specifications, being developed by the CSS WG, supersede a previous level published as a W3C Recommendation, meaning that the series shortname no longer targets the Recommendation, but rather targets the new level. That suggests that the previous level no longer needs to be tracked in browser-specs (at least, that is the rule we follow for IDL specs).

This update removes the following CSS Recommendations from the index as a result:
- [CSS Color 3](https://www.w3.org/TR/css-color-3/)
- [CSS Containment 1](https://www.w3.org/TR/css-contain-1/)
- [CSS Fonts 3](https://www.w3.org/TR/css-fonts-3/)
- [CSS Basic UI 3](https://www.w3.org/TR/css-ui-3/)
- [CSS Writing Modes 3](https://www.w3.org/TR/css-writing-modes-3/)
- [CSS Mediaqueries 3](https://www.w3.org/TR/css3-mediaqueries/)
- [CSS Selectors 3](https://www.w3.org/TR/selectors-3/)
- [CSS User Timing 2](https://www.w3.org/TR/user-timing-2/)

See original discussion in:
https://github.com/tidoust/reffy/issues/417

I guess the overall question that this PR raises is around the definition of "superseded". One could perhaps argue that previous levels need to be retained, e.g. because they could still, in theory, be updated.