### PR TITLE
Drop useless imports in index.js script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 "use strict";
 
-const computeShortname = require("./src/compute-shortname.js");
-const computePrevNext = require("./src/compute-prevnext.js");
-const computeCurrentLevel = require("./src/compute-currentlevel.js");
 const specs = require("./index.json");
 
 


### PR DESCRIPTION
Not sure how they ended up in there, but these lines are useless.