### PR TITLE
Get current specification from W3C API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -218,9 +218,9 @@
     "url": "https://www.w3.org/TR/css-backgrounds-3/",
     "shortTitle": "CSS Backgrounds 3"
   },
-  "https://www.w3.org/TR/css-box-3/ current",
+  "https://www.w3.org/TR/css-box-3/",
   "https://www.w3.org/TR/css-box-4/",
-  "https://www.w3.org/TR/css-break-3/ current",
+  "https://www.w3.org/TR/css-break-3/",
   "https://www.w3.org/TR/css-break-4/",
   {
     "url": "https://www.w3.org/TR/css-cascade-3/",
@@ -228,8 +228,7 @@
   },
   {
     "url": "https://www.w3.org/TR/css-cascade-4/",
-    "shortTitle": "CSS Cascading 4",
-    "forceCurrent": true
+    "shortTitle": "CSS Cascading 4"
   },
   "https://www.w3.org/TR/css-color-4/",
   "https://www.w3.org/TR/css-color-5/ delta",
@@ -461,7 +460,7 @@
   "https://www.w3.org/TR/uievents-key/",
   "https://www.w3.org/TR/uievents/",
   "https://www.w3.org/TR/upgrade-insecure-requests/",
-  "https://www.w3.org/TR/user-timing-2/ current",
+  "https://www.w3.org/TR/user-timing-2/",
   "https://www.w3.org/TR/user-timing-3/",
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/wai-aria-1.2/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -88,22 +88,22 @@ const specs = require("../specs.json")
 
 
 // Fetch additional spec info from external sources and complete the list
-// Note on the "assign" call:
-// - `{}` is needed to avoid overriding spec
-// - `spec` appears first to impose the order of properties computed above in
-// the resulting object
-// - `specInfo[spec.shortname]` is the info we retrieved from the source
-// - final `spec` ensures that properties defined in specs.json override info
-// from the source.
 fetchInfo(specs, { w3cApiKey })
   .then(specInfo => specs.map(spec => {
+    // Note on the "assign" call:
+    // - `{}` is needed to avoid overriding spec
+    // - `spec` appears first to impose the order of properties computed above
+    // in the resulting object
+    // - `specInfo[spec.shortname]` is the info we retrieved from the source
+    // - final `spec` ensures that properties defined in specs.json override
+    // info from the source.
     const res = Object.assign({}, spec, specInfo[spec.shortname], spec);
 
     // Update the current specification based on the info returned by the
     // W3C API, unless specs.json imposed a specific level.
     // Note: the current specification returned by the W3C API may not be in the
     // list, since we tend not to include previous levels for IDL specs (even
-    // if they are still "current"), in which case, we'll just ignore the info
+    // if they are still "current"), in which case we'll just ignore the info
     // returned from the W3C API.
     const currentSpecification = specInfo.__current ?
       specInfo.__current[spec.series.shortname] : null;

--- a/src/compute-currentlevel.js
+++ b/src/compute-currentlevel.js
@@ -39,6 +39,7 @@ module.exports = function (spec, list) {
   }, spec);
   
   return {
-    currentSpecification: current.shortname
+    currentSpecification: current.shortname,
+    forceCurrent: current.forceCurrent
   };
 };

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -129,9 +129,8 @@ async function fetchInfoFromW3CApi(specs, options) {
 
   // Fetch info on the series
   const seriesShortnames = [...new Set(
-    Object.values(results)
-      .map(spec => spec.series)
-      .map(series => series.shortname))];
+    Object.values(results).map(spec => spec.series.shortname)
+  )];
   const seriesInfo = await Promise.all(seriesShortnames.map(async shortname => {
     const url = `https://api.w3.org/specification-series/${shortname}`;
     return new Promise((resolve, reject) => {

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -43,7 +43,6 @@
 
 const https = require("https");
 
-
 async function fetchInfoFromW3CApi(specs, options) {
   // Cannot query the W3C API if API key was not given
   if (!options || !options.w3cApiKey) {
@@ -87,7 +86,7 @@ async function fetchInfoFromW3CApi(specs, options) {
             resolve(JSON.parse(data));
           }
           catch (err) {
-            reject("Specref returned invalid JSON");
+            reject("W3C API returned invalid JSON");
           }
         });
       });
@@ -115,13 +114,59 @@ async function fetchInfoFromW3CApi(specs, options) {
       const nightly = info[idx]["editor-draft"] ?
         info[idx]["editor-draft"].replace(/^http:/, 'https:') :
         null;
+
+      const seriesUrl = info[idx]._links.series.href;
+      const seriesShortname = seriesUrl.substring(seriesUrl.lastIndexOf('/') + 1);
+
       results[spec.shortname] = {
+        series: { shortname: seriesShortname },
         release: { url: release },
         nightly: { url: nightly },
         title: info[idx].title
       };
     }
   });
+
+  // Fetch info on the series
+  const seriesShortnames = [...new Set(
+    Object.values(results)
+      .map(spec => spec.series)
+      .map(series => series.shortname))];
+  const seriesInfo = await Promise.all(seriesShortnames.map(async shortname => {
+    const url = `https://api.w3.org/specification-series/${shortname}`;
+    return new Promise((resolve, reject) => {
+      const request = https.get(url, options, res => {
+        if (res.statusCode === 404) {
+          resolve(null);
+        }
+        if (res.statusCode !== 200) {
+          reject(`W3C API returned an error, status code is ${res.statusCode}`);
+          return;
+        }
+        res.setEncoding("utf8");
+        let data = "";
+        res.on("data", chunk => data += chunk);
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          }
+          catch (err) {
+            reject("W3C API returned invalid JSON");
+          }
+        });
+      });
+      request.on("error", err => reject(err));
+      request.end();
+    });
+  }));
+
+  results.__current = {};
+  seriesInfo.forEach(info => {
+    const currSpecUrl = info._links["current-specification"].href;
+    const currSpec = currSpecUrl.substring(currSpecUrl.lastIndexOf('/') + 1);
+    results.__current[info.shortname] = currSpec;
+  });
+
   return results;
 }
 
@@ -287,6 +332,9 @@ async function fetchInfo(specs, options) {
     (w3cInfo[name] ? Object.assign(w3cInfo[name], { source: "w3c" }) : null) ||
     (specrefInfo[name] ? Object.assign(specrefInfo[name], { source: "specref" }) : null) ||
     (specInfo[name] ? Object.assign(specInfo[name], { source: "spec" }) : null));
+
+  // Add current specification info from W3C API
+  results.__current = w3cInfo.__current;
 
   return results;
 }

--- a/test/fetch-info-w3c.js
+++ b/test/fetch-info-w3c.js
@@ -44,6 +44,9 @@ describe("fetch-info module (with W3C API key)", function () {
       assert.equal(info[spec.shortname].release.url, spec.url);
       assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/hr-time/");
       assert.equal(info[spec.shortname].title, "High Resolution Time Level 2");
+
+      assert.ok(info.__current);
+      assert.equal(info.__current["hr-time"], "hr-time-2");
     });
 
     it("can operate on multiple specs at once", async () => {
@@ -61,6 +64,10 @@ describe("fetch-info module (with W3C API key)", function () {
       assert.equal(info[other.shortname].release.url, other.url);
       assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
       assert.equal(info[other.shortname].title, "Presentation API");
+
+      assert.ok(info.__current);
+      assert.equal(info.__current["hr-time"], "hr-time-2");
+      assert.equal(info.__current["presentation-api"], "presentation-api");
     });
 
     it("throws when W3C API key is invalid", async () => {


### PR DESCRIPTION
Fixes #176.

The current specification in a series of specifications was the last level that was not a delta spec, unless otherwise specified in specs.json.

This update extends the definition as follows: for W3C specifications, the current specification becomes the one returned by the W3C API, unless otherwise specified in specs.json, and provided that the current specification returned by the W3C API is in the list.

In turn, this allows us to drop the manual "current" entries in specs.json. They are no longer needed, the W3C API returns the right info for them.

This will trigger one change in the resulting index: the current specification for Compositing and Blending will become Level 1. It used to be Level 2, but Level 2 has not been published as a /TR/ draft yet, so it makes sense to me to have Level 1 as the current specification. I note that this is not fully aligned with what the unversioned ED URL returns though, since https://drafts.fxtf.org/compositing/ returns Level 2.

One possible update that we could consider is to make sure that, for /TR/ specs, we always have the current specification in browser-specs. This would require adding the following specifications that are the current ones of more recent ones in browser-specs:
- [`accname-1.1`](https://www.w3.org/TR/accname-1.1/)
- [`core-aam-1.1`](https://www.w3.org/TR/core-aam-1.1/)
- [`hr-time-2`](https://www.w3.org/TR/hr-time-2/)
- [`navigation-timing`](https://www.w3.org/TR/navigation-timing/)
- [`pointerevents2`](https://www.w3.org/TR/pointerevents2/)
- [`pointerlock`](https://www.w3.org/TR/pointerlock/)
- [`resource-timing-1`](https://www.w3.org/TR/resource-timing-1/)
- [`wai-aria-1.1`](https://www.w3.org/TR/wai-aria-1.1/)
- [`webauthn-1`](https://www.w3.org/TR/webauthn-1/)
- [`WOFF`](https://www.w3.org/TR/WOFF/)

I'm not convinced that's really needed.