### PR TITLE
Define short title for webauthn explicitly

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -481,7 +481,10 @@
   "https://www.w3.org/TR/web-animations-1/",
   "https://www.w3.org/TR/web-share/",
   "https://www.w3.org/TR/webaudio/",
-  "https://www.w3.org/TR/webauthn-2/",
+  {
+    "url": "https://www.w3.org/TR/webauthn-2/",
+    "shortTitle": "Web Authentication"
+  },
   "https://www.w3.org/TR/WebCryptoAPI/",
   "https://www.w3.org/TR/webdriver2/",
   "https://www.w3.org/TR/WebIDL-1/",


### PR DESCRIPTION
Automatically generated short title is:
"Web Authentication: An API for accessing Public Key Credentials: 2"

This update shortens is to "Web Authentication". No level indication since we
don't have any other levels in the list.

Close #197.