### PR TITLE
Add periodic check on base URL

### DIFF
--- a/.github/incorrect-base-url.md
+++ b/.github/incorrect-base-url.md
@@ -1,0 +1,10 @@
+---
+title: New specs for review
+assignees: tidoust, dontcallmedom
+labels: bug
+---
+[check-base-url](../blob/master/src/check-base-url.js) has detected that the base URL of the following specifications is not the expected one:
+
+{{ env.check_list }}
+
+Please review the above list. For each specification, consider updating the URL in [specs.json](../blob/master/specs.json) or fixing the info at the source (the W3C API, Specref, or the spec itself). If the discrepancy seems warranted, the specification should be hardcoded as an exception to the rule in the [check-base-url](../blob/master/src/check-base-url.js) script.

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -1,0 +1,23 @@
+name: Check base URL
+
+on:
+  schedule:
+    - cron: '30 0 * * 1'
+jobs:
+  find-specs:
+    name: Check base URL
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: node src/check-base-url.js # sets check_list env variable
+    - uses: JasonEtco/create-an-issue@v2
+      if: ${{ env.check_list }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: .github/incorrect-base-url.md

--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -1,0 +1,28 @@
+/**
+ * CLI tool that parses the generated index of specifications to make sure that
+ * the base URL either matches the release URL if there is one, or the nightly
+ * URL otherwise.
+ *
+ * The CLI tool returns Markdown that can typically be used to create an issue.
+ * It also sets a check_list environment variable that can be used in GitHub
+ * actions.
+ *
+ * No content is returned when everything looks good.
+ */
+
+const core = require("@actions/core");
+const specs = require("../index.json");
+
+const problems = specs
+  .filter(s => (s.release && s.url !== s.release.url) || (!s.release && s.url !== s.nightly.url))
+  .map(s => {
+    const expected = s.release ? "release" : "nightly";
+    const expectedUrl = s.release ? s.release.url : s.nightly.url;
+    return `- [ ] [${s.title}](${s.url}): expected ${expected} URL [${expectedUrl}](${expectedUrl}) but base URL is [${s.url}](${s.url})`;
+  });
+
+if (problems.length > 0) {
+  const res = problems.join("\n");
+  core.exportVariable("check_list", res);
+  console.log(res);
+}

--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -18,7 +18,7 @@ const problems = specs
   .map(s => {
     const expected = s.release ? "release" : "nightly";
     const expectedUrl = s.release ? s.release.url : s.nightly.url;
-    return `- [ ] [${s.title}](${s.url}): expected ${expected} URL [${expectedUrl}](${expectedUrl}) but base URL is [${s.url}](${s.url})`;
+    return `- [ ] [${s.title}](${s.url}): expected ${expected} URL ${expectedUrl} but base URL is ${s.url}`;
   });
 
 if (problems.length > 0) {


### PR DESCRIPTION
The base URL of a specification should either match its release URL if there is one or its nightly URL otherwise.

This update adds a `check-base-url` script and a weekly GitHub action, run on Mondays at 00:30 (to avoid collision with the monitor action), to make sure that this is actually the case. The action creates an issue when there are specifications to check.

Cancels and replaces #72.