### PR TITLE
Bump version of create-pull-request GitHub action

### DIFF
--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: 12.x
     - run: npm install
     - run: node src/monitor-specs.js # sets review_list env variable
-    - uses: peter-evans/create-pull-request@v2
+    - uses: peter-evans/create-pull-request@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -21,7 +21,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         filename: .github/candidate-specs.md
-    - uses: peter-evans/create-pull-request@v2
+    - uses: peter-evans/create-pull-request@v3
       if: ${{ env.monitor_list }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v2 uses `set-env` commands which have been deprecated from GitHub:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

The action fails as a reusult (even though it still manages to create a PR somehow).