### PR TITLE
Move dependencies to developer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "ajv": "^6.11.0",
     "auto-changelog": "^1.16.4",
     "mocha": "^7.0.0",
-    "release-it": "^13.5.1"
-  },
-  "dependencies": {
+    "release-it": "^13.5.1",
     "@actions/core": "^1.2.6",
     "jsdom": "^16.2.2",
     "node-fetch": "^2.6.1"


### PR DESCRIPTION
The published package only contains the index.json file and should not have any direct dependencies.