### PR TITLE
Add ECMAscript Internationalization API spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -70,6 +70,11 @@
     "shortname": "ecmascript",
     "shortTitle": "ECMAScript"
   },
+  {
+    "url": "https://tc39.es/ecma402/",
+    "shortname": "ecma-402",
+    "shortTitle": "Intl API"
+  },
   "https://tc39.es/proposal-atomics-wait-async/",
   "https://tc39.es/proposal-class-fields/",
   "https://tc39.es/proposal-import-assertions/",

--- a/specs.json
+++ b/specs.json
@@ -72,8 +72,7 @@
   },
   {
     "url": "https://tc39.es/ecma402/",
-    "shortname": "ecma-402",
-    "shortTitle": "Intl API"
+    "shortname": "ecma-402"
   },
   "https://tc39.es/proposal-atomics-wait-async/",
   "https://tc39.es/proposal-class-fields/",


### PR DESCRIPTION
The `ecma-402` shortname is based on that used in Specref.
Short title may be too short, perhaps?