### PR TITLE
Drop Worklets spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -493,6 +493,5 @@
     "url": "https://www.w3.org/TR/WOFF2/",
     "shortTitle": "WOFF 2.0"
   },
-  "https://www.w3.org/TR/worklets-1/",
   "https://xhr.spec.whatwg.org/"
 ]


### PR DESCRIPTION
https://drafts.css-houdini.org/worklets/ now redirects to HTML,
into which it's been integrated.