### PR TITLE
Fix version extraction for WebGL extensions and ECMA specs

### DIFF
--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -122,7 +122,7 @@ function computeShortname(url) {
 /**
  * Compute the shortname and level from the spec name, if possible.
  */
-function completeWithSeriesAndLevel(shortname) {
+function completeWithSeriesAndLevel(shortname, url) {
   // Use latest convention for CSS specs
   function modernizeShortname(name) {
     if (name.startsWith("css3-")) {
@@ -134,6 +134,16 @@ function completeWithSeriesAndLevel(shortname) {
     else {
       return name;
     }
+  }
+
+  // Shortnames of WebGL extensions sometimes end up with digits which are *not*
+  // to be interpreted as level numbers. Similarly, shortnames of ECMA specs
+  // typically have the form "ecma-ddd", and "ddd" is *not* a level number.
+  if (shortname.match(/^ecma-/) || url.match(/^https:\/\/www\.khronos\.org\/registry\/webgl\/extensions\//)) {
+    return {
+      shortname,
+      series: { shortname }
+    };
   }
 
   // Extract X and X.Y levels, with form "name-X" or "name-X.Y".
@@ -174,5 +184,5 @@ module.exports = function (url) {
   if (!url) {
     throw "No URL passed as parameter";
   }
-  return completeWithSeriesAndLevel(computeShortname(url));
+  return completeWithSeriesAndLevel(computeShortname(url), url);
 }

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -20,6 +20,10 @@ describe("compute-shortname module", () => {
       assertName("https://tc39.es/proposal-smartidea/", "tc39-smartidea");
     });
 
+    it("handles Khronos Group WebGL extensions", () => {
+      assertName("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/", "EXT_wow32");
+    });
+
     it("handles URLs of drafts on GitHub", () => {
       assertName("https://wicg.github.io/whataspec/", "whataspec");
     });
@@ -140,6 +144,14 @@ describe("compute-shortname module", () => {
     it("automatically updates CSS specs with an old 'css3-' name", () => {
       assertSeries("css3-conditional", "css-conditional");
     });
+
+    it("preserves ECMA spec numbers", () => {
+      assertSeries("ecma-402", "ecma-402");
+    });
+
+    it("preserves digits at the end of WebGL extension names", () => {
+      assertSeries("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/", "EXT_wow32");
+    });
   });
 
 
@@ -182,6 +194,14 @@ describe("compute-shortname module", () => {
 
     it("does not get lost with inner digits", () => {
       assertNoSeriesVersion("my-2-cents");
+    });
+
+    it("does not confuse an ECMA spec number with a series version", () => {
+      assertNoSeriesVersion("ecma-402");
+    });
+
+    it("does not confuse digits at the end of a WebGL extension spec with a series version", () => {
+      assertNoSeriesVersion("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/");
     });
   });
 });


### PR DESCRIPTION
Shortnames of WebGL extensions and ECMA specs sometimes end with digits that were incorrectly interpreted as level numbers. This update excludes these specs from the level extraction logic. In turn, this makes the code generate the right `seriesVersion` property for these specs (none in practice) and the right `series.shortname`.

Close #221.