### PR TITLE
Update CSS Grid, CSS Highlight, WebXR Hand Input

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -17,7 +17,7 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS GCPM 4"
   },
-  "https://drafts.csswg.org/css-highlight-api-1/",
+  "https://drafts.csswg.org/css-grid-3/ delta",
   {
     "url": "https://drafts.csswg.org/css-multicol-2/",
     "seriesComposition": "delta",
@@ -45,7 +45,6 @@
   "https://immersive-web.github.io/dom-overlays/",
   "https://immersive-web.github.io/hit-test/",
   "https://immersive-web.github.io/layers/",
-  "https://immersive-web.github.io/webxr-hand-input/",
   "https://infra.spec.whatwg.org/",
   "https://mathml-refresh.github.io/mathml-core/",
   "https://mimesniff.spec.whatwg.org/",
@@ -253,8 +252,8 @@
     "url": "https://www.w3.org/TR/css-gcpm-3/",
     "shortTitle": "CSS GCPM 3"
   },
-  "https://www.w3.org/TR/css-grid-1/",
-  "https://www.w3.org/TR/css-grid-2/ delta",
+  "https://www.w3.org/TR/css-grid-2/",
+  "https://www.w3.org/TR/css-highlight-api-1/",
   {
     "url": "https://www.w3.org/TR/css-images-3/",
     "shortTitle": "CSS Images 3"
@@ -488,6 +487,7 @@
   "https://www.w3.org/TR/webvtt1/",
   "https://www.w3.org/TR/webxr-ar-module-1/",
   "https://www.w3.org/TR/webxr-gamepads-module-1/",
+  "https://www.w3.org/TR/webxr-hand-input-1/",
   "https://www.w3.org/TR/webxr/",
   {
     "url": "https://www.w3.org/TR/WOFF2/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -119,6 +119,9 @@
     },
     "WICG/media-source": {
       "comment": "Merged back into main spec in the Media WG"
+    },
+    "w3c/epub-specs": {
+      "comment": "not targeted at browsers"
     }
   },
   "specs": {


### PR DESCRIPTION
- Drop CSS Grid Level 1 as /TR/css-grid/ now redirects to Level 2
- Update CSS Grid Level 2, no longer a delta spec
- Add CSS Grid Level 3, delta spec
- Update URL of CSS Highlight API Level 1
- Update URL of WebXR Hand Input
- Add EPUB3 repo to ignore list, not targeted at browsers

Fixes #180