### PR TITLE
Fix relative link to find-specs script

### DIFF
--- a/.github/candidate-specs.md
+++ b/.github/candidate-specs.md
@@ -3,7 +3,7 @@ title: New specs for review
 assignees: tidoust, dontcallmedom
 labels: enhancement
 ---
-[find-specs](src/find-specs.js) has identified the following candidates as potential new specs to consider:
+[find-specs](../blob/master/src/find-specs.js) has identified the following candidates as potential new specs to consider:
 
 {{ env.candidate_list }}
 

--- a/.github/candidate-specs.md
+++ b/.github/candidate-specs.md
@@ -7,4 +7,4 @@ labels: enhancement
 
 {{ env.candidate_list }}
 
-Please review if they match the inclusion criteria. Those that don't and never will should be added to [ignore.json](src/data/ignore.json), those that don't match yet but may in the future can be added to [monitor-repo.json](src/data/monitor-repos.json), and those that do match should be brought as a pull request on [specs.json](specs.json).
+Please review if they match the inclusion criteria. Those that don't and never will should be added to [ignore.json](../blob/master/src/data/ignore.json), those that don't match yet but may in the future can be added to [monitor-repo.json](../blob/master/src/data/monitor-repos.json), and those that do match should be brought as a pull request on [specs.json](../blob/master/specs.json).


### PR DESCRIPTION
Link is currently broken, see for example https://github.com/w3c/browser-specs/issues/188