### PR TITLE
Flag CSS Box 3 as current specification

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -216,7 +216,7 @@
     "url": "https://www.w3.org/TR/css-backgrounds-3/",
     "shortTitle": "CSS Backgrounds 3"
   },
-  "https://www.w3.org/TR/css-box-3/",
+  "https://www.w3.org/TR/css-box-3/ current",
   "https://www.w3.org/TR/css-box-4/",
   "https://www.w3.org/TR/css-break-3/ current",
   "https://www.w3.org/TR/css-break-4/",


### PR DESCRIPTION
Level 3 is marked as current work in [Shepherd](https://drafts.csswg.org/) and https://www.w3.org/TR/css-box/ redirects to level 3.

Triggered by https://github.com/tidoust/reffy/issues/417#issuecomment-707701186