### PR TITLE
Expose path to source of nightly spec in sourcePath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         npm ci
     - name: Build new index file
       run: npm run build
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Commit updates
       run: |
         git config user.name "fetch-info bot"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,11 @@ property in `index.json`.
 property in `index.json`. The property must only be set for delta spec (since
 full is the default).
 - `nightly`: same as the [`nightly`](README.md#nightly) property in
-`index.json`. The property must only be set when the URL of the nightly spec
-returned by external sources would be wrong **and** when it cannot be fixed at
-the source.
+`index.json`. The property must only be set when:
+  - The URL of the nightly spec returned by external sources would be wrong
+    **and** when it cannot be fixed at the source.
+  - The code cannot compute the right [`sourcePath`](README.md#nightlysourcepath)
+    because the source file of the nightly spec does not follow a common pattern.
 - `shortTitle`: same as the [`shortTitle`](README.md#shorttitle) property in
 `index.json`. The property must only be set when the short title computed
 automatically is not the expected one.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cross-references, WebIDL, quality, etc.
     - [`nightly.filename`](#nightlyfilename)
     - [`nightly.pages`](#nightlypages)
     - [`nightly.repository`](#nightlyrepository)
+    - [`nightly.sourcePath`](#nightlysourcepath)
   - [`source`](#source)
 - [How to add/update/delete a spec](#how-to-addupdatedelete-a-spec)
 - [Spec selection criteria](#spec-selection-criteria)
@@ -94,7 +95,8 @@ Each specification in the list comes with the following properties:
   "nightly": {
     "url": "https://drafts.csswg.org/css-color/",
     "repository": "https://github.com/w3c/csswg-drafts",
-    "filename": "Overview.html"
+    "filename": "Overview.html",
+    "sourcePath": "css-color-4/Overview.bs"
   },
   "source": "w3c"
 }
@@ -296,6 +298,22 @@ computed from `nightly.url`.
 The `repository` property is always set.
 
 
+#### `nightly.sourcePath`
+
+The relative path to the filename that contains the source of the Editor's Draft
+or of the living standard at the HEAD of the default branch of the repository.
+
+That path is computed by parsing the contents of the repository for common
+patterns. The info must be specified in `specs.json` for specifications that do
+not follow a common pattern.
+
+The `sourcePath` property is always set.
+
+**Note:** The path is relative to the root of the repository, and only valid in
+the default branch of the repository. If needed, the source may be fetched from
+the absolute HTTPS URL `${nightly.repository}/blob/HEAD/${nightly.sourcePath}`.
+
+
 ### `source`
 
 The provenance for the `title` and `nightly` property values. Can be one of:
@@ -376,7 +394,9 @@ npm run build
 **Important:** The generation process will try to retrieve information about W3C
 specification from the W3C API. For that to work, the code requires the presence
 of a `config.json` file in the root folder with a `w3cApiKey` field set to a
-valid [W3C API key](https://w3c.github.io/w3c-api/).
+valid [W3C API key](https://w3c.github.io/w3c-api/) and a `githubToken` field
+set to a valid [GitHub Personal Token](https://github.com/settings/tokens)
+(default read permissions are enough).
 
 
 ### Tests

--- a/index.json
+++ b/index.json
@@ -6063,15 +6063,15 @@
       "shortname": "mediacapture-streams",
       "currentSpecification": "mediacapture-streams"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/mediacapture-main/",
+      "sourcePath": "getusermedia.html",
+      "repository": "https://github.com/w3c/mediacapture-main",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/mediacapture-streams/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/mediacapture-main/",
-      "repository": "https://github.com/w3c/mediacapture-main",
-      "sourcePath": "index.html",
-      "filename": "index.html"
     },
     "title": "Media Capture and Streams",
     "source": "w3c",
@@ -7834,7 +7834,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-stats/",
       "repository": "https://github.com/w3c/webrtc-stats",
-      "sourcePath": "index.html",
+      "sourcePath": "webrtc-stats.html",
       "filename": "index.html"
     },
     "title": "Identifiers for WebRTC's Statistics API",
@@ -7878,7 +7878,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-pc/",
       "repository": "https://github.com/w3c/webrtc-pc",
-      "sourcePath": "index.html",
+      "sourcePath": "webrtc.html",
       "filename": "index.html"
     },
     "title": "WebRTC 1.0: Real-Time Communication Between Browsers",

--- a/index.json
+++ b/index.json
@@ -6063,15 +6063,15 @@
       "shortname": "mediacapture-streams",
       "currentSpecification": "mediacapture-streams"
     },
-    "nightly": {
-      "url": "https://w3c.github.io/mediacapture-main/",
-      "sourcePath": "getusermedia.html",
-      "repository": "https://github.com/w3c/mediacapture-main",
-      "filename": "index.html"
-    },
     "release": {
       "url": "https://www.w3.org/TR/mediacapture-streams/",
       "filename": "Overview.html"
+    },
+    "nightly": {
+      "url": "https://w3c.github.io/mediacapture-main/",
+      "repository": "https://github.com/w3c/mediacapture-main",
+      "sourcePath": "getusermedia.html",
+      "filename": "index.html"
     },
     "title": "Media Capture and Streams",
     "source": "w3c",
@@ -7352,15 +7352,15 @@
       "shortname": "uievents-code",
       "currentSpecification": "uievents-code"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/uievents-code/",
+      "sourcePath": "index-source.txt",
+      "repository": "https://github.com/w3c/uievents-code",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/uievents-code/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/uievents-code/",
-      "repository": "https://github.com/w3c/uievents-code",
-      "sourcePath": "index.html",
-      "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent code Values",
     "source": "w3c",
@@ -7374,15 +7374,15 @@
       "shortname": "uievents-key",
       "currentSpecification": "uievents-key"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/uievents-key/",
+      "sourcePath": "index-source.txt",
+      "repository": "https://github.com/w3c/uievents-key",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/uievents-key/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/uievents-key/",
-      "repository": "https://github.com/w3c/uievents-key",
-      "sourcePath": "index.html",
-      "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent key Values",
     "source": "w3c",

--- a/index.json
+++ b/index.json
@@ -9,6 +9,7 @@
     },
     "nightly": {
       "url": "https://compat.spec.whatwg.org/",
+      "sourcePath": "compatibility.bs",
       "repository": "https://github.com/whatwg/compat",
       "filename": "index.html"
     },
@@ -27,6 +28,7 @@
     "nightly": {
       "url": "https://console.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/console",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Console Standard",
@@ -44,6 +46,7 @@
     "nightly": {
       "url": "https://dom.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/dom",
+      "sourcePath": "dom.bs",
       "filename": "index.html"
     },
     "title": "DOM Standard",
@@ -63,6 +66,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-typed-om-2/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-typed-om-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Typed OM Level 2",
@@ -81,6 +85,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "font-metrics-api/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Font Metrics API Level 1",
@@ -100,6 +105,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-animations-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-animations-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Animations Level 2",
@@ -119,6 +125,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-backgrounds-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-backgrounds-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Backgrounds and Borders Module Level 4",
@@ -139,6 +146,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-cascade-5/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-cascade-5/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 5",
@@ -156,6 +164,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-env-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-env-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Environment Variables Module Level 1",
@@ -174,6 +183,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-extensions-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-extensions-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Extensions",
@@ -194,6 +204,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-gcpm-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-gcpm-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module Level 4",
@@ -212,6 +223,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-grid-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-grid-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Grid Layout Module Level 3",
@@ -232,6 +244,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-multicol-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-multicol-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 2",
@@ -249,6 +262,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-nesting-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-nesting-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Nesting Module",
@@ -268,6 +282,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-page-4/Overview.src.html",
       "filename": "Overview.html"
     },
     "title": "Proposals for the future of CSS Paged Media",
@@ -287,6 +302,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-shapes-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-shapes-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Shapes Module Level 2",
@@ -306,6 +322,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-size-adjust-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-size-adjust-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Mobile Text Size Adjustment Module Level 1",
@@ -324,6 +341,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-transitions-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-transitions-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Transitions Level 2",
@@ -342,6 +360,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/scroll-animations-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "scroll-animations-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Scroll-linked Animations",
@@ -362,6 +381,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/compositing-2/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "compositing-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 2",
@@ -380,6 +400,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/filter-effects-2/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "filter-effects-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Filter Effects Module Level 2",
@@ -397,6 +418,7 @@
     "nightly": {
       "url": "https://fetch.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/fetch",
+      "sourcePath": "fetch.bs",
       "filename": "index.html"
     },
     "title": "Fetch Standard",
@@ -414,6 +436,7 @@
     "nightly": {
       "url": "https://fullscreen.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/fullscreen",
+      "sourcePath": "fullscreen.bs",
       "filename": "index.html"
     },
     "title": "Fullscreen API Standard",
@@ -431,6 +454,7 @@
     "nightly": {
       "url": "https://gpuweb.github.io/gpuweb/",
       "repository": "https://github.com/gpuweb/gpuweb",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "WebGPU",
@@ -447,6 +471,7 @@
     },
     "nightly": {
       "url": "https://html.spec.whatwg.org/multipage/",
+      "sourcePath": "source",
       "repository": "https://github.com/whatwg/html",
       "pages": [
         "https://html.spec.whatwg.org/multipage/introduction.html",
@@ -526,6 +551,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/anchors/",
       "repository": "https://github.com/immersive-web/anchors",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Anchors Module",
@@ -543,6 +569,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/dom-overlays/",
       "repository": "https://github.com/immersive-web/dom-overlays",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR DOM Overlays Module",
@@ -560,6 +587,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/hit-test/",
       "repository": "https://github.com/immersive-web/hit-test",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Hit Test Module",
@@ -577,6 +605,7 @@
     "nightly": {
       "url": "https://infra.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/infra",
+      "sourcePath": "infra.bs",
       "filename": "index.html"
     },
     "title": "Infra Standard",
@@ -594,6 +623,7 @@
     "nightly": {
       "url": "https://mathml-refresh.github.io/mathml-core/",
       "repository": "https://github.com/mathml-refresh/mathml-core",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "MathML Core",
@@ -611,6 +641,7 @@
     "nightly": {
       "url": "https://mimesniff.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/mimesniff",
+      "sourcePath": "mimesniff.bs",
       "filename": "index.html"
     },
     "title": "MIME Sniffing Standard",
@@ -628,6 +659,7 @@
     "nightly": {
       "url": "https://notifications.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/notifications",
+      "sourcePath": "notifications.bs",
       "filename": "index.html"
     },
     "title": "Notifications API Standard",
@@ -645,6 +677,7 @@
     "nightly": {
       "url": "https://privacycg.github.io/private-click-measurement/",
       "repository": "https://github.com/privacycg/private-click-measurement",
+      "sourcePath": "private-click-measurement.bs",
       "filename": "index.html"
     },
     "title": "Private Click Measurement",
@@ -662,6 +695,7 @@
     "nightly": {
       "url": "https://privacycg.github.io/storage-access/",
       "repository": "https://github.com/privacycg/storage-access",
+      "sourcePath": "storage-access.bs",
       "filename": "index.html"
     },
     "title": "The Storage Access API",
@@ -679,6 +713,7 @@
     "nightly": {
       "url": "https://quirks.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/quirks",
+      "sourcePath": "quirks.bs",
       "filename": "index.html"
     },
     "title": "Quirks Mode Standard",
@@ -696,6 +731,7 @@
     "nightly": {
       "url": "https://storage.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/storage",
+      "sourcePath": "storage.bs",
       "filename": "index.html"
     },
     "title": "Storage Standard",
@@ -713,6 +749,7 @@
     "nightly": {
       "url": "https://streams.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/streams",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Streams Standard",
@@ -730,6 +767,7 @@
     "nightly": {
       "url": "https://svgwg.org/specs/animations/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "specs/animations/master/Overview.html",
       "filename": "Overview.html"
     },
     "title": "SVG Animations Level 2",
@@ -748,6 +786,7 @@
     "nightly": {
       "url": "https://tc39.es/ecma262/",
       "repository": "https://github.com/tc39/ecma262",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "ECMAScript Language Specification",
@@ -764,6 +803,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-atomics-wait-async/",
       "repository": "https://github.com/tc39/proposal-atomics-wait-async",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Atomics.waitAsync",
@@ -781,6 +821,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-class-fields/",
       "repository": "https://github.com/tc39/proposal-class-fields",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Public and private instance fields proposal",
@@ -798,6 +839,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-import-assertions/",
       "repository": "https://github.com/tc39/proposal-import-assertions",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "import assertions",
@@ -815,6 +857,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-private-methods/",
       "repository": "https://github.com/tc39/proposal-private-methods",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Private Methods and Accessors Proposal",
@@ -832,6 +875,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-regexp-match-indices/",
       "repository": "https://github.com/tc39/proposal-regexp-match-indices",
+      "sourcePath": "spec/index.html",
       "filename": "index.html"
     },
     "title": "RegExp Match Indices",
@@ -849,6 +893,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-relative-indexing-method/",
       "repository": "https://github.com/tc39/proposal-relative-indexing-method",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Relative Indexing Method",
@@ -866,6 +911,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-static-class-features/",
       "repository": "https://github.com/tc39/proposal-static-class-features",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Static class features",
@@ -883,6 +929,7 @@
     "nightly": {
       "url": "https://tc39.es/proposal-top-level-await/",
       "repository": "https://github.com/tc39/proposal-top-level-await",
+      "sourcePath": "spec.html",
       "filename": "index.html"
     },
     "title": "Top-Level Await",
@@ -900,6 +947,7 @@
     "nightly": {
       "url": "https://url.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/url",
+      "sourcePath": "url.bs",
       "filename": "index.html"
     },
     "title": "URL Standard",
@@ -917,6 +965,7 @@
     "nightly": {
       "url": "https://w3c.github.io/badging/",
       "repository": "https://github.com/w3c/badging",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Badging API",
@@ -934,6 +983,7 @@
     "nightly": {
       "url": "https://w3c.github.io/contentEditable/",
       "repository": "https://github.com/w3c/contentEditable",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "ContentEditable",
@@ -951,6 +1001,7 @@
     "nightly": {
       "url": "https://w3c.github.io/gamepad/extensions.html",
       "repository": "https://github.com/w3c/gamepad",
+      "sourcePath": "extensions.html",
       "filename": "extensions.html"
     },
     "title": "Gamepad Extensions",
@@ -968,6 +1019,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mathml-aam/",
       "repository": "https://github.com/w3c/mathml-aam",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "MathML Accessiblity API Mappings 1.0",
@@ -985,6 +1037,7 @@
     "nightly": {
       "url": "https://w3c.github.io/media-playback-quality/",
       "repository": "https://github.com/w3c/media-playback-quality",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Media Playback Quality",
@@ -1002,6 +1055,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-automation/",
       "repository": "https://github.com/w3c/mediacapture-automation",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Media Capture Automation",
@@ -1019,6 +1073,7 @@
     "nightly": {
       "url": "https://w3c.github.io/screen-fold/",
       "repository": "https://github.com/w3c/screen-fold",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "The Screen Fold API",
@@ -1036,6 +1091,7 @@
     "nightly": {
       "url": "https://w3c.github.io/web-nfc/",
       "repository": "https://github.com/w3c/web-nfc",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web NFC API",
@@ -1053,6 +1109,7 @@
     "nightly": {
       "url": "https://w3c.github.io/web-share-target/",
       "repository": "https://github.com/w3c/web-share-target",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web Share Target API",
@@ -1070,6 +1127,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-change-password-url/",
       "repository": "https://github.com/w3c/webappsec-change-password-url",
+      "sourcePath": "change-password-url.bs",
       "filename": "index.html"
     },
     "title": "A Well-Known URL for Changing Passwords",
@@ -1087,6 +1145,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
       "repository": "https://github.com/w3c/webappsec-trusted-types",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "Trusted Types",
@@ -1104,6 +1163,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webdriver-bidi/",
       "repository": "https://github.com/w3c/webdriver-bidi",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebDriver BiDi",
@@ -1121,6 +1181,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-ice/",
       "repository": "https://github.com/w3c/webrtc-ice",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "IceTransport Extensions for WebRTC",
@@ -1138,6 +1199,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-insertable-streams/",
       "repository": "https://github.com/w3c/webrtc-insertable-streams",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebRTC Insertable Media using Streams",
@@ -1155,6 +1217,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webtransport/",
       "repository": "https://github.com/w3c/webtransport",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebTransport",
@@ -1172,6 +1235,7 @@
     "nightly": {
       "url": "https://webbluetoothcg.github.io/web-bluetooth/",
       "repository": "https://github.com/WebBluetoothCG/web-bluetooth",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Bluetooth",
@@ -1189,6 +1253,7 @@
     "nightly": {
       "url": "https://wicg.github.io/background-fetch/",
       "repository": "https://github.com/WICG/background-fetch",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Background Fetch",
@@ -1207,6 +1272,7 @@
     "nightly": {
       "url": "https://wicg.github.io/background-sync/spec/",
       "repository": "https://github.com/WICG/background-sync",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "Web Background Synchronization",
@@ -1223,6 +1289,7 @@
     "nightly": {
       "url": "https://wicg.github.io/client-hints-infrastructure/",
       "repository": "https://github.com/WICG/client-hints-infrastructure",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Client Hints Infrastructure",
@@ -1240,6 +1307,7 @@
     "nightly": {
       "url": "https://wicg.github.io/compression/",
       "repository": "https://github.com/WICG/compression",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Compression Streams",
@@ -1257,6 +1325,7 @@
     "nightly": {
       "url": "https://wicg.github.io/construct-stylesheets/",
       "repository": "https://github.com/WICG/construct-stylesheets",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Constructable Stylesheet Objects",
@@ -1274,6 +1343,7 @@
     "nightly": {
       "url": "https://wicg.github.io/contact-api/spec/",
       "repository": "https://github.com/WICG/contact-api",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "Contact Picker API",
@@ -1291,6 +1361,7 @@
     "nightly": {
       "url": "https://wicg.github.io/content-index/spec/",
       "repository": "https://github.com/WICG/content-index",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "Content Index",
@@ -1308,6 +1379,7 @@
     "nightly": {
       "url": "https://wicg.github.io/cookie-store/",
       "repository": "https://github.com/WICG/cookie-store",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Cookie Store API",
@@ -1325,6 +1397,7 @@
     "nightly": {
       "url": "https://wicg.github.io/cors-rfc1918/",
       "repository": "https://github.com/WICG/cors-rfc1918",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "CORS and RFC1918",
@@ -1342,6 +1415,7 @@
     "nightly": {
       "url": "https://wicg.github.io/crash-reporting/",
       "repository": "https://github.com/WICG/crash-reporting",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Crash Reporting",
@@ -1359,6 +1433,7 @@
     "nightly": {
       "url": "https://wicg.github.io/css-parser-api/",
       "repository": "https://github.com/WICG/css-parser-api",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "CSS Parser API",
@@ -1376,6 +1451,7 @@
     "nightly": {
       "url": "https://wicg.github.io/custom-state-pseudo-class/",
       "repository": "https://github.com/WICG/custom-state-pseudo-class",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Custom State Pseudo Class",
@@ -1393,6 +1469,7 @@
     "nightly": {
       "url": "https://wicg.github.io/deprecation-reporting/",
       "repository": "https://github.com/WICG/deprecation-reporting",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Deprecation Reporting",
@@ -1410,6 +1487,7 @@
     "nightly": {
       "url": "https://wicg.github.io/element-timing/",
       "repository": "https://github.com/WICG/element-timing",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Element Timing API",
@@ -1427,6 +1505,7 @@
     "nightly": {
       "url": "https://wicg.github.io/entries-api/",
       "repository": "https://github.com/WICG/entries-api",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "File and Directory Entries API",
@@ -1444,6 +1523,7 @@
     "nightly": {
       "url": "https://wicg.github.io/event-timing/",
       "repository": "https://github.com/WICG/event-timing",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Event Timing API",
@@ -1461,6 +1541,7 @@
     "nightly": {
       "url": "https://wicg.github.io/file-system-access/",
       "repository": "https://github.com/WICG/file-system-access",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "File System Access",
@@ -1478,6 +1559,7 @@
     "nightly": {
       "url": "https://wicg.github.io/frame-timing/",
       "repository": "https://github.com/WICG/frame-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Frame Timing",
@@ -1495,6 +1577,7 @@
     "nightly": {
       "url": "https://wicg.github.io/get-installed-related-apps/spec/",
       "repository": "https://github.com/WICG/get-installed-related-apps",
+      "sourcePath": "spec/index.bs",
       "filename": "index.html"
     },
     "title": "Get Installed Related Apps API",
@@ -1512,6 +1595,7 @@
     "nightly": {
       "url": "https://wicg.github.io/idle-detection/",
       "repository": "https://github.com/WICG/idle-detection",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Idle Detection API",
@@ -1529,6 +1613,7 @@
     "nightly": {
       "url": "https://wicg.github.io/import-maps/",
       "repository": "https://github.com/WICG/import-maps",
+      "sourcePath": "spec.bs",
       "filename": "index.html"
     },
     "title": "Import Maps",
@@ -1546,6 +1631,7 @@
     "nightly": {
       "url": "https://wicg.github.io/input-device-capabilities/",
       "repository": "https://github.com/WICG/input-device-capabilities",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Input Device Capabilities",
@@ -1563,6 +1649,7 @@
     "nightly": {
       "url": "https://wicg.github.io/intervention-reporting/",
       "repository": "https://github.com/WICG/intervention-reporting",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Intervention Reporting",
@@ -1580,6 +1667,7 @@
     "nightly": {
       "url": "https://wicg.github.io/is-input-pending/",
       "repository": "https://github.com/WICG/is-input-pending",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "isInputPending",
@@ -1597,6 +1685,7 @@
     "nightly": {
       "url": "https://wicg.github.io/js-self-profiling/",
       "repository": "https://github.com/WICG/js-self-profiling",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "JS Self-Profiling API",
@@ -1614,6 +1703,7 @@
     "nightly": {
       "url": "https://wicg.github.io/keyboard-lock/",
       "repository": "https://github.com/WICG/keyboard-lock",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Keyboard Lock",
@@ -1631,6 +1721,7 @@
     "nightly": {
       "url": "https://wicg.github.io/keyboard-map/",
       "repository": "https://github.com/WICG/keyboard-map",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Keyboard Map",
@@ -1648,6 +1739,7 @@
     "nightly": {
       "url": "https://wicg.github.io/largest-contentful-paint/",
       "repository": "https://github.com/WICG/largest-contentful-paint",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Largest Contentful Paint",
@@ -1665,6 +1757,7 @@
     "nightly": {
       "url": "https://wicg.github.io/layout-instability/",
       "repository": "https://github.com/WICG/layout-instability",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Layout Instability",
@@ -1682,6 +1775,7 @@
     "nightly": {
       "url": "https://wicg.github.io/local-font-access/",
       "repository": "https://github.com/WICG/local-font-access",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Local Font Access API",
@@ -1699,6 +1793,7 @@
     "nightly": {
       "url": "https://wicg.github.io/media-feeds/",
       "repository": "https://github.com/WICG/media-feeds",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Media Feeds",
@@ -1716,6 +1811,7 @@
     "nightly": {
       "url": "https://wicg.github.io/netinfo/",
       "repository": "https://github.com/WICG/netinfo",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Network Information API",
@@ -1733,6 +1829,7 @@
     "nightly": {
       "url": "https://wicg.github.io/origin-policy/",
       "repository": "https://github.com/WICG/origin-policy",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Origin Policy",
@@ -1750,6 +1847,7 @@
     "nightly": {
       "url": "https://wicg.github.io/overscroll-scrollend-events/",
       "repository": "https://github.com/WICG/overscroll-scrollend-events",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "overscroll and scrollend events",
@@ -1767,6 +1865,7 @@
     "nightly": {
       "url": "https://wicg.github.io/page-lifecycle/",
       "repository": "https://github.com/WICG/page-lifecycle",
+      "sourcePath": "spec.bs",
       "filename": "index.html"
     },
     "title": "Page Lifecycle",
@@ -1784,6 +1883,7 @@
     "nightly": {
       "url": "https://wicg.github.io/performance-measure-memory/",
       "repository": "https://github.com/WICG/performance-measure-memory",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Measure Memory API",
@@ -1801,6 +1901,7 @@
     "nightly": {
       "url": "https://wicg.github.io/periodic-background-sync/",
       "repository": "https://github.com/WICG/periodic-background-sync",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Periodic Background Synchronization",
@@ -1818,6 +1919,7 @@
     "nightly": {
       "url": "https://wicg.github.io/permissions-request/",
       "repository": "https://github.com/WICG/permissions-request",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Requesting Permissions",
@@ -1835,6 +1937,7 @@
     "nightly": {
       "url": "https://wicg.github.io/permissions-revoke/",
       "repository": "https://github.com/WICG/permissions-revoke",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Relinquishing Permissions",
@@ -1852,6 +1955,7 @@
     "nightly": {
       "url": "https://wicg.github.io/portals/",
       "repository": "https://github.com/WICG/portals",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Portals",
@@ -1869,6 +1973,7 @@
     "nightly": {
       "url": "https://wicg.github.io/priority-hints/",
       "repository": "https://github.com/WICG/priority-hints",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Priority Hints",
@@ -1886,6 +1991,7 @@
     "nightly": {
       "url": "https://wicg.github.io/savedata/",
       "repository": "https://github.com/WICG/savedata",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Save Data API",
@@ -1903,6 +2009,7 @@
     "nightly": {
       "url": "https://wicg.github.io/scroll-to-text-fragment/",
       "repository": "https://github.com/WICG/scroll-to-text-fragment",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Text Fragments",
@@ -1920,6 +2027,7 @@
     "nightly": {
       "url": "https://wicg.github.io/serial/",
       "repository": "https://github.com/WICG/serial",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web Serial API",
@@ -1937,6 +2045,7 @@
     "nightly": {
       "url": "https://wicg.github.io/shape-detection-api/",
       "repository": "https://github.com/WICG/shape-detection-api",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Accelerated Shape Detection in Images",
@@ -1954,6 +2063,7 @@
     "nightly": {
       "url": "https://wicg.github.io/shape-detection-api/text.html",
       "repository": "https://github.com/WICG/shape-detection-api",
+      "sourcePath": "text.bs",
       "filename": "text.html"
     },
     "title": "Accelerated Text Detection in Images",
@@ -1972,6 +2082,7 @@
     "nightly": {
       "url": "https://wicg.github.io/sms-one-time-codes/",
       "repository": "https://github.com/WICG/sms-one-time-codes",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Origin-bound one-time codes delivered via SMS",
@@ -1988,6 +2099,7 @@
     "nightly": {
       "url": "https://wicg.github.io/speech-api/",
       "repository": "https://github.com/WICG/speech-api",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Speech API",
@@ -2005,6 +2117,7 @@
     "nightly": {
       "url": "https://wicg.github.io/ua-client-hints/",
       "repository": "https://github.com/WICG/ua-client-hints",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "User-Agent Client Hints",
@@ -2022,6 +2135,7 @@
     "nightly": {
       "url": "https://wicg.github.io/video-rvfc/",
       "repository": "https://github.com/WICG/video-rvfc",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
@@ -2039,6 +2153,7 @@
     "nightly": {
       "url": "https://wicg.github.io/visual-viewport/",
       "repository": "https://github.com/WICG/visual-viewport",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Visual Viewport API",
@@ -2056,6 +2171,7 @@
     "nightly": {
       "url": "https://wicg.github.io/web-codecs/",
       "repository": "https://github.com/WICG/web-codecs",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "WebCodecs",
@@ -2073,6 +2189,7 @@
     "nightly": {
       "url": "https://wicg.github.io/web-locks/",
       "repository": "https://github.com/WICG/web-locks",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Locks API",
@@ -2090,6 +2207,7 @@
     "nightly": {
       "url": "https://wicg.github.io/web-otp/",
       "repository": "https://github.com/WICG/web-otp",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web OTP API",
@@ -2107,6 +2225,7 @@
     "nightly": {
       "url": "https://wicg.github.io/webhid/",
       "repository": "https://github.com/WICG/webhid",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "WebHID API",
@@ -2124,6 +2243,7 @@
     "nightly": {
       "url": "https://wicg.github.io/webpackage/loading.html",
       "repository": "https://github.com/WICG/webpackage",
+      "sourcePath": "loading.bs",
       "filename": "loading.html"
     },
     "title": "Loading Signed Exchanges",
@@ -2141,6 +2261,7 @@
     "nightly": {
       "url": "https://wicg.github.io/webusb/",
       "repository": "https://github.com/WICG/webusb",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebUSB API",
@@ -2158,6 +2279,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/ANGLE_instanced_arrays/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL ANGLE_instanced_arrays Khronos Ratified Extension Specification",
@@ -2175,6 +2297,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_blend_minmax/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_blend_minmax Khronos Ratified Extension Specification",
@@ -2192,6 +2315,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_clip_cull_distance/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_clip_cull_distance/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_clip_cull_distance Extension Draft Specification",
@@ -2209,6 +2333,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_color_buffer_float/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_color_buffer_float Extension Specification",
@@ -2226,6 +2351,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_color_buffer_half_float/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_color_buffer_half_float Extension Specification",
@@ -2244,6 +2370,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_disjoint_timer_query_webgl2/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_disjoint_timer_query_webgl2 Extension Specification",
@@ -2261,6 +2388,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_disjoint_timer_query/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_disjoint_timer_query Extension Specification",
@@ -2278,6 +2406,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_float_blend/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_float_blend Extension Specification",
@@ -2295,6 +2424,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_frag_depth/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_frag_depth Khronos Ratified Extension Specification",
@@ -2312,6 +2442,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_shader_texture_lod/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_shader_texture_lod Khronos Ratified Extension Specification",
@@ -2329,6 +2460,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_sRGB/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_sRGB Extension Specification",
@@ -2346,6 +2478,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_texture_compression_bptc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_texture_compression_bptc Extension Specification",
@@ -2363,6 +2496,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_texture_compression_rgtc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_texture_compression_rgtc Extension Specification",
@@ -2380,6 +2514,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_texture_filter_anisotropic/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_texture_filter_anisotropic Khronos Ratified Extension Specification",
@@ -2398,6 +2533,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/EXT_texture_norm16/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL EXT_texture_norm16 Extension Specification",
@@ -2415,6 +2551,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/KHR_parallel_shader_compile/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL KHR_parallel_shader_compile Extension Specification",
@@ -2432,6 +2569,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_draw_buffers_indexed/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_draw_buffers_indexed/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_draw_buffers_indexed Extension Draft Specification",
@@ -2449,6 +2587,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_element_index_uint/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_element_index_uint Khronos Ratified Extension Specification",
@@ -2466,6 +2605,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_fbo_render_mipmap/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_fbo_render_mipmap Extension Specification",
@@ -2483,6 +2623,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_standard_derivatives/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_standard_derivatives Khronos Ratified Extension Specification",
@@ -2500,6 +2641,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_texture_float_linear/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_texture_float_linear Khronos Ratified Extension Specification",
@@ -2517,6 +2659,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_texture_float/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_texture_float Khronos Ratified Extension Specification",
@@ -2534,6 +2677,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_texture_half_float_linear/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_texture_half_float_linear Khronos Ratified Extension Specification",
@@ -2551,6 +2695,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_texture_half_float/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_texture_half_float Khronos Ratified Extension Specification",
@@ -2568,6 +2713,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OES_vertex_array_object/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OES_vertex_array_object Khronos Ratified Extension Specification",
@@ -2586,6 +2732,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/OVR_multiview2/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL OVR_multiview2 Extension Specification",
@@ -2603,6 +2750,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_blend_equation_advanced_coherent/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_blend_equation_advanced_coherent Extension Draft Specification",
@@ -2620,6 +2768,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_color_buffer_float/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_color_buffer_float Extension Specification",
@@ -2637,6 +2786,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_astc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_astc Extension Specification",
@@ -2655,6 +2805,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_etc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_etc Extension Specification",
@@ -2674,6 +2825,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_etc1/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_etc1 Extension Specification",
@@ -2691,6 +2843,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_pvrtc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_pvrtc Extension Specification",
@@ -2708,6 +2861,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_s3tc_srgb Extension Specification",
@@ -2725,6 +2879,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_compressed_texture_s3tc/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_compressed_texture_s3tc Khronos Ratified Extension Specification",
@@ -2742,6 +2897,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_debug_renderer_info/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_debug_renderer_info Khronos Ratified Extension Specification",
@@ -2759,6 +2915,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_debug_shaders/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_debug_shaders Khronos Ratified Extension Specification",
@@ -2776,6 +2933,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_depth_texture/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_depth_texture Khronos Ratified Extension Specification",
@@ -2793,6 +2951,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_draw_buffers/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_draw_buffers Khronos Ratified Extension Specification",
@@ -2810,6 +2969,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_draw_instanced_base_vertex_base_instance Extension Draft Specification",
@@ -2827,6 +2987,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_lose_context/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_lose_context Khronos Ratified Extension Specification",
@@ -2844,6 +3005,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_multi_draw_instanced_base_vertex_base_instance Extension Draft Specification",
@@ -2861,6 +3023,7 @@
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
       "repository": "https://github.com/KhronosGroup/WebGL",
+      "sourcePath": "extensions/WEBGL_multi_draw/extension.xml",
       "filename": "index.html"
     },
     "title": "WebGL WEBGL_multi_draw Extension Specification",
@@ -2878,6 +3041,7 @@
     "seriesVersion": "1",
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
+      "sourcePath": "specs/latest/1.0/index.html",
       "repository": "https://github.com/KhronosGroup/WebGL",
       "filename": "index.html"
     },
@@ -2896,6 +3060,7 @@
     "seriesVersion": "2",
     "nightly": {
       "url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/",
+      "sourcePath": "specs/latest/2.0/index.html",
       "repository": "https://github.com/KhronosGroup/WebGL",
       "filename": "index.html"
     },
@@ -2918,6 +3083,7 @@
     "nightly": {
       "url": "https://w3c.github.io/accelerometer/",
       "repository": "https://github.com/w3c/accelerometer",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Accelerometer",
@@ -2940,6 +3106,7 @@
     "nightly": {
       "url": "https://w3c.github.io/accname/",
       "repository": "https://github.com/w3c/accname",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Accessible Name and Description Computation 1.2",
@@ -2961,6 +3128,7 @@
     "nightly": {
       "url": "https://w3c.github.io/ambient-light/",
       "repository": "https://github.com/w3c/ambient-light",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Ambient Light Sensor",
@@ -2982,6 +3150,7 @@
     "nightly": {
       "url": "https://w3c.github.io/manifest/",
       "repository": "https://github.com/w3c/manifest",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web App Manifest",
@@ -3003,6 +3172,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-output/",
       "repository": "https://github.com/w3c/mediacapture-output",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Audio Output Devices API",
@@ -3024,6 +3194,7 @@
     "nightly": {
       "url": "https://w3c.github.io/battery/",
       "repository": "https://github.com/w3c/battery",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Battery Status API",
@@ -3045,6 +3216,7 @@
     "nightly": {
       "url": "https://w3c.github.io/beacon/",
       "repository": "https://github.com/w3c/beacon",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Beacon",
@@ -3066,6 +3238,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-clear-site-data/",
       "repository": "https://github.com/w3c/webappsec-clear-site-data",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Clear Site Data",
@@ -3087,6 +3260,7 @@
     "nightly": {
       "url": "https://w3c.github.io/clipboard-apis/",
       "repository": "https://github.com/w3c/clipboard-apis",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Clipboard API and events",
@@ -3111,6 +3285,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/compositing-1/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "compositing-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 1",
@@ -3132,6 +3307,7 @@
     "nightly": {
       "url": "https://w3c.github.io/core-aam/",
       "repository": "https://github.com/w3c/core-aam",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Core Accessibility API Mappings 1.2",
@@ -3154,6 +3330,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-credential-management/",
       "repository": "https://github.com/w3c/webappsec-credential-management",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Credential Management Level 1",
@@ -3175,6 +3352,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-cspee/",
       "repository": "https://github.com/w3c/webappsec-cspee",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Content Security Policy: Embedded Enforcement",
@@ -3197,6 +3375,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-csp/",
       "repository": "https://github.com/w3c/webappsec-csp",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Content Security Policy Level 3",
@@ -3219,6 +3398,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-align/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-align-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Box Alignment Module Level 3",
@@ -3241,6 +3421,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-animationworklet-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-animation-worklet-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Animation Worklet API",
@@ -3264,6 +3445,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-animations/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-animations-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Animations Level 1",
@@ -3288,6 +3470,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-backgrounds/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-backgrounds-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Backgrounds and Borders Module Level 3",
@@ -3310,6 +3493,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-box-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-box-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Box Model Module Level 3",
@@ -3333,6 +3517,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-box-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-box-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Box Model Module Level 4",
@@ -3356,6 +3541,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-break/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-break-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Fragmentation Module Level 3",
@@ -3379,6 +3565,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-break-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-break-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Fragmentation Module Level 4",
@@ -3403,6 +3590,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-cascade-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-cascade-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 3",
@@ -3427,6 +3615,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-cascade/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-cascade-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 4",
@@ -3449,6 +3638,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-color/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-color-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Color Module Level 4",
@@ -3472,6 +3662,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-color-5/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-color-5/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Color Module Level 5",
@@ -3494,6 +3685,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-color-adjust-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-color-adjust-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Color Adjustment Module Level 1",
@@ -3518,6 +3710,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-conditional-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-conditional-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 3",
@@ -3541,6 +3734,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-conditional-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-conditional-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 4",
@@ -3562,6 +3756,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-contain-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-contain-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Containment Module Level 2",
@@ -3584,6 +3779,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-content-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-content-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Generated Content Module Level 3",
@@ -3606,6 +3802,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-counter-styles/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-counter-styles-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Counter Styles Level 3",
@@ -3628,6 +3825,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-device-adapt/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-device-adapt-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Device Adaptation Module Level 1",
@@ -3650,6 +3848,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-display/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-display-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Display Module Level 3",
@@ -3672,6 +3871,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-easing/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-easing-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Easing Functions Level 1",
@@ -3695,6 +3895,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-flexbox-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-flexbox-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Flexible Box Layout Module Level 1",
@@ -3716,6 +3917,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-font-loading/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-font-loading-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Font Loading Module Level 3",
@@ -3738,6 +3940,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-fonts-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-fonts-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Fonts Module Level 4",
@@ -3762,6 +3965,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-gcpm/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-gcpm-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module",
@@ -3784,6 +3988,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-grid-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-grid-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Grid Layout Module Level 2",
@@ -3806,6 +4011,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-highlight-api-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-highlight-api-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Custom Highlight API Module Level 1",
@@ -3830,6 +4036,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-images-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-images-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Image Values and Replaced Content Module Level 3",
@@ -3853,6 +4060,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-images-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-images-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Image Values and Replaced Content Module Level 4",
@@ -3874,6 +4082,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-inline-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-inline-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Inline Layout Module Level 3",
@@ -3896,6 +4105,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-layout-api-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-layout-api/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Layout API Level 1",
@@ -3918,6 +4128,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-line-grid/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-line-grid-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Line Grid Module Level 1",
@@ -3941,6 +4152,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-lists-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-lists-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Lists Module Level 3",
@@ -3963,6 +4175,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-logical-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-logical-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Logical Properties and Values Level 1",
@@ -3984,6 +4197,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/css-masking-1/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "css-masking-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Masking Module Level 1",
@@ -4008,6 +4222,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-multicol/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-multicol-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 1",
@@ -4029,6 +4244,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-namespaces/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-namespaces-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Namespaces Module Level 3",
@@ -4051,6 +4267,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-nav-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-nav-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Spatial Navigation Level 1",
@@ -4074,6 +4291,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-overflow-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-overflow-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Overflow Module Level 3",
@@ -4097,6 +4315,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-overflow-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-overflow-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Overflow Module Level 4",
@@ -4119,6 +4338,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-overscroll-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-overscroll-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Overscroll Behavior Module Level 1",
@@ -4142,6 +4362,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-page-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Paged Media Module Level 3",
@@ -4164,6 +4385,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-page-floats/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-page-floats-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Page Floats",
@@ -4186,6 +4408,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-paint-api-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-paint-api/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Painting API Level 1",
@@ -4208,6 +4431,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-position/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-position-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Positioned Layout Module Level 3",
@@ -4230,6 +4454,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-properties-values-api-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-properties-values-api/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Properties and Values API Level 1",
@@ -4252,6 +4477,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-pseudo-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-pseudo-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Pseudo-Elements Module Level 4",
@@ -4274,6 +4500,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-regions/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-regions-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Regions Module Level 1",
@@ -4296,6 +4523,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-rhythm/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-rhythm-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Rhythmic Sizing",
@@ -4318,6 +4546,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-round-display/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-round-display-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Round Display Level 1",
@@ -4340,6 +4569,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-ruby-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-ruby-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Ruby Layout Module Level 1",
@@ -4362,6 +4592,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-scoping/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-scoping-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Scoping Module Level 1",
@@ -4384,6 +4615,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-scroll-anchoring",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-scroll-anchoring-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Scroll Anchoring Module Level 1",
@@ -4406,6 +4638,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-scroll-snap-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-scroll-snap-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Scroll Snap Module Level 1",
@@ -4428,6 +4661,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-scrollbars/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-scrollbars-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Scrollbars Module Level 1",
@@ -4450,6 +4684,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-shadow-parts/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-shadow-parts-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Shadow Parts",
@@ -4473,6 +4708,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-shapes/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-shapes-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Shapes Module Level 1",
@@ -4497,6 +4733,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-sizing-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-sizing-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Box Sizing Module Level 3",
@@ -4520,6 +4757,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-sizing-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-sizing-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Box Sizing Module Level 4",
@@ -4541,6 +4779,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-speech-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-speech-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Speech Module",
@@ -4555,13 +4794,14 @@
       "shortname": "css-style-attr",
       "currentSpecification": "css-style-attr"
     },
-    "release": {
-      "url": "https://www.w3.org/TR/css-style-attr/",
-      "filename": "Overview.html"
-    },
     "nightly": {
       "url": "https://drafts.csswg.org/css-style-attr/",
+      "sourcePath": "css-style-attr-1/Overview.src.html",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
+    },
+    "release": {
+      "url": "https://www.w3.org/TR/css-style-attr/",
       "filename": "Overview.html"
     },
     "title": "CSS Style Attributes",
@@ -4584,6 +4824,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-syntax/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-syntax-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Syntax Module Level 3",
@@ -4606,6 +4847,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-tables-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-tables-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Table Module Level 3",
@@ -4629,6 +4871,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-text-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Text Module Level 3",
@@ -4652,6 +4895,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-text-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Text Module Level 4",
@@ -4675,6 +4919,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-decor-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-text-decor-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Text Decoration Module Level 3",
@@ -4698,6 +4943,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-text-decor-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-text-decor-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Text Decoration Module Level 4",
@@ -4721,6 +4967,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-transforms/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-transforms-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Transforms Module Level 1",
@@ -4744,6 +4991,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-transforms-2/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-transforms-2/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Transforms Module Level 2",
@@ -4767,6 +5015,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-transitions/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-transitions-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Transitions",
@@ -4790,6 +5039,7 @@
     "nightly": {
       "url": "https://drafts.css-houdini.org/css-typed-om-1/",
       "repository": "https://github.com/w3c/css-houdini-drafts",
+      "sourcePath": "css-typed-om/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Typed OM Level 1",
@@ -4813,6 +5063,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-ui-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-ui-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Basic User Interface Module Level 4",
@@ -4836,6 +5087,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-values-3/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-values-3/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 3",
@@ -4859,6 +5111,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-values-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-values-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 4",
@@ -4881,6 +5134,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-variables/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-variables-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Custom Properties for Cascading Variables Module Level 1",
@@ -4902,6 +5156,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-will-change/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-will-change-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Will Change Module Level 1",
@@ -4924,6 +5179,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/css-writing-modes-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-writing-modes-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Writing Modes Level 4",
@@ -4939,6 +5195,13 @@
       "currentSpecification": "CSS22"
     },
     "seriesVersion": "2.1",
+    "nightly": {
+      "url": "https://drafts.csswg.org/css2/",
+      "sourcePath": "css2/Overview.bs",
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "pages": [],
+      "filename": "Overview.html"
+    },
     "seriesNext": "CSS22",
     "release": {
       "url": "https://www.w3.org/TR/CSS21/",
@@ -4972,12 +5235,6 @@
       ],
       "filename": "Overview.html"
     },
-    "nightly": {
-      "url": "https://drafts.csswg.org/css2/",
-      "repository": "https://github.com/w3c/csswg-drafts",
-      "pages": [],
-      "filename": "Overview.html"
-    },
     "title": "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification",
     "source": "w3c",
     "shortTitle": "CSS 2.1"
@@ -4991,6 +5248,13 @@
       "currentSpecification": "CSS22"
     },
     "seriesVersion": "2.2",
+    "nightly": {
+      "url": "https://drafts.csswg.org/css2/",
+      "sourcePath": "css2/Overview.bs",
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "pages": [],
+      "filename": "Overview.html"
+    },
     "seriesPrevious": "CSS21",
     "release": {
       "url": "https://www.w3.org/TR/CSS22/",
@@ -5024,12 +5288,6 @@
       ],
       "filename": "Overview.html"
     },
-    "nightly": {
-      "url": "https://drafts.csswg.org/css2/",
-      "repository": "https://github.com/w3c/csswg-drafts",
-      "pages": [],
-      "filename": "Overview.html"
-    },
     "title": "Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification",
     "source": "w3c",
     "shortTitle": "CSS 2.2"
@@ -5042,14 +5300,15 @@
       "shortname": "css-exclusions",
       "currentSpecification": "css3-exclusions"
     },
-    "seriesVersion": "3",
-    "release": {
-      "url": "https://www.w3.org/TR/css3-exclusions/",
-      "filename": "Overview.html"
-    },
+    "seriesVersion": "1",
     "nightly": {
       "url": "https://drafts.csswg.org/css-exclusions/",
+      "sourcePath": "css-exclusions-1/Overview.bs",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "filename": "Overview.html"
+    },
+    "release": {
+      "url": "https://www.w3.org/TR/css3-exclusions/",
       "filename": "Overview.html"
     },
     "title": "CSS Exclusions Module Level 1",
@@ -5072,6 +5331,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/cssom/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "cssom-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Object Model (CSSOM)",
@@ -5094,6 +5354,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/cssom-view/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "cssom-view-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSSOM View Module",
@@ -5116,6 +5377,7 @@
     "nightly": {
       "url": "https://w3c.github.io/device-memory/",
       "repository": "https://github.com/w3c/device-memory",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Device Memory",
@@ -5137,6 +5399,7 @@
     "nightly": {
       "url": "https://w3c.github.io/DOM-Parsing/",
       "repository": "https://github.com/w3c/DOM-Parsing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "DOM Parsing and Serialization",
@@ -5158,6 +5421,7 @@
     "nightly": {
       "url": "https://encoding.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/encoding",
+      "sourcePath": "encoding.bs",
       "filename": "index.html"
     },
     "title": "Encoding",
@@ -5172,14 +5436,15 @@
       "shortname": "encrypted-media",
       "currentSpecification": "encrypted-media"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/encrypted-media/",
+      "sourcePath": "encrypted-media-respec.html",
+      "repository": "https://github.com/w3c/encrypted-media",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/encrypted-media/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/encrypted-media/",
-      "repository": "https://github.com/w3c/encrypted-media",
-      "filename": "index.html"
     },
     "title": "Encrypted Media Extensions",
     "source": "w3c",
@@ -5201,6 +5466,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-fetch-metadata/",
       "repository": "https://github.com/w3c/webappsec-fetch-metadata",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Fetch Metadata Request Headers",
@@ -5221,6 +5487,7 @@
     "nightly": {
       "url": "https://w3c.github.io/FileAPI/",
       "repository": "https://github.com/w3c/FileAPI",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "File API",
@@ -5243,6 +5510,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/fill-stroke/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "fill-stroke/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Fill and Stroke Module Level 3",
@@ -5266,6 +5534,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/filter-effects-1/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "filter-effects/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Filter Effects Module Level 1",
@@ -5287,6 +5556,7 @@
     "nightly": {
       "url": "https://w3c.github.io/gamepad/",
       "repository": "https://github.com/w3c/gamepad",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Gamepad",
@@ -5308,6 +5578,7 @@
     "nightly": {
       "url": "https://w3c.github.io/sensors/",
       "repository": "https://github.com/w3c/sensors",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Generic Sensor API",
@@ -5329,6 +5600,7 @@
     "nightly": {
       "url": "https://w3c.github.io/geolocation-api/",
       "repository": "https://github.com/w3c/geolocation-api",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Geolocation API Specification 2nd Edition",
@@ -5350,6 +5622,7 @@
     "nightly": {
       "url": "https://w3c.github.io/geolocation-sensor/",
       "repository": "https://github.com/w3c/geolocation-sensor",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Geolocation Sensor",
@@ -5372,6 +5645,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/geometry/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "geometry/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Geometry Interfaces Module Level 1",
@@ -5394,6 +5668,7 @@
     "nightly": {
       "url": "https://w3c.github.io/graphics-aam/",
       "repository": "https://github.com/w3c/graphics-aam",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Graphics Accessibility API Mappings",
@@ -5416,6 +5691,7 @@
     "nightly": {
       "url": "https://w3c.github.io/graphics-aria/",
       "repository": "https://github.com/w3c/graphics-aria",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "WAI-ARIA Graphics Module",
@@ -5437,6 +5713,7 @@
     "nightly": {
       "url": "https://w3c.github.io/gyroscope/",
       "repository": "https://github.com/w3c/gyroscope",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Gyroscope",
@@ -5459,6 +5736,7 @@
     "nightly": {
       "url": "https://w3c.github.io/hr-time/",
       "repository": "https://github.com/w3c/hr-time",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "High Resolution Time",
@@ -5481,6 +5759,7 @@
     "nightly": {
       "url": "https://w3c.github.io/html-aam/",
       "repository": "https://github.com/w3c/html-aam",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "HTML Accessibility API Mappings 1.0",
@@ -5502,6 +5781,7 @@
     "nightly": {
       "url": "https://w3c.github.io/html-aria/",
       "repository": "https://github.com/w3c/html-aria",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "ARIA in HTML",
@@ -5523,6 +5803,7 @@
     "nightly": {
       "url": "https://w3c.github.io/html-media-capture/",
       "repository": "https://github.com/w3c/html-media-capture",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "HTML Media Capture",
@@ -5544,6 +5825,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-image/",
       "repository": "https://github.com/w3c/mediacapture-image",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "\"MediaStream Image Capture\"",
@@ -5565,6 +5847,7 @@
     "nightly": {
       "url": "https://w3c.github.io/image-resource/",
       "repository": "https://github.com/w3c/image-resource",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Image Resource",
@@ -5588,6 +5871,7 @@
     "nightly": {
       "url": "https://w3c.github.io/IndexedDB/",
       "repository": "https://github.com/w3c/IndexedDB",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Indexed Database API 2.0",
@@ -5609,6 +5893,7 @@
     "nightly": {
       "url": "https://w3c.github.io/input-events/",
       "repository": "https://github.com/w3c/input-events",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Input Events Level 2",
@@ -5630,6 +5915,7 @@
     "nightly": {
       "url": "https://w3c.github.io/IntersectionObserver/",
       "repository": "https://github.com/w3c/IntersectionObserver",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Intersection Observer",
@@ -5652,6 +5938,7 @@
     "nightly": {
       "url": "https://w3c.github.io/longtasks/",
       "repository": "https://github.com/w3c/longtasks",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Long Tasks API 1",
@@ -5673,6 +5960,7 @@
     "nightly": {
       "url": "https://w3c.github.io/magnetometer/",
       "repository": "https://github.com/w3c/magnetometer",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Magnetometer",
@@ -5694,6 +5982,7 @@
     "nightly": {
       "url": "https://w3c.github.io/media-capabilities/",
       "repository": "https://github.com/w3c/media-capabilities",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Media Capabilities",
@@ -5708,14 +5997,15 @@
       "shortname": "media-source",
       "currentSpecification": "media-source"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/media-source/",
+      "sourcePath": "media-source-respec.html",
+      "repository": "https://github.com/w3c/media-source",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/media-source/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/media-source/",
-      "repository": "https://github.com/w3c/media-source",
-      "filename": "index.html"
     },
     "title": "Media Source Extensions™",
     "source": "w3c",
@@ -5736,6 +6026,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-depth/",
       "repository": "https://github.com/w3c/mediacapture-depth",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Media Capture Depth Stream Extensions",
@@ -5757,6 +6048,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-fromelement/",
       "repository": "https://github.com/w3c/mediacapture-fromelement",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Media Capture from DOM Elements",
@@ -5778,6 +6070,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-main/",
       "repository": "https://github.com/w3c/mediacapture-main",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Media Capture and Streams",
@@ -5801,6 +6094,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/mediaqueries-4/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "mediaqueries-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Media Queries Level 4",
@@ -5824,6 +6118,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/mediaqueries-5/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "mediaqueries-5/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Media Queries Level 5",
@@ -5845,6 +6140,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediasession/",
       "repository": "https://github.com/w3c/mediasession",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Media Session Standard",
@@ -5859,14 +6155,15 @@
       "shortname": "mediastream-recording",
       "currentSpecification": "mediastream-recording"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/mediacapture-record/",
+      "sourcePath": "MediaRecorder.bs",
+      "repository": "https://github.com/w3c/mediacapture-record",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/mediastream-recording/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/mediacapture-record/",
-      "repository": "https://github.com/w3c/mediacapture-record",
-      "filename": "index.html"
     },
     "title": "MediaStream Recording",
     "source": "w3c",
@@ -5887,6 +6184,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-mixed-content/",
       "repository": "https://github.com/w3c/webappsec-mixed-content",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Mixed Content",
@@ -5909,6 +6207,7 @@
     "nightly": {
       "url": "https://drafts.fxtf.org/motion-1/",
       "repository": "https://github.com/w3c/fxtf-drafts",
+      "sourcePath": "motion-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Motion Path Module Level 1",
@@ -5930,6 +6229,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mst-content-hint/",
       "repository": "https://github.com/w3c/mst-content-hint",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "MediaStreamTrack Content Hints",
@@ -5952,6 +6252,7 @@
     "nightly": {
       "url": "https://w3c.github.io/navigation-timing/",
       "repository": "https://github.com/w3c/navigation-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Navigation Timing Level 2",
@@ -5974,6 +6275,7 @@
     "nightly": {
       "url": "https://w3c.github.io/network-error-logging/",
       "repository": "https://github.com/w3c/network-error-logging",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Network Error Logging",
@@ -5995,6 +6297,7 @@
     "nightly": {
       "url": "https://w3c.github.io/deviceorientation/",
       "repository": "https://github.com/w3c/deviceorientation",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "DeviceOrientation Event Specification",
@@ -6016,6 +6319,7 @@
     "nightly": {
       "url": "https://w3c.github.io/orientation-sensor/",
       "repository": "https://github.com/w3c/orientation-sensor",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Orientation Sensor",
@@ -6038,6 +6342,7 @@
     "nightly": {
       "url": "https://w3c.github.io/page-visibility/",
       "repository": "https://github.com/w3c/page-visibility",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Page Visibility Level 2",
@@ -6052,14 +6357,15 @@
       "shortname": "paint-timing",
       "currentSpecification": "paint-timing"
     },
+    "nightly": {
+      "url": "https://w3c.github.io/paint-timing/",
+      "sourcePath": "painttiming.bs",
+      "repository": "https://github.com/w3c/paint-timing",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/paint-timing/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/paint-timing/",
-      "repository": "https://github.com/w3c/paint-timing",
-      "filename": "index.html"
     },
     "title": "Paint Timing 1",
     "source": "w3c",
@@ -6080,6 +6386,7 @@
     "nightly": {
       "url": "https://w3c.github.io/payment-handler/",
       "repository": "https://github.com/w3c/payment-handler",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Payment Handler API",
@@ -6102,6 +6409,7 @@
     "nightly": {
       "url": "https://w3c.github.io/payment-method-basic-card/",
       "repository": "https://github.com/w3c/payment-method-basic-card",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Payment Method: Basic Card",
@@ -6122,6 +6430,7 @@
     "nightly": {
       "url": "https://w3c.github.io/payment-method-id/",
       "repository": "https://github.com/w3c/payment-method-id",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Payment Method Identifiers",
@@ -6143,6 +6452,7 @@
     "nightly": {
       "url": "https://w3c.github.io/payment-method-manifest/",
       "repository": "https://github.com/w3c/payment-method-manifest",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Payment Method Manifest",
@@ -6164,6 +6474,7 @@
     "nightly": {
       "url": "https://w3c.github.io/payment-request/",
       "repository": "https://github.com/w3c/payment-request",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Payment Request API",
@@ -6186,6 +6497,7 @@
     "nightly": {
       "url": "https://w3c.github.io/performance-timeline/",
       "repository": "https://github.com/w3c/performance-timeline",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Performance Timeline Level 2",
@@ -6208,6 +6520,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-permissions-policy/",
       "repository": "https://github.com/w3c/webappsec-permissions-policy",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Permissions Policy",
@@ -6229,6 +6542,7 @@
     "nightly": {
       "url": "https://w3c.github.io/permissions/",
       "repository": "https://github.com/w3c/permissions",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Permissions",
@@ -6250,6 +6564,7 @@
     "nightly": {
       "url": "https://w3c.github.io/picture-in-picture/",
       "repository": "https://github.com/w3c/picture-in-picture",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Picture-in-Picture",
@@ -6272,6 +6587,7 @@
     "nightly": {
       "url": "https://w3c.github.io/pointerevents/",
       "repository": "https://github.com/w3c/pointerevents",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Pointer Events Level 3",
@@ -6294,6 +6610,7 @@
     "nightly": {
       "url": "https://w3c.github.io/pointerlock/",
       "repository": "https://github.com/w3c/pointerlock",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Pointer Lock 2.0",
@@ -6315,6 +6632,7 @@
     "nightly": {
       "url": "https://w3c.github.io/preload/",
       "repository": "https://github.com/w3c/preload",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Preload",
@@ -6336,6 +6654,7 @@
     "nightly": {
       "url": "https://w3c.github.io/presentation-api/",
       "repository": "https://github.com/w3c/presentation-api",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Presentation API",
@@ -6357,6 +6676,7 @@
     "nightly": {
       "url": "https://w3c.github.io/proximity/",
       "repository": "https://github.com/w3c/proximity",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Proximity Sensor",
@@ -6378,6 +6698,7 @@
     "nightly": {
       "url": "https://w3c.github.io/push-api/",
       "repository": "https://github.com/w3c/push-api",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Push API",
@@ -6399,6 +6720,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-referrer-policy/",
       "repository": "https://github.com/w3c/webappsec-referrer-policy",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Referrer Policy",
@@ -6420,6 +6742,7 @@
     "nightly": {
       "url": "https://w3c.github.io/remote-playback/",
       "repository": "https://github.com/w3c/remote-playback",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Remote Playback API",
@@ -6442,6 +6765,7 @@
     "nightly": {
       "url": "https://w3c.github.io/reporting/",
       "repository": "https://github.com/w3c/reporting",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Reporting API",
@@ -6463,6 +6787,7 @@
     "nightly": {
       "url": "https://w3c.github.io/requestidlecallback/",
       "repository": "https://github.com/w3c/requestidlecallback",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Cooperative Scheduling of Background Tasks",
@@ -6485,6 +6810,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/resize-observer/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "resize-observer-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Resize Observer",
@@ -6506,6 +6832,7 @@
     "nightly": {
       "url": "https://w3c.github.io/resource-hints/",
       "repository": "https://github.com/w3c/resource-hints",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Resource Hints",
@@ -6528,6 +6855,7 @@
     "nightly": {
       "url": "https://w3c.github.io/resource-timing/",
       "repository": "https://github.com/w3c/resource-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Resource Timing Level 2",
@@ -6549,6 +6877,7 @@
     "nightly": {
       "url": "https://w3c.github.io/mediacapture-screen-share/",
       "repository": "https://github.com/w3c/mediacapture-screen-share",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Screen Capture",
@@ -6570,6 +6899,7 @@
     "nightly": {
       "url": "https://w3c.github.io/screen-orientation/",
       "repository": "https://github.com/w3c/screen-orientation",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "The Screen Orientation API",
@@ -6591,6 +6921,7 @@
     "nightly": {
       "url": "https://w3c.github.io/screen-wake-lock/",
       "repository": "https://github.com/w3c/screen-wake-lock",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Screen Wake Lock API",
@@ -6612,6 +6943,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-secure-contexts/",
       "repository": "https://github.com/w3c/webappsec-secure-contexts",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Secure Contexts",
@@ -6633,6 +6965,7 @@
     "nightly": {
       "url": "https://w3c.github.io/selection-api/",
       "repository": "https://github.com/w3c/selection-api",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Selection API",
@@ -6655,6 +6988,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/selectors/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "selectors-4/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Selectors Level 4",
@@ -6677,6 +7011,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/selectors-nonelement/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "selectors-nonelement-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Non-element Selectors Module Level 1",
@@ -6698,6 +7033,7 @@
     "nightly": {
       "url": "https://w3c.github.io/server-timing/",
       "repository": "https://github.com/w3c/server-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Server Timing",
@@ -6716,6 +7052,7 @@
     "nightly": {
       "url": "https://w3c.github.io/ServiceWorker/",
       "repository": "https://github.com/w3c/ServiceWorker",
+      "sourcePath": "docs/index.bs",
       "filename": "index.html"
     },
     "release": {
@@ -6742,6 +7079,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-subresource-integrity/",
       "repository": "https://github.com/w3c/webappsec-subresource-integrity",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Subresource Integrity",
@@ -6763,6 +7101,7 @@
     "nightly": {
       "url": "https://w3c.github.io/svg-aam/",
       "repository": "https://github.com/w3c/svg-aam",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "SVG Accessibility API Mappings",
@@ -6784,6 +7123,7 @@
     "nightly": {
       "url": "https://svgwg.org/specs/integration/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "specs/integration/master/Overview.html",
       "filename": "Overview.html"
     },
     "title": "SVG Integration",
@@ -6805,6 +7145,7 @@
     "nightly": {
       "url": "https://svgwg.org/specs/markers/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "specs/markers/master/Overview.html",
       "filename": "Overview.html"
     },
     "title": "SVG Markers",
@@ -6826,6 +7167,7 @@
     "nightly": {
       "url": "https://svgwg.org/specs/paths/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "specs/paths/master/Overview.html",
       "filename": "Overview.html"
     },
     "title": "SVG Paths",
@@ -6847,6 +7189,7 @@
     "nightly": {
       "url": "https://svgwg.org/specs/strokes/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "specs/strokes/master/Overview.html",
       "filename": "Overview.html"
     },
     "title": "SVG Strokes",
@@ -6898,6 +7241,7 @@
     "nightly": {
       "url": "https://svgwg.org/svg2-draft/",
       "repository": "https://github.com/w3c/svgwg",
+      "sourcePath": "master/Overview.html",
       "pages": [
         "https://svgwg.org/svg2-draft/intro.html",
         "https://svgwg.org/svg2-draft/conform.html",
@@ -6948,6 +7292,7 @@
     "nightly": {
       "url": "https://w3c.github.io/timing-entrytypes-registry/",
       "repository": "https://github.com/w3c/timing-entrytypes-registry",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Timing Entry Names Registry",
@@ -6969,6 +7314,7 @@
     "nightly": {
       "url": "https://w3c.github.io/touch-events/",
       "repository": "https://github.com/w3c/touch-events",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Touch Events",
@@ -6991,6 +7337,7 @@
     "nightly": {
       "url": "https://w3c.github.io/trace-context/",
       "repository": "https://github.com/w3c/trace-context",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Trace Context - Level 1",
@@ -7012,6 +7359,7 @@
     "nightly": {
       "url": "https://w3c.github.io/uievents-code/",
       "repository": "https://github.com/w3c/uievents-code",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent code Values",
@@ -7033,6 +7381,7 @@
     "nightly": {
       "url": "https://w3c.github.io/uievents-key/",
       "repository": "https://github.com/w3c/uievents-key",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "UI Events KeyboardEvent key Values",
@@ -7054,6 +7403,7 @@
     "nightly": {
       "url": "https://w3c.github.io/uievents/",
       "repository": "https://github.com/w3c/uievents",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "UI Events",
@@ -7075,6 +7425,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webappsec-upgrade-insecure-requests/",
       "repository": "https://github.com/w3c/webappsec-upgrade-insecure-requests",
+      "sourcePath": "index.src.html",
       "filename": "index.html"
     },
     "title": "Upgrade Insecure Requests",
@@ -7098,6 +7449,7 @@
     "nightly": {
       "url": "https://w3c.github.io/user-timing/",
       "repository": "https://github.com/w3c/user-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "User Timing Level 2",
@@ -7121,6 +7473,7 @@
     "nightly": {
       "url": "https://w3c.github.io/user-timing/",
       "repository": "https://github.com/w3c/user-timing",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "User Timing Level 3",
@@ -7142,6 +7495,7 @@
     "nightly": {
       "url": "https://w3c.github.io/vibration/",
       "repository": "https://github.com/w3c/vibration",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Vibration API (Second Edition)",
@@ -7164,6 +7518,7 @@
     "nightly": {
       "url": "https://w3c.github.io/aria/",
       "repository": "https://github.com/w3c/aria",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Accessible Rich Internet Applications (WAI-ARIA) 1.2",
@@ -7186,6 +7541,7 @@
     "nightly": {
       "url": "https://webassembly.github.io/spec/core/bikeshed/",
       "repository": "https://github.com/WebAssembly/spec",
+      "sourcePath": "document/core/index.bs",
       "filename": "index.html"
     },
     "title": "WebAssembly Core Specification",
@@ -7208,6 +7564,7 @@
     "nightly": {
       "url": "https://webassembly.github.io/spec/js-api/",
       "repository": "https://github.com/WebAssembly/spec",
+      "sourcePath": "document/js-api/index.bs",
       "filename": "index.html"
     },
     "title": "WebAssembly JavaScript Interface",
@@ -7230,6 +7587,7 @@
     "nightly": {
       "url": "https://webassembly.github.io/spec/web-api/",
       "repository": "https://github.com/WebAssembly/spec",
+      "sourcePath": "document/web-api/index.bs",
       "filename": "index.html"
     },
     "title": "WebAssembly Web API",
@@ -7252,6 +7610,7 @@
     "nightly": {
       "url": "https://drafts.csswg.org/web-animations-1/",
       "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "web-animations-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "Web Animations",
@@ -7273,6 +7632,7 @@
     "nightly": {
       "url": "https://w3c.github.io/web-share/",
       "repository": "https://github.com/w3c/web-share",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web Share API",
@@ -7294,6 +7654,7 @@
     "nightly": {
       "url": "https://webaudio.github.io/web-audio-api/",
       "repository": "https://github.com/WebAudio/web-audio-api",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Audio API",
@@ -7317,6 +7678,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webauthn/",
       "repository": "https://github.com/w3c/webauthn",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "Web Authentication: An API for accessing Public Key Credentials: Level 2",
@@ -7337,6 +7699,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webcrypto/",
       "repository": "https://github.com/w3c/webcrypto",
+      "sourcePath": "spec/Overview.html",
       "filename": "Overview.html"
     },
     "title": "Web Cryptography API",
@@ -7359,6 +7722,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webdriver/",
       "repository": "https://github.com/w3c/webdriver",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "WebDriver - Level 2",
@@ -7381,6 +7745,7 @@
     "nightly": {
       "url": "https://heycam.github.io/webidl/",
       "repository": "https://github.com/heycam/webidl",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebIDL Level 1",
@@ -7402,6 +7767,7 @@
     "nightly": {
       "url": "https://webaudio.github.io/web-midi-api/",
       "repository": "https://github.com/WebAudio/web-midi-api",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Web MIDI API",
@@ -7423,6 +7789,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-identity/identity.html",
       "repository": "https://github.com/w3c/webrtc-identity",
+      "sourcePath": "identity.html",
       "filename": "identity.html"
     },
     "title": "Identity for WebRTC 1.0",
@@ -7444,6 +7811,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-priority/",
       "repository": "https://github.com/w3c/webrtc-priority",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebRTC Priority Control API",
@@ -7466,6 +7834,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-stats/",
       "repository": "https://github.com/w3c/webrtc-stats",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Identifiers for WebRTC's Statistics API",
@@ -7486,6 +7855,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-svc/",
       "repository": "https://github.com/w3c/webrtc-svc",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "Scalable Video Coding (SVC) Extension for WebRTC",
@@ -7508,6 +7878,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webrtc-pc/",
       "repository": "https://github.com/w3c/webrtc-pc",
+      "sourcePath": "index.html",
       "filename": "index.html"
     },
     "title": "WebRTC 1.0: Real-Time Communication Between Browsers",
@@ -7529,6 +7900,7 @@
     "nightly": {
       "url": "https://w3c.github.io/webvtt/",
       "repository": "https://github.com/w3c/webvtt",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebVTT: The Web Video Text Tracks Format",
@@ -7551,6 +7923,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/webxr-ar-module/",
       "repository": "https://github.com/immersive-web/webxr-ar-module",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Augmented Reality Module - Level 1",
@@ -7573,6 +7946,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/webxr-gamepads-module/",
       "repository": "https://github.com/immersive-web/webxr-gamepads-module",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Gamepads Module - Level 1",
@@ -7595,6 +7969,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/webxr-hand-input/",
       "repository": "https://github.com/immersive-web/webxr-hand-input",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Hand Input Module - Level 1",
@@ -7616,6 +7991,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/webxr/",
       "repository": "https://github.com/immersive-web/webxr",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
     "title": "WebXR Device API",
@@ -7638,6 +8014,7 @@
     "nightly": {
       "url": "https://immersive-web.github.io/layers/",
       "repository": "https://github.com/immersive-web/layers",
+      "sourcePath": "webxrlayers-1.bs",
       "filename": "index.html"
     },
     "title": "WebXR Layers API Level 1",
@@ -7654,14 +8031,15 @@
     },
     "seriesVersion": "2",
     "shortTitle": "WOFF 2.0",
+    "nightly": {
+      "url": "https://w3c.github.io/woff/woff2/",
+      "sourcePath": "woff2/index.html",
+      "repository": "https://github.com/w3c/woff",
+      "filename": "index.html"
+    },
     "release": {
       "url": "https://www.w3.org/TR/WOFF2/",
       "filename": "Overview.html"
-    },
-    "nightly": {
-      "url": "https://w3c.github.io/woff/woff2/",
-      "repository": "https://github.com/w3c/woff",
-      "filename": "index.html"
     },
     "title": "WOFF File Format 2.0",
     "source": "w3c"
@@ -7677,6 +8055,7 @@
     "nightly": {
       "url": "https://xhr.spec.whatwg.org/",
       "repository": "https://github.com/whatwg/xhr",
+      "sourcePath": "xhr.bs",
       "filename": "index.html"
     },
     "title": "XMLHttpRequest Standard",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@actions/core": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
-      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -77,131 +78,127 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
-      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+      "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0"
+        "@octokit/types": "^6.0.0"
       }
     },
     "@octokit/core": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.4.3.tgz",
-      "integrity": "sha512-9T91nYeBB7+PNK3oxOuA+6DXCPRvhJ80ke+NqhXirBjVtNepTKFJXoWPqguRSBQ+dkEVA8dZJMxfFzjz9yhiuA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
+      "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
       "dev": true,
       "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.3.1",
-        "@octokit/types": "^2.0.0",
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
         "before-after-hook": "^2.1.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.0.tgz",
-      "integrity": "sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+      "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^5.0.0"
+        "@octokit/types": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/graphql": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
-      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
+      "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^2.0.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
-          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
-          "dev": true,
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
+        "@octokit/types": "^6.0.0",
+        "universal-user-agent": "^6.0.0"
       }
     },
+    "@octokit/openapi-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
+      "integrity": "sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==",
+      "dev": true
+    },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.0.2.tgz",
-      "integrity": "sha512-HzODcSUt9mjErly26TlTOGZrhf9bmF/FEDQ2zln1izhgmIV6ulsjsHmgmR4VZ0wzVr/m52Eb6U2XuyS8fkcR1A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
+      "integrity": "sha512-3Dy7/YZAwdOaRpGQoNHPeT0VU1fYLpIUdPyvR37IyFLgd6XSij4j9V/xN/+eSjF2KKvmfIulEh9LF1tRPjIiDA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.1"
+        "@octokit/types": "^6.0.1"
       }
     },
     "@octokit/plugin-request-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.4.0.tgz",
-      "integrity": "sha512-Tvctk0u5SVrSLAzi8SLo0KrLSBl5biAHBgWy3L65vsbO/2fjzr62HVkoDPyr+WRT+eHhhqpKAERF3dQWOIUOvQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
+      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.1",
+        "@octokit/types": "^6.1.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.4.tgz",
-      "integrity": "sha512-qyj8G8BxQyXjt9Xu6NvfvOr1E0l35lsXtwm3SopsYg/JWXjlsnwqLc8rsD2OLguEL/JjLfBvrXr4az7z8Lch2A==",
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
+      "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^6.0.0",
+        "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "node-fetch": "^2.3.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
-      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
+      "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^6.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "17.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.1.4.tgz",
-      "integrity": "sha512-LGghhepxoXyvi7ew0OdedrlwXQog8gvTbcdXoQ6RDKnzoYW2rBpcqeWC4fTuPUp9K0UEykcMix8kFnQ5b+64JQ==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
+      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
       "dev": true,
       "requires": {
-        "@octokit/core": "^2.4.3",
-        "@octokit/plugin-paginate-rest": "^2.0.0",
-        "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "3.4.0"
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
       }
     },
     "@octokit/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-q4Wr7RexkPRrkQpXzUYF5Fj/14Mr65RyOHj6B9d/sQACpqGcStkHZj4qMEtlMY5SnD/69jlL9ItGPbDM0dR/dA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz",
+      "integrity": "sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==",
       "dev": true,
       "requires": {
+        "@octokit/openapi-types": "^2.0.0",
         "@types/node": ">= 8"
       }
     },
@@ -277,17 +274,20 @@
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "dev": true
     },
     "acorn": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
       "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
@@ -296,12 +296,14 @@
     "acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true
     },
     "ajv": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
       "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -413,6 +415,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -420,7 +423,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "async-retry": {
       "version": "1.3.1",
@@ -434,7 +438,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "auto-changelog": {
       "version": "1.16.4",
@@ -463,12 +468,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -480,6 +487,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -630,7 +638,8 @@
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -695,7 +704,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -861,6 +871,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -900,7 +911,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -937,12 +949,14 @@
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
     },
     "cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
       "requires": {
         "cssom": "~0.3.6"
       },
@@ -950,7 +964,8 @@
         "cssom": {
           "version": "0.3.8",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
         }
       }
     },
@@ -958,6 +973,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -966,6 +982,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
       "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
       "requires": {
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
@@ -990,7 +1007,8 @@
     "decimal.js": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
     },
     "decompress-response": {
       "version": "5.0.0",
@@ -1010,7 +1028,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "defaults": {
       "version": "1.0.3",
@@ -1048,7 +1067,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "deprecated-obj": {
       "version": "1.0.1",
@@ -1097,6 +1117,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
       "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dev": true,
       "requires": {
         "webidl-conversions": "^5.0.0"
       },
@@ -1104,7 +1125,8 @@
         "webidl-conversions": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
         }
       }
     },
@@ -1127,6 +1149,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1202,6 +1225,7 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -1213,17 +1237,20 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "execa": {
       "version": "4.0.0",
@@ -1312,7 +1339,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -1328,12 +1356,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.2",
@@ -1352,12 +1382,14 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.7.0",
@@ -1407,7 +1439,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "3.0.0",
@@ -1458,6 +1491,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1597,12 +1631,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -1645,6 +1681,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
       "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
@@ -1659,6 +1696,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1675,6 +1713,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1875,7 +1914,8 @@
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -2010,18 +2050,16 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-      "dev": true,
-      "requires": {
-        "isobject": "^4.0.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2071,7 +2109,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -2085,16 +2124,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-      "dev": true
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2115,12 +2149,14 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
       "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+      "dev": true,
       "requires": {
         "abab": "^2.0.3",
         "acorn": "^7.1.1",
@@ -2165,22 +2201,26 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2216,6 +2256,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -2240,7 +2281,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -2251,7 +2293,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -2322,12 +2365,14 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -2437,7 +2482,8 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -2463,12 +2509,14 @@
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -2526,6 +2574,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -2956,7 +3005,8 @@
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -2991,7 +3041,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.1",
@@ -3008,7 +3059,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -3025,7 +3077,8 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -3040,7 +3093,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "pupa": {
       "version": "2.0.1",
@@ -3054,7 +3108,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",
@@ -3157,6 +3212,62 @@
         "yargs-parser": "18.1.2"
       },
       "dependencies": {
+        "@octokit/core": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+          "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/auth-token": "^2.4.0",
+            "@octokit/graphql": "^4.3.1",
+            "@octokit/request": "^5.4.0",
+            "@octokit/types": "^5.0.0",
+            "before-after-hook": "^2.1.0",
+            "universal-user-agent": "^5.0.0"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.4.0.tgz",
+          "integrity": "sha512-Tvctk0u5SVrSLAzi8SLo0KrLSBl5biAHBgWy3L65vsbO/2fjzr62HVkoDPyr+WRT+eHhhqpKAERF3dQWOIUOvQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.1",
+            "deprecation": "^2.3.1"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "2.16.2",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+              "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+              "dev": true,
+              "requires": {
+                "@types/node": ">= 8"
+              }
+            }
+          }
+        },
+        "@octokit/rest": {
+          "version": "17.1.4",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.1.4.tgz",
+          "integrity": "sha512-LGghhepxoXyvi7ew0OdedrlwXQog8gvTbcdXoQ6RDKnzoYW2rBpcqeWC4fTuPUp9K0UEykcMix8kFnQ5b+64JQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/core": "^2.4.3",
+            "@octokit/plugin-paginate-rest": "^2.0.0",
+            "@octokit/plugin-request-log": "^1.0.0",
+            "@octokit/plugin-rest-endpoint-methods": "3.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+          "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -3256,6 +3367,15 @@
             "has-flag": "^4.0.0"
           }
         },
+        "universal-user-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        },
         "yargs-parser": {
           "version": "18.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
@@ -3272,6 +3392,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3299,6 +3420,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -3309,6 +3431,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -3317,7 +3440,8 @@
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -3325,6 +3449,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -3333,6 +3458,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
@@ -3343,6 +3469,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -3435,17 +3562,20 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
       "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -3520,7 +3650,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3532,6 +3663,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -3547,7 +3679,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -3618,7 +3751,8 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "term-size": {
       "version": "2.2.0",
@@ -3660,6 +3794,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
       "requires": {
         "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
@@ -3670,6 +3805,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
       "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -3684,6 +3820,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3691,12 +3828,14 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -3746,13 +3885,10 @@
       }
     },
     "universal-user-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-      "dev": true,
-      "requires": {
-        "os-name": "^3.1.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "update-notifier": {
       "version": "4.1.0",
@@ -3831,6 +3967,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3860,6 +3997,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -3870,6 +4008,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
@@ -3878,6 +4017,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
       "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
@@ -3894,12 +4034,14 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -3907,12 +4049,14 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
       "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
@@ -3922,7 +4066,8 @@
         "webidl-conversions": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
         }
       }
     },
@@ -4064,7 +4209,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -4132,7 +4278,8 @@
     "ws": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -4143,12 +4290,14 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "release": "release-it"
   },
   "devDependencies": {
+    "@actions/core": "^1.2.6",
+    "@octokit/rest": "^18.0.12",
     "ajv": "^6.11.0",
     "auto-changelog": "^1.16.4",
-    "mocha": "^7.0.0",
-    "release-it": "^13.5.1",
-    "@actions/core": "^1.2.6",
     "jsdom": "^16.2.2",
-    "node-fetch": "^2.6.1"
+    "mocha": "^7.0.0",
+    "node-fetch": "^2.6.1",
+    "release-it": "^13.5.1"
   }
 }

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -13,6 +13,11 @@
       "pattern": "^\\w+\\.html$"
     },
 
+    "relativePath": {
+      "type": "string",
+      "pattern": "^[\\w\\-\\.]+(\\/[\\w\\-\\.]+)*$"
+    },
+
     "shortname": {
       "type": "string",
       "pattern": "^[\\w\\-]+((?<=\\-\\d+)\\.\\d+)?$"
@@ -73,13 +78,13 @@
       "properties": {
         "url": { "$ref": "#/proptype/url" },
         "filename": { "$ref": "#/proptype/filename" },
+        "sourcePath": { "$ref": "#/proptype/relativePath" },
         "pages": {
           "type": "array",
           "items": { "$ref": "#/proptype/url" }
         },
         "repository": { "$ref": "#/proptype/url" }
       },
-      "required": ["url"],
       "additionalProperties": false
     }
   }

--- a/specs.json
+++ b/specs.json
@@ -1,5 +1,10 @@
 [
-  "https://compat.spec.whatwg.org/",
+  {
+    "url": "https://compat.spec.whatwg.org/",
+    "nightly": {
+      "sourcePath": "compatibility.bs"
+    }
+  },
   "https://console.spec.whatwg.org/",
   "https://dom.spec.whatwg.org/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
@@ -40,7 +45,13 @@
   "https://fetch.spec.whatwg.org/",
   "https://fullscreen.spec.whatwg.org/",
   "https://gpuweb.github.io/gpuweb/",
-  "https://html.spec.whatwg.org/multipage/ multipage",
+  {
+    "url": "https://html.spec.whatwg.org/multipage/",
+    "multipage": true,
+    "nightly": {
+      "sourcePath": "source"
+    }
+  },
   "https://immersive-web.github.io/anchors/",
   "https://immersive-web.github.io/dom-overlays/",
   "https://immersive-web.github.io/hit-test/",
@@ -70,7 +81,12 @@
   "https://url.spec.whatwg.org/",
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contentEditable/",
-  "https://w3c.github.io/gamepad/extensions.html",
+  {
+    "url": "https://w3c.github.io/gamepad/extensions.html",
+    "nightly": {
+      "sourcePath": "extensions.html"
+    }
+  },
   "https://w3c.github.io/mathml-aam/",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/mediacapture-automation/",
@@ -134,7 +150,10 @@
   "https://wicg.github.io/shape-detection-api/",
   {
     "url": "https://wicg.github.io/shape-detection-api/text.html",
-    "shortname": "text-detection-api"
+    "shortname": "text-detection-api",
+    "nightly": {
+      "sourcePath": "text.bs"
+    }
   },
   {
     "url": "https://wicg.github.io/sms-one-time-codes/",
@@ -148,7 +167,12 @@
   "https://wicg.github.io/web-locks/",
   "https://wicg.github.io/web-otp/",
   "https://wicg.github.io/webhid/",
-  "https://wicg.github.io/webpackage/loading.html",
+  {
+    "url": "https://wicg.github.io/webpackage/loading.html",
+    "nightly": {
+      "sourcePath": "loading.bs"
+    }
+  },
   "https://wicg.github.io/webusb/",
   "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
   "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
@@ -197,6 +221,9 @@
     "shortname": "webgl1",
     "series": {
       "shortname": "webgl1"
+    },
+    "nightly": {
+      "sourcePath": "specs/latest/1.0/index.html"
     }
   },
   {
@@ -204,6 +231,9 @@
     "shortname": "webgl2",
     "series": {
       "shortname": "webgl2"
+    },
+    "nightly": {
+      "sourcePath": "specs/latest/2.0/index.html"
     }
   },
   "https://www.w3.org/TR/accelerometer/",
@@ -327,7 +357,12 @@
     "shortTitle": "CSS Sizing 4"
   },
   "https://www.w3.org/TR/css-speech-1/",
-  "https://www.w3.org/TR/css-style-attr/",
+  {
+    "url": "https://www.w3.org/TR/css-style-attr/",
+    "nightly": {
+      "sourcePath": "css-style-attr-1/Overview.src.html"
+    }
+  },
   "https://www.w3.org/TR/css-syntax-3/",
   "https://www.w3.org/TR/css-tables-3/",
   "https://www.w3.org/TR/css-text-3/",
@@ -356,18 +391,38 @@
   },
   "https://www.w3.org/TR/css-will-change-1/",
   "https://www.w3.org/TR/css-writing-modes-4/",
-  "https://www.w3.org/TR/CSS21/ multipage",
-  "https://www.w3.org/TR/CSS22/ multipage",
+  {
+    "url": "https://www.w3.org/TR/CSS21/",
+    "multipage": true,
+    "nightly": {
+      "sourcePath": "css2/Overview.bs"
+    }
+  },
+  {
+    "url": "https://www.w3.org/TR/CSS22/",
+    "multipage": true,
+    "nightly": {
+      "sourcePath": "css2/Overview.bs"
+    }
+  },
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",
-    "seriesVersion": "3"
+    "seriesVersion": "1",
+    "nightly": {
+      "sourcePath": "css-exclusions-1/Overview.bs"
+    }
   },
   "https://www.w3.org/TR/cssom-1/",
   "https://www.w3.org/TR/cssom-view-1/",
   "https://www.w3.org/TR/device-memory-1/",
   "https://www.w3.org/TR/DOM-Parsing/",
   "https://www.w3.org/TR/encoding/",
-  "https://www.w3.org/TR/encrypted-media/",
+  {
+    "url": "https://www.w3.org/TR/encrypted-media/",
+    "nightly": {
+      "sourcePath": "encrypted-media-respec.html"
+    }
+  },
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
     "shortTitle": "Fetch Metadata"
@@ -398,14 +453,24 @@
   "https://www.w3.org/TR/longtasks-1/",
   "https://www.w3.org/TR/magnetometer/",
   "https://www.w3.org/TR/media-capabilities/",
-  "https://www.w3.org/TR/media-source/",
+  {
+    "url": "https://www.w3.org/TR/media-source/",
+    "nightly": {
+      "sourcePath": "media-source-respec.html"
+    }
+  },
   "https://www.w3.org/TR/mediacapture-depth/",
   "https://www.w3.org/TR/mediacapture-fromelement/",
   "https://www.w3.org/TR/mediacapture-streams/",
   "https://www.w3.org/TR/mediaqueries-4/",
   "https://www.w3.org/TR/mediaqueries-5/ delta",
   "https://www.w3.org/TR/mediasession/",
-  "https://www.w3.org/TR/mediastream-recording/",
+  {
+    "url": "https://www.w3.org/TR/mediastream-recording/",
+    "nightly": {
+      "sourcePath": "MediaRecorder.bs"
+    }
+  },
   "https://www.w3.org/TR/mixed-content/",
   "https://www.w3.org/TR/motion-1/",
   "https://www.w3.org/TR/mst-content-hint/",
@@ -414,7 +479,12 @@
   "https://www.w3.org/TR/orientation-event/",
   "https://www.w3.org/TR/orientation-sensor/",
   "https://www.w3.org/TR/page-visibility-2/",
-  "https://www.w3.org/TR/paint-timing/",
+  {
+    "url": "https://www.w3.org/TR/paint-timing/",
+    "nightly": {
+      "sourcePath": "painttiming.bs"
+    }
+  },
   "https://www.w3.org/TR/payment-handler/",
   {
     "url": "https://www.w3.org/TR/payment-method-basic-card/",
@@ -489,7 +559,12 @@
   "https://www.w3.org/TR/webdriver2/",
   "https://www.w3.org/TR/WebIDL-1/",
   "https://www.w3.org/TR/webmidi/",
-  "https://www.w3.org/TR/webrtc-identity/",
+  {
+    "url": "https://www.w3.org/TR/webrtc-identity/",
+    "nightly": {
+      "sourcePath": "identity.html"
+    }
+  },
   "https://www.w3.org/TR/webrtc-priority/",
   {
     "url": "https://www.w3.org/TR/webrtc-stats/",
@@ -508,7 +583,10 @@
   "https://www.w3.org/TR/webxrlayers-1/",
   {
     "url": "https://www.w3.org/TR/WOFF2/",
-    "shortTitle": "WOFF 2.0"
+    "shortTitle": "WOFF 2.0",
+    "nightly": {
+      "sourcePath": "woff2/index.html"
+    }
   },
   "https://xhr.spec.whatwg.org/"
 ]

--- a/specs.json
+++ b/specs.json
@@ -448,12 +448,7 @@
   },
   "https://www.w3.org/TR/mediacapture-depth/",
   "https://www.w3.org/TR/mediacapture-fromelement/",
-  {
-    "url": "https://www.w3.org/TR/mediacapture-streams/",
-    "nightly": {
-      "sourcePath": "getusermedia.html"
-    }
-  },
+  "https://www.w3.org/TR/mediacapture-streams/",
   "https://www.w3.org/TR/mediaqueries-4/",
   "https://www.w3.org/TR/mediaqueries-5/ delta",
   "https://www.w3.org/TR/mediasession/",
@@ -529,8 +524,18 @@
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
   "https://www.w3.org/TR/trace-context-1/",
-  "https://www.w3.org/TR/uievents-code/",
-  "https://www.w3.org/TR/uievents-key/",
+  {
+    "url": "https://www.w3.org/TR/uievents-code/",
+    "nightly": {
+      "sourcePath": "index-source.txt"
+    }
+  },
+  {
+    "url": "https://www.w3.org/TR/uievents-key/",
+    "nightly": {
+      "sourcePath": "index-source.txt"
+    }
+  },
   "https://www.w3.org/TR/uievents/",
   "https://www.w3.org/TR/upgrade-insecure-requests/",
   "https://www.w3.org/TR/user-timing-2/",

--- a/specs.json
+++ b/specs.json
@@ -81,12 +81,7 @@
   "https://url.spec.whatwg.org/",
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contentEditable/",
-  {
-    "url": "https://w3c.github.io/gamepad/extensions.html",
-    "nightly": {
-      "sourcePath": "extensions.html"
-    }
-  },
+  "https://w3c.github.io/gamepad/extensions.html",
   "https://w3c.github.io/mathml-aam/",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/mediacapture-automation/",
@@ -150,10 +145,7 @@
   "https://wicg.github.io/shape-detection-api/",
   {
     "url": "https://wicg.github.io/shape-detection-api/text.html",
-    "shortname": "text-detection-api",
-    "nightly": {
-      "sourcePath": "text.bs"
-    }
+    "shortname": "text-detection-api"
   },
   {
     "url": "https://wicg.github.io/sms-one-time-codes/",
@@ -167,12 +159,7 @@
   "https://wicg.github.io/web-locks/",
   "https://wicg.github.io/web-otp/",
   "https://wicg.github.io/webhid/",
-  {
-    "url": "https://wicg.github.io/webpackage/loading.html",
-    "nightly": {
-      "sourcePath": "loading.bs"
-    }
-  },
+  "https://wicg.github.io/webpackage/loading.html",
   "https://wicg.github.io/webusb/",
   "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
   "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
@@ -559,12 +546,7 @@
   "https://www.w3.org/TR/webdriver2/",
   "https://www.w3.org/TR/WebIDL-1/",
   "https://www.w3.org/TR/webmidi/",
-  {
-    "url": "https://www.w3.org/TR/webrtc-identity/",
-    "nightly": {
-      "sourcePath": "identity.html"
-    }
-  },
+  "https://www.w3.org/TR/webrtc-identity/",
   "https://www.w3.org/TR/webrtc-priority/",
   {
     "url": "https://www.w3.org/TR/webrtc-stats/",

--- a/specs.json
+++ b/specs.json
@@ -448,7 +448,12 @@
   },
   "https://www.w3.org/TR/mediacapture-depth/",
   "https://www.w3.org/TR/mediacapture-fromelement/",
-  "https://www.w3.org/TR/mediacapture-streams/",
+  {
+    "url": "https://www.w3.org/TR/mediacapture-streams/",
+    "nightly": {
+      "sourcePath": "getusermedia.html"
+    }
+  },
   "https://www.w3.org/TR/mediaqueries-4/",
   "https://www.w3.org/TR/mediaqueries-5/ delta",
   "https://www.w3.org/TR/mediasession/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -17,6 +17,14 @@ const determineFilename = require("./determine-filename.js");
 const extractPages = require("./extract-pages.js");
 const fetchInfo = require("./fetch-info.js");
 const { w3cApiKey } = require("../config.json");
+const githubToken = (_ => {
+  try {
+    return require("../config.json").githubToken;
+  }
+  catch {
+    return process.env.GITHUB_TOKEN;
+  }
+})();
 
 // If the index already exists, reuse the info it contains when info cannot
 // be refreshed due to some external (network) issue.
@@ -90,14 +98,21 @@ const specs = require("../specs.json")
 // Fetch additional spec info from external sources and complete the list
 fetchInfo(specs, { w3cApiKey })
   .then(specInfo => specs.map(spec => {
-    // Note on the "assign" call:
-    // - `{}` is needed to avoid overriding spec
-    // - `spec` appears first to impose the order of properties computed above
-    // in the resulting object
-    // - `specInfo[spec.shortname]` is the info we retrieved from the source
-    // - final `spec` ensures that properties defined in specs.json override
-    // info from the source.
-    const res = Object.assign({}, spec, specInfo[spec.shortname], spec);
+    // Make a copy of the spec object and extend it with the info we retrieved
+    // from the source
+    const res = Object.assign({}, spec, specInfo[spec.shortname]);
+
+    // Specific info in specs.json overrides info from the source
+    // (but not we go one level deeper not to override the entire "nightly"
+    // property, as specs.json may only override one of its sub-properties).
+    Object.keys(spec).forEach(key => {
+      if (res[key] && (typeof spec[key] === 'object')) {
+        Object.assign(res[key], spec[key]);
+      }
+      else {
+        res[key] = spec[key];
+      }
+    });
 
     // Update the current specification based on the info returned by the
     // W3C API, unless specs.json imposed a specific level.
@@ -124,7 +139,7 @@ fetchInfo(specs, { w3cApiKey })
   }))
 
   // Complete with repository
-  .then(index => computeRepository(index))
+  .then(index => computeRepository(index, { githubToken }))
 
   // Complete with list of pages for multipage specs
   .then(index => Promise.all(

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -103,7 +103,7 @@ fetchInfo(specs, { w3cApiKey })
     const res = Object.assign({}, spec, specInfo[spec.shortname]);
 
     // Specific info in specs.json overrides info from the source
-    // (but not we go one level deeper not to override the entire "nightly"
+    // (but note we go one level deeper not to override the entire "nightly"
     // property, as specs.json may only override one of its sub-properties).
     Object.keys(spec).forEach(key => {
       if (res[key] && (typeof spec[key] === 'object')) {

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -1,13 +1,13 @@
 /**
- * Module that exports a function that takes the URL of a specification as input
- * and computes the URL of the repository that contains the source code for this
- * specification.
+ * Module that exports a function that takes a list of specifications as input
+ * and computes, for each of them, the URL of the repository that contains the
+ * source code for this, as well as the source file of the specification at the
+ * HEAD of default branch in the repository.
  *
- * The function returns null when it cannot compute the URL of a repository from
- * the given URL.
+ * The function needs an authentication token for the GitHub API.
  */
 
-const fetch = require("node-fetch");
+const { Octokit } = require("@octokit/rest");
 
 
 /**
@@ -67,20 +67,16 @@ function urlToGitHubRepository(url) {
 
 
 /**
- * Function that takes a GitHub repo owner name (lowercase version) and that
- * retrieves the real owner name (with possible uppercase characters) from the
- * GitHub API.
+ * Returns the first item in the list found in the array, or null if none of
+ * the items exists in the array.
  */
-async function fetchRealGitHubOwnerName(owner) {
-  return await fetch(`https://api.github.com/users/${owner}`)
-    .then(resp => resp.json())
-    .then(resp => {
-      // Alert when user does not exist
-      if (resp.message) {
-        throw resp.message;
-      }
-      return resp.login;
-    });
+function getFirstFoundInArray(array, ...items) {
+  for (const item of items) {
+    if (array.includes(item)) {
+      return item;
+    }
+  }
+  return null;
 }
 
 
@@ -89,11 +85,12 @@ async function fetchRealGitHubOwnerName(owner) {
  * as input, completes entries with a nightly.repository property when possible
  * and returns the list.
  *
- * The options parameter can be used to set a `localOnly` flag that tells the
- * function to bypass the "fake to real" repo owner name mapping, which requires
- * going through the GitHub API. This is useful to prevent tests from exceeding
- * GitHub API's rate limit (but obviously means that the owner name returned
- * by the function will remain the lowercased version).
+ * The options parameter is used to specify the GitHub API authentication token.
+ * In the absence of it, the function does not go through the GitHub API and
+ * thus cannot set most of the information. This is useful to run tests without
+ * an authentication token (but obviously means that the owner name returned
+ * by the function will remain the lowercased version, and that the returned
+ * info won't include the source file).
  */
 module.exports = async function (specs, options) {
   if (!specs || specs.find(spec => !spec.nightly || !spec.nightly.url)) {
@@ -101,28 +98,104 @@ module.exports = async function (specs, options) {
   }
   options = options || {};
 
+  const octokit = new Octokit({ auth: options.githubToken });
+  const repoPathCache = new Map();
+  const userCache = new Map();
+
+  /**
+   * Take a GitHub repo owner name (lowercase version) and retrieve the real
+   * owner name (with possible uppercase characters) from the GitHub API.
+   */
+  async function fetchRealGitHubOwnerName(username) {
+    if (!userCache.has(username)) {
+      const { data } = await octokit.users.getByUsername({ username });
+      if (data.message) {
+        // Alert when user does not exist
+        throw res.message;
+      }
+      userCache.set(username, data.login);
+    }
+    return userCache.get(username);
+  }
+
+  /**
+   * Determine the name of the file that contains the source of the spec in the
+   * default branch of the GitHub repository associated with the specification.
+   */
+  async function determineSourcePath(spec, repo) {
+    // Retrieve all paths of the GitHub repository
+    const cacheKey = `${repo.owner}/${repo.name}`;
+    if (!repoPathCache.has(cacheKey)) {
+      const { data } = await octokit.git.getTree({
+        owner: repo.owner,
+        repo: repo.name,
+        tree_sha: "HEAD",
+        recursive: true
+      });
+      const paths = data.tree.map(entry => entry.path);
+      repoPathCache.set(cacheKey, paths);
+    }
+    const paths = repoPathCache.get(cacheKey);
+
+    return getFirstFoundInArray(paths,
+      // Common paths for CSS specs
+      `${spec.shortname}.bs`,
+      `${spec.shortname}/Overview.bs`,
+      `${spec.shortname}/Overview.src.html`,
+      `${spec.series.shortname}/Overview.bs`,
+      `${spec.series.shortname}/Overview.src.html`,
+
+      // WebGL extensions
+      `extensions/${spec.shortname}/extension.xml`,
+
+      // WebAssembly specs
+      `document/${spec.series.shortname.replace(/^wasm-/, '')}/index.bs`,
+
+      // SVG specs
+      `specs/${spec.shortname.replace(/^svg-/, '')}/master/Overview.html`,
+      `master/Overview.html`,
+
+      // Following patterns are used in a small number of cases, but could
+      // perhaps appear again in the future, so worth handling here.
+      "spec/index.bs",
+      "spec/index.html",    // Only one TC39 spec
+      "spec/Overview.html", // Only WebCrypto
+      "docs/index.bs",      // Only ServiceWorker
+      "spec.html",          // Most TC39 specs
+
+      // Most common patterns, checking on "index.html" last as some repos
+      // include such a file to store the generated spec from the source.
+      "index.src.html",
+      "index.bs",
+      "spec.bs",
+      "index.html"
+    );
+  }
+
   // Compute GitHub repositories with lowercase owner names
   const repos = specs.map(spec => urlToGitHubRepository(spec.nightly.url));
 
-  // Extract the list of owners and fetch their real name (preserving case)
-  if (!options.localOnly) {
-    const owners = [...new Set(repos.map(repo => repo.owner))];
-    const realOwners = await Promise.all(
-      owners.map(owner => fetchRealGitHubOwnerName(owner)));
-    const ownerMapping = {};
-    owners.forEach((owner, idx) => ownerMapping[owner] = realOwners[idx]);
-
-    // Use real owner names
-    repos.forEach(repo => repo.owner = ownerMapping[repo.owner]);
+  if (options.githubToken) {
+    // Fetch the real name of repository owners (preserving case)
+    for (const repo of repos) {
+      repo.owner = await fetchRealGitHubOwnerName(repo.owner);
+    }
   }
 
-  // Compute final repo URL
-  specs.forEach((spec, idx) => {
-    const repo = repos[idx];
+  // Compute final repo URL and add source file if possible
+  for (const spec of specs) {
+    const repo = repos.shift();
     if (repo) {
       spec.nightly.repository = `https://github.com/${repo.owner}/${repo.name}`;
+
+      if (options.githubToken && !spec.nightly.sourcePath) {
+        const sourcePath = await determineSourcePath(spec, repo);
+        if (sourcePath) {
+          spec.nightly.sourcePath = sourcePath;
+        }
+      }
     }
-  });
+  }
 
   return specs;
 };

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -137,6 +137,10 @@ module.exports = async function (specs, options) {
     }
     const paths = repoPathCache.get(cacheKey);
 
+    // Extract filename from nightly URL when there is one
+    const match = spec.nightly.url.match(/\/(\w+)\.html$/);
+    const nightlyFilename = match ? match[1] : "";
+
     return getFirstFoundInArray(paths,
       // Common paths for CSS specs
       `${spec.shortname}.bs`,
@@ -144,6 +148,10 @@ module.exports = async function (specs, options) {
       `${spec.shortname}/Overview.src.html`,
       `${spec.series.shortname}/Overview.bs`,
       `${spec.series.shortname}/Overview.src.html`,
+
+      // Named after the nightly filename
+      `${nightlyFilename}.bs`,
+      `${nightlyFilename}.html`,
 
       // WebGL extensions
       `extensions/${spec.shortname}/extension.xml`,

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -4,7 +4,7 @@ const computeRepo = require("../src/compute-repository.js");
 describe("compute-repository module", async () => {
   async function computeSingleRepo(url) {
     const spec = { nightly: { url } };
-    const result = await computeRepo([spec], { localOnly: true });
+    const result = await computeRepo([spec]);
     return result[0].nightly.repository;
   };
 

--- a/test/index.js
+++ b/test/index.js
@@ -87,8 +87,18 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("contains nightly URLs for all specs", () => {
+    const wrong = specs.filter(s => !s.nightly.url);
+    assert.deepStrictEqual(wrong, []);
+  });
+
   it("contains repository URLs for all specs", () => {
     const wrong = specs.filter(s => !s.nightly.repository);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("contains relative paths to source of nightly spec for all specs", () => {
+    const wrong = specs.filter(s => !s.nightly.sourcePath);
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
This update makes the build process compute the relative path to the source of the nightly version of each spec at the HEAD of the default branch of the spec repository. That information gets exposed in the `nightly.sourcePath` property.

The code retrieves and parses the tree of the repository from the GitHub API, looking for common patterns (such as `index.bs`). The code follows the same logic as in the Web IDL updater in:
https://github.com/saschanaz/webidl-updater/blob/main/src/find-source-path.js

As opposed to the approach taken in the auto updater, the code here does not attempt to differentiate between types of specs (because that does not seem needed) and does not try to deal with exceptions-to-the-rule which rather need to be handled by specifying `nightly.sourcePath` in `specs.json`. In practice, that is needed for 17 specifications out of 379.

A valid GitHub authentication token is needed not to end up being rate limited by GitHub. The same authentication token is now also used to retrieve the case-sensitive version of repository owners.

The `sourcePath` property should always be set, and tests will fail if one is missing.

@saschanaz, first, many thanks for identifying what the common patterns were and for creating a reference list against which I could compare the results I get. I took the liberty to base the code logic on yours, I hope that's fine :) I compared the result with the reference file in the Web IDL updater [spec-sources.browsers.generated.json](https://github.com/saschanaz/webidl-updater/blob/main/spec-sources.browsers.generated.json) and could only spot 2 differences for WebAssembly specs that are, I believe, due to wrong info on your side:
- For wasm-js-api-1, correct path should be `document/js-api/index.bs` but your file has `document/core/index.bs` (which is the path to the core WebAssembly spec)
- For wasm-web-api-1, correct path should be `document/web-api/index.bs` but your file also has `document/core/index.bs`

One possible question: the `sourcePath` property is to be interpreted at the HEAD of the default branch of the repository. That said, we don't expose the name of the default branch. That's not needed to compute an absolute HTTPS URL to the source file and I added the formula in the README. Would it be better to (also, or instead) expose the absolute URL in `index.json`? And/Or should we expose the default branch name? 

Close #173.

PS: The update also fixes the `seriesVersion` for the css3-exclusions spec, since the spec is actually at Level 1.