### PR TITLE
Expose test repository and paths for each spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.cache
 node_modules/
 config.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,11 @@ full is the default).
     **and** when it cannot be fixed at the source.
   - The code cannot compute the right [`sourcePath`](README.md#nightlysourcepath)
     because the source file of the nightly spec does not follow a common pattern.
+- `tests`: same as the [`tests`](README.md#tests) property in `index.json`. The
+property must only be set when:
+  - The test suite of the specification is not in a well-known repository.
+  - The code cannot determine the correct list of [`testPaths`](README.md#teststestpaths)
+    and/or [`excludePaths`](README.md#testsexcludepaths).
 - `shortTitle`: same as the [`shortTitle`](README.md#shorttitle) property in
 `index.json`. The property must only be set when the short title computed
 automatically is not the expected one.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ cross-references, WebIDL, quality, etc.
     - [`nightly.pages`](#nightlypages)
     - [`nightly.repository`](#nightlyrepository)
     - [`nightly.sourcePath`](#nightlysourcepath)
+  - [`tests`](#tests)
+    - [`tests.repository`](#testsrepository)
+    - [`tests.testPaths`](#teststestpaths)
+    - [`tests.excludePaths`](#testsexcludepaths)
   - [`source`](#source)
 - [How to add/update/delete a spec](#how-to-addupdatedelete-a-spec)
 - [Spec selection criteria](#spec-selection-criteria)
@@ -97,6 +101,10 @@ Each specification in the list comes with the following properties:
     "repository": "https://github.com/w3c/csswg-drafts",
     "filename": "Overview.html",
     "sourcePath": "css-color-4/Overview.bs"
+  },
+  "tests": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "testPaths": ["css/css-color"]
   },
   "source": "w3c"
 }
@@ -312,6 +320,47 @@ The `sourcePath` property is always set.
 **Note:** The path is relative to the root of the repository, and only valid in
 the default branch of the repository. If needed, the source may be fetched from
 the absolute HTTPS URL `${nightly.repository}/blob/HEAD/${nightly.sourcePath}`.
+
+
+### `tests`
+
+An object that links the specification with its test suite when it has one.
+
+
+#### `tests.repository`
+
+The URL of the repository that contains the test suite of the specification,
+typically `https://github.com/web-platform-tests/wpt`.
+
+The `repository` property is always set when the `tests` object is present.
+
+#### `tests.testPaths`
+
+The list of relative paths to the actual tests at the HEAD of the default branch
+of the test repository.
+
+For test suites within [Web Platform
+Tests](https://github.com/web-platform-tests/wpt), the list is determined by
+looking at `META.yml` files within each folder.
+
+The `testPaths` array typically only contains one entry, but tests of a given
+spec are sometimes spread over multiple folders. For instance, that is the case
+for DOM and HTML tests.
+
+The `testPaths` property is usually set when the `tests` object is present. When
+absent, that means that the entire repository is the test suite.
+
+#### `tests.excludePaths`
+
+The list of relative sub-paths of paths listed in the `testPaths` property that
+do not contain tests for the underlying spec. For instance, tests for the
+WebXR Device API are under the
+[`webxr`](https://github.com/web-platform-tests/wpt/tree/master/webxr) folder,
+but several folders under `webxr` actually contain test suites for WebXR module
+specs and as such need to be excluded from the test suite of the WebXR Device
+API spec.
+
+The `excludePaths` property is seldom set.
 
 
 ### `source`

--- a/index.json
+++ b/index.json
@@ -15,7 +15,13 @@
     },
     "title": "Compatibility Standard",
     "source": "specref",
-    "shortTitle": "Compatibility"
+    "shortTitle": "Compatibility",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "compat"
+      ]
+    }
   },
   {
     "url": "https://console.spec.whatwg.org/",
@@ -33,7 +39,13 @@
     },
     "title": "Console Standard",
     "source": "specref",
-    "shortTitle": "Console"
+    "shortTitle": "Console",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "console"
+      ]
+    }
   },
   {
     "url": "https://dom.spec.whatwg.org/",
@@ -51,7 +63,14 @@
     },
     "title": "DOM Standard",
     "source": "specref",
-    "shortTitle": "DOM"
+    "shortTitle": "DOM",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "dom",
+        "shadow-dom"
+      ]
+    }
   },
   {
     "url": "https://drafts.css-houdini.org/css-typed-om-2/",
@@ -71,7 +90,13 @@
     },
     "title": "CSS Typed OM Level 2",
     "source": "spec",
-    "shortTitle": "CSS Typed OM 2"
+    "shortTitle": "CSS Typed OM 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-typed-om"
+      ]
+    }
   },
   {
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
@@ -110,7 +135,13 @@
     },
     "title": "CSS Animations Level 2",
     "source": "spec",
-    "shortTitle": "CSS Animations 2"
+    "shortTitle": "CSS Animations 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-animations"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
@@ -130,7 +161,13 @@
     },
     "title": "CSS Backgrounds and Borders Module Level 4",
     "source": "specref",
-    "shortTitle": "CSS Backgrounds and Borders 4"
+    "shortTitle": "CSS Backgrounds and Borders 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-backgrounds"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-cascade-5/",
@@ -150,7 +187,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 5",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-cascade"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-env-1/",
@@ -169,7 +212,13 @@
     },
     "title": "CSS Environment Variables Module Level 1",
     "source": "spec",
-    "shortTitle": "CSS Environment Variables 1"
+    "shortTitle": "CSS Environment Variables 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-env"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-extensions-1/",
@@ -208,7 +257,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module Level 4",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-gcpm"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-grid-3/",
@@ -228,7 +283,13 @@
     },
     "title": "CSS Grid Layout Module Level 3",
     "source": "spec",
-    "shortTitle": "CSS Grid Layout 3"
+    "shortTitle": "CSS Grid Layout 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-grid"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-multicol-2/",
@@ -248,7 +309,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 2",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-multicol"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-nesting-1/",
@@ -287,7 +354,13 @@
     },
     "title": "Proposals for the future of CSS Paged Media",
     "source": "spec",
-    "shortTitle": "Proposals for the future of CSS Paged Media"
+    "shortTitle": "Proposals for the future of CSS Paged Media",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-page"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-shapes-2/",
@@ -307,7 +380,13 @@
     },
     "title": "CSS Shapes Module Level 2",
     "source": "spec",
-    "shortTitle": "CSS Shapes 2"
+    "shortTitle": "CSS Shapes 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-shapes"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
@@ -326,7 +405,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Mobile Text Size Adjustment Module Level 1",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-size-adjust"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/css-transitions-2/",
@@ -346,7 +431,13 @@
     },
     "title": "CSS Transitions Level 2",
     "source": "spec",
-    "shortTitle": "CSS Transitions 2"
+    "shortTitle": "CSS Transitions 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-transitions"
+      ]
+    }
   },
   {
     "url": "https://drafts.csswg.org/scroll-animations-1/",
@@ -365,7 +456,13 @@
     },
     "title": "Scroll-linked Animations",
     "source": "spec",
-    "shortTitle": "Scroll-linked Animations"
+    "shortTitle": "Scroll-linked Animations",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "scroll-animations"
+      ]
+    }
   },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",
@@ -385,7 +482,13 @@
       "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 2",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/compositing"
+      ]
+    }
   },
   {
     "url": "https://drafts.fxtf.org/filter-effects-2/",
@@ -405,7 +508,13 @@
     },
     "title": "Filter Effects Module Level 2",
     "source": "spec",
-    "shortTitle": "Filter Effects 2"
+    "shortTitle": "Filter Effects 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/filter-effects"
+      ]
+    }
   },
   {
     "url": "https://fetch.spec.whatwg.org/",
@@ -423,7 +532,17 @@
     },
     "title": "Fetch Standard",
     "source": "specref",
-    "shortTitle": "Fetch"
+    "shortTitle": "Fetch",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "cors",
+        "fetch"
+      ],
+      "excludePaths": [
+        "fetch/metadata"
+      ]
+    }
   },
   {
     "url": "https://fullscreen.spec.whatwg.org/",
@@ -441,7 +560,13 @@
     },
     "title": "Fullscreen API Standard",
     "source": "specref",
-    "shortTitle": "Fullscreen API"
+    "shortTitle": "Fullscreen API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "fullscreen"
+      ]
+    }
   },
   {
     "url": "https://gpuweb.github.io/gpuweb/",
@@ -450,6 +575,12 @@
     "series": {
       "shortname": "gpuweb",
       "currentSpecification": "gpuweb"
+    },
+    "tests": {
+      "repository": "https://github.com/gpuweb/cts",
+      "testPaths": [
+        "src/webgpu"
+      ]
     },
     "nightly": {
       "url": "https://gpuweb.github.io/gpuweb/",
@@ -538,7 +669,23 @@
     },
     "title": "HTML Standard",
     "source": "specref",
-    "shortTitle": "HTML"
+    "shortTitle": "HTML",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "custom-elements",
+        "eventsource",
+        "html",
+        "imagebitmap-renderingcontext",
+        "webmessaging",
+        "websockets",
+        "webstorage",
+        "workers",
+        "worklets",
+        "x-frame-options",
+        "xslt"
+      ]
+    }
   },
   {
     "url": "https://immersive-web.github.io/anchors/",
@@ -556,7 +703,13 @@
     },
     "title": "WebXR Anchors Module",
     "source": "spec",
-    "shortTitle": "WebXR Anchors"
+    "shortTitle": "WebXR Anchors",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/anchors"
+      ]
+    }
   },
   {
     "url": "https://immersive-web.github.io/dom-overlays/",
@@ -574,7 +727,13 @@
     },
     "title": "WebXR DOM Overlays Module",
     "source": "spec",
-    "shortTitle": "WebXR DOM Overlays"
+    "shortTitle": "WebXR DOM Overlays",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/dom-overlay"
+      ]
+    }
   },
   {
     "url": "https://immersive-web.github.io/hit-test/",
@@ -592,7 +751,13 @@
     },
     "title": "WebXR Hit Test Module",
     "source": "spec",
-    "shortTitle": "WebXR Hit Test"
+    "shortTitle": "WebXR Hit Test",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/hit-test"
+      ]
+    }
   },
   {
     "url": "https://infra.spec.whatwg.org/",
@@ -628,7 +793,13 @@
     },
     "title": "MathML Core",
     "source": "specref",
-    "shortTitle": "MathML Core"
+    "shortTitle": "MathML Core",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mathml"
+      ]
+    }
   },
   {
     "url": "https://mimesniff.spec.whatwg.org/",
@@ -646,7 +817,13 @@
     },
     "title": "MIME Sniffing Standard",
     "source": "specref",
-    "shortTitle": "MIME Sniffing"
+    "shortTitle": "MIME Sniffing",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mimesniff"
+      ]
+    }
   },
   {
     "url": "https://notifications.spec.whatwg.org/",
@@ -664,7 +841,13 @@
     },
     "title": "Notifications API Standard",
     "source": "specref",
-    "shortTitle": "Notifications API"
+    "shortTitle": "Notifications API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "notifications"
+      ]
+    }
   },
   {
     "url": "https://privacycg.github.io/private-click-measurement/",
@@ -700,7 +883,13 @@
     },
     "title": "The Storage Access API",
     "source": "spec",
-    "shortTitle": "The Storage Access API"
+    "shortTitle": "The Storage Access API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "storage-access-api"
+      ]
+    }
   },
   {
     "url": "https://quirks.spec.whatwg.org/",
@@ -718,7 +907,13 @@
     },
     "title": "Quirks Mode Standard",
     "source": "specref",
-    "shortTitle": "Quirks Mode"
+    "shortTitle": "Quirks Mode",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "quirks"
+      ]
+    }
   },
   {
     "url": "https://storage.spec.whatwg.org/",
@@ -736,7 +931,16 @@
     },
     "title": "Storage Standard",
     "source": "specref",
-    "shortTitle": "Storage"
+    "shortTitle": "Storage",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "storage"
+      ],
+      "excludePaths": [
+        "storage/buckets"
+      ]
+    }
   },
   {
     "url": "https://streams.spec.whatwg.org/",
@@ -754,7 +958,13 @@
     },
     "title": "Streams Standard",
     "source": "specref",
-    "shortTitle": "Streams"
+    "shortTitle": "Streams",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "streams"
+      ]
+    }
   },
   {
     "url": "https://svgwg.org/specs/animations/",
@@ -783,6 +993,15 @@
       "currentSpecification": "ecmascript"
     },
     "shortTitle": "ECMAScript",
+    "tests": {
+      "repository": "https://github.com/tc39/test262",
+      "testPaths": [
+        "test"
+      ],
+      "excludePaths": [
+        "test/intl402"
+      ]
+    },
     "nightly": {
       "url": "https://tc39.es/ecma262/",
       "repository": "https://github.com/tc39/ecma262",
@@ -799,6 +1018,12 @@
     "series": {
       "shortname": "ecma-402",
       "currentSpecification": "ecma-402"
+    },
+    "tests": {
+      "repository": "https://github.com/tc39/test262",
+      "testPaths": [
+        "test/intl402"
+      ]
     },
     "nightly": {
       "url": "https://tc39.es/ecma402/",
@@ -970,7 +1195,13 @@
     },
     "title": "URL Standard",
     "source": "specref",
-    "shortTitle": "URL"
+    "shortTitle": "URL",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "url"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/badging/",
@@ -988,7 +1219,13 @@
     },
     "title": "Badging API",
     "source": "specref",
-    "shortTitle": "Badging API"
+    "shortTitle": "Badging API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "badging"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/contentEditable/",
@@ -1006,7 +1243,13 @@
     },
     "title": "ContentEditable",
     "source": "spec",
-    "shortTitle": "ContentEditable"
+    "shortTitle": "ContentEditable",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "contenteditable"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/gamepad/extensions.html",
@@ -1060,7 +1303,13 @@
     },
     "title": "Media Playback Quality",
     "source": "specref",
-    "shortTitle": "Media Playback Quality"
+    "shortTitle": "Media Playback Quality",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "media-playback-quality"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/mediacapture-automation/",
@@ -1096,7 +1345,13 @@
     },
     "title": "Web NFC API",
     "source": "specref",
-    "shortTitle": "Web NFC API"
+    "shortTitle": "Web NFC API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "web-nfc"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/web-share-target/",
@@ -1150,7 +1405,13 @@
     },
     "title": "Trusted Types",
     "source": "specref",
-    "shortTitle": "Trusted Types"
+    "shortTitle": "Trusted Types",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "trusted-types"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/webdriver-bidi/",
@@ -1204,7 +1465,13 @@
     },
     "title": "WebRTC Insertable Media using Streams",
     "source": "specref",
-    "shortTitle": "WebRTC Insertable Media using Streams"
+    "shortTitle": "WebRTC Insertable Media using Streams",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc-insertable-streams"
+      ]
+    }
   },
   {
     "url": "https://w3c.github.io/webtransport/",
@@ -1222,7 +1489,13 @@
     },
     "title": "WebTransport",
     "source": "spec",
-    "shortTitle": "WebTransport"
+    "shortTitle": "WebTransport",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webtransport"
+      ]
+    }
   },
   {
     "url": "https://webbluetoothcg.github.io/web-bluetooth/",
@@ -1240,7 +1513,13 @@
     },
     "title": "Web Bluetooth",
     "source": "specref",
-    "shortTitle": "Web Bluetooth"
+    "shortTitle": "Web Bluetooth",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "bluetooth"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/background-fetch/",
@@ -1258,7 +1537,13 @@
     },
     "title": "Background Fetch",
     "source": "specref",
-    "shortTitle": "Background Fetch"
+    "shortTitle": "Background Fetch",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "background-fetch"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/background-sync/spec/",
@@ -1276,7 +1561,13 @@
       "filename": "index.html"
     },
     "title": "Web Background Synchronization",
-    "source": "spec"
+    "source": "spec",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "BackgroundSync"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/client-hints-infrastructure/",
@@ -1294,7 +1585,13 @@
     },
     "title": "Client Hints Infrastructure",
     "source": "specref",
-    "shortTitle": "Client Hints Infrastructure"
+    "shortTitle": "Client Hints Infrastructure",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "client-hints"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/compression/",
@@ -1312,7 +1609,13 @@
     },
     "title": "Compression Streams",
     "source": "specref",
-    "shortTitle": "Compression Streams"
+    "shortTitle": "Compression Streams",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "compression"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/construct-stylesheets/",
@@ -1330,7 +1633,13 @@
     },
     "title": "Constructable Stylesheet Objects",
     "source": "spec",
-    "shortTitle": "Constructable Stylesheet Objects"
+    "shortTitle": "Constructable Stylesheet Objects",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/construct-stylesheets"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/contact-api/spec/",
@@ -1348,7 +1657,13 @@
     },
     "title": "Contact Picker API",
     "source": "spec",
-    "shortTitle": "Contact Picker API"
+    "shortTitle": "Contact Picker API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "contacts"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/content-index/spec/",
@@ -1366,7 +1681,13 @@
     },
     "title": "Content Index",
     "source": "spec",
-    "shortTitle": "Content Index"
+    "shortTitle": "Content Index",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "content-index"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/cookie-store/",
@@ -1384,7 +1705,13 @@
     },
     "title": "Cookie Store API",
     "source": "specref",
-    "shortTitle": "Cookie Store API"
+    "shortTitle": "Cookie Store API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "cookie-store"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/cors-rfc1918/",
@@ -1402,7 +1729,13 @@
     },
     "title": "CORS and RFC1918",
     "source": "specref",
-    "shortTitle": "CORS and RFC1918"
+    "shortTitle": "CORS and RFC1918",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "cors-rfc1918"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/crash-reporting/",
@@ -1438,7 +1771,13 @@
     },
     "title": "CSS Parser API",
     "source": "specref",
-    "shortTitle": "CSS Parser API"
+    "shortTitle": "CSS Parser API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-parser-api"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/custom-state-pseudo-class/",
@@ -1456,7 +1795,13 @@
     },
     "title": "Custom State Pseudo Class",
     "source": "spec",
-    "shortTitle": "Custom State Pseudo Class"
+    "shortTitle": "Custom State Pseudo Class",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "custom-state-pseudo-class"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/deprecation-reporting/",
@@ -1474,7 +1819,13 @@
     },
     "title": "Deprecation Reporting",
     "source": "spec",
-    "shortTitle": "Deprecation Reporting"
+    "shortTitle": "Deprecation Reporting",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "deprecation-reporting"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/element-timing/",
@@ -1492,7 +1843,13 @@
     },
     "title": "Element Timing API",
     "source": "specref",
-    "shortTitle": "Element Timing API"
+    "shortTitle": "Element Timing API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "element-timing"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/entries-api/",
@@ -1510,7 +1867,13 @@
     },
     "title": "File and Directory Entries API",
     "source": "specref",
-    "shortTitle": "File and Directory Entries API"
+    "shortTitle": "File and Directory Entries API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "entries-api"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/event-timing/",
@@ -1528,7 +1891,13 @@
     },
     "title": "Event Timing API",
     "source": "specref",
-    "shortTitle": "Event Timing API"
+    "shortTitle": "Event Timing API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "event-timing"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/file-system-access/",
@@ -1546,7 +1915,13 @@
     },
     "title": "File System Access",
     "source": "specref",
-    "shortTitle": "File System Access"
+    "shortTitle": "File System Access",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "native-file-system"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/frame-timing/",
@@ -1582,7 +1957,13 @@
     },
     "title": "Get Installed Related Apps API",
     "source": "spec",
-    "shortTitle": "Get Installed Related Apps API"
+    "shortTitle": "Get Installed Related Apps API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "installedapp"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/idle-detection/",
@@ -1600,7 +1981,13 @@
     },
     "title": "Idle Detection API",
     "source": "spec",
-    "shortTitle": "Idle Detection API"
+    "shortTitle": "Idle Detection API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "idle-detection"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/import-maps/",
@@ -1618,7 +2005,13 @@
     },
     "title": "Import Maps",
     "source": "spec",
-    "shortTitle": "Import Maps"
+    "shortTitle": "Import Maps",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "import-maps"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/input-device-capabilities/",
@@ -1636,7 +2029,13 @@
     },
     "title": "Input Device Capabilities",
     "source": "specref",
-    "shortTitle": "Input Device Capabilities"
+    "shortTitle": "Input Device Capabilities",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "input-device-capabilities"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/intervention-reporting/",
@@ -1654,7 +2053,13 @@
     },
     "title": "Intervention Reporting",
     "source": "spec",
-    "shortTitle": "Intervention Reporting"
+    "shortTitle": "Intervention Reporting",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "intervention-reporting"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/is-input-pending/",
@@ -1672,7 +2077,13 @@
     },
     "title": "isInputPending",
     "source": "spec",
-    "shortTitle": "isInputPending"
+    "shortTitle": "isInputPending",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "is-input-pending"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/js-self-profiling/",
@@ -1690,7 +2101,13 @@
     },
     "title": "JS Self-Profiling API",
     "source": "specref",
-    "shortTitle": "JS Self-Profiling API"
+    "shortTitle": "JS Self-Profiling API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "js-self-profiling"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/keyboard-lock/",
@@ -1708,7 +2125,13 @@
     },
     "title": "Keyboard Lock",
     "source": "specref",
-    "shortTitle": "Keyboard Lock"
+    "shortTitle": "Keyboard Lock",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "keyboard-lock"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/keyboard-map/",
@@ -1726,7 +2149,13 @@
     },
     "title": "Keyboard Map",
     "source": "specref",
-    "shortTitle": "Keyboard Map"
+    "shortTitle": "Keyboard Map",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "keyboard-map"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/largest-contentful-paint/",
@@ -1744,7 +2173,13 @@
     },
     "title": "Largest Contentful Paint",
     "source": "specref",
-    "shortTitle": "Largest Contentful Paint"
+    "shortTitle": "Largest Contentful Paint",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "largest-contentful-paint"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/layout-instability/",
@@ -1762,7 +2197,13 @@
     },
     "title": "Layout Instability",
     "source": "specref",
-    "shortTitle": "Layout Instability"
+    "shortTitle": "Layout Instability",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "layout-instability"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/local-font-access/",
@@ -1798,7 +2239,13 @@
     },
     "title": "Media Feeds",
     "source": "spec",
-    "shortTitle": "Media Feeds"
+    "shortTitle": "Media Feeds",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "media-feeds"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/netinfo/",
@@ -1816,7 +2263,13 @@
     },
     "title": "Network Information API",
     "source": "specref",
-    "shortTitle": "Network Information API"
+    "shortTitle": "Network Information API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "netinfo"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/origin-policy/",
@@ -1834,7 +2287,13 @@
     },
     "title": "Origin Policy",
     "source": "specref",
-    "shortTitle": "Origin Policy"
+    "shortTitle": "Origin Policy",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "origin-policy"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/overscroll-scrollend-events/",
@@ -1870,7 +2329,14 @@
     },
     "title": "Page Lifecycle",
     "source": "specref",
-    "shortTitle": "Page Lifecycle"
+    "shortTitle": "Page Lifecycle",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "lifecycle",
+        "page-lifecycle"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/performance-measure-memory/",
@@ -1888,7 +2354,13 @@
     },
     "title": "Measure Memory API",
     "source": "spec",
-    "shortTitle": "Measure Memory API"
+    "shortTitle": "Measure Memory API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "measure-memory"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/periodic-background-sync/",
@@ -1906,7 +2378,13 @@
     },
     "title": "Web Periodic Background Synchronization",
     "source": "specref",
-    "shortTitle": "Web Periodic Background Synchronization"
+    "shortTitle": "Web Periodic Background Synchronization",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "periodic-background-sync"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/permissions-request/",
@@ -1924,7 +2402,13 @@
     },
     "title": "Requesting Permissions",
     "source": "specref",
-    "shortTitle": "Requesting Permissions"
+    "shortTitle": "Requesting Permissions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "permissions-request"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/permissions-revoke/",
@@ -1942,7 +2426,13 @@
     },
     "title": "Relinquishing Permissions",
     "source": "specref",
-    "shortTitle": "Relinquishing Permissions"
+    "shortTitle": "Relinquishing Permissions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "permissions-revoke"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/portals/",
@@ -1960,7 +2450,13 @@
     },
     "title": "Portals",
     "source": "spec",
-    "shortTitle": "Portals"
+    "shortTitle": "Portals",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "portals"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/priority-hints/",
@@ -1978,7 +2474,13 @@
     },
     "title": "Priority Hints",
     "source": "specref",
-    "shortTitle": "Priority Hints"
+    "shortTitle": "Priority Hints",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "priority-hints"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/savedata/",
@@ -1996,7 +2498,13 @@
     },
     "title": "Save Data API",
     "source": "spec",
-    "shortTitle": "Save Data API"
+    "shortTitle": "Save Data API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "savedata"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/scroll-to-text-fragment/",
@@ -2014,7 +2522,13 @@
     },
     "title": "Text Fragments",
     "source": "spec",
-    "shortTitle": "Text Fragments"
+    "shortTitle": "Text Fragments",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "scroll-to-text-fragment"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/serial/",
@@ -2032,7 +2546,13 @@
     },
     "title": "Web Serial API",
     "source": "spec",
-    "shortTitle": "Web Serial API"
+    "shortTitle": "Web Serial API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "serial"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/shape-detection-api/",
@@ -2050,7 +2570,13 @@
     },
     "title": "Accelerated Shape Detection in Images",
     "source": "specref",
-    "shortTitle": "Accelerated Shape Detection in Images"
+    "shortTitle": "Accelerated Shape Detection in Images",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "shape-detection"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/shape-detection-api/text.html",
@@ -2104,7 +2630,13 @@
     },
     "title": "Web Speech API",
     "source": "specref",
-    "shortTitle": "Web Speech API"
+    "shortTitle": "Web Speech API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "speech-api"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/ua-client-hints/",
@@ -2122,7 +2654,13 @@
     },
     "title": "User-Agent Client Hints",
     "source": "spec",
-    "shortTitle": "User-Agent Client Hints"
+    "shortTitle": "User-Agent Client Hints",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "ua-client-hints"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/video-rvfc/",
@@ -2140,7 +2678,13 @@
     },
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
     "source": "spec",
-    "shortTitle": "HTMLVideoElement.requestVideoFrameCallback()"
+    "shortTitle": "HTMLVideoElement.requestVideoFrameCallback()",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "video-rvfc"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/visual-viewport/",
@@ -2158,7 +2702,13 @@
     },
     "title": "Visual Viewport API",
     "source": "specref",
-    "shortTitle": "Visual Viewport API"
+    "shortTitle": "Visual Viewport API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "visual-viewport"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/web-codecs/",
@@ -2176,7 +2726,13 @@
     },
     "title": "WebCodecs",
     "source": "spec",
-    "shortTitle": "WebCodecs"
+    "shortTitle": "WebCodecs",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webcodecs"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/web-locks/",
@@ -2194,7 +2750,13 @@
     },
     "title": "Web Locks API",
     "source": "specref",
-    "shortTitle": "Web Locks API"
+    "shortTitle": "Web Locks API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "web-locks"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/web-otp/",
@@ -2212,7 +2774,13 @@
     },
     "title": "Web OTP API",
     "source": "spec",
-    "shortTitle": "Web OTP API"
+    "shortTitle": "Web OTP API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "web-otp"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/webhid/",
@@ -2230,7 +2798,13 @@
     },
     "title": "WebHID API",
     "source": "spec",
-    "shortTitle": "WebHID API"
+    "shortTitle": "WebHID API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webhid"
+      ]
+    }
   },
   {
     "url": "https://wicg.github.io/webpackage/loading.html",
@@ -2266,7 +2840,13 @@
     },
     "title": "WebUSB API",
     "source": "specref",
-    "shortTitle": "WebUSB API"
+    "shortTitle": "WebUSB API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webusb"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
@@ -2284,7 +2864,13 @@
     },
     "title": "WebGL ANGLE_instanced_arrays Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL ANGLE_instanced_arrays Khronos Ratified Extension"
+    "shortTitle": "WebGL ANGLE_instanced_arrays Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
@@ -2302,7 +2888,13 @@
     },
     "title": "WebGL EXT_blend_minmax Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_blend_minmax Khronos Ratified Extension"
+    "shortTitle": "WebGL EXT_blend_minmax Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_clip_cull_distance/",
@@ -2320,7 +2912,13 @@
     },
     "title": "WebGL EXT_clip_cull_distance Extension Draft Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_clip_cull_distance Extension Draft"
+    "shortTitle": "WebGL EXT_clip_cull_distance Extension Draft",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/",
@@ -2338,7 +2936,13 @@
     },
     "title": "WebGL EXT_color_buffer_float Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_color_buffer_float Extension"
+    "shortTitle": "WebGL EXT_color_buffer_float Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/",
@@ -2356,7 +2960,13 @@
     },
     "title": "WebGL EXT_color_buffer_half_float Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_color_buffer_half_float Extension"
+    "shortTitle": "WebGL EXT_color_buffer_half_float Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
@@ -2374,7 +2984,13 @@
     },
     "title": "WebGL EXT_disjoint_timer_query_webgl2 Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_disjoint_timer_query_webgl2 Extension"
+    "shortTitle": "WebGL EXT_disjoint_timer_query_webgl2 Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
@@ -2392,7 +3008,13 @@
     },
     "title": "WebGL EXT_disjoint_timer_query Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_disjoint_timer_query Extension"
+    "shortTitle": "WebGL EXT_disjoint_timer_query Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/",
@@ -2410,7 +3032,13 @@
     },
     "title": "WebGL EXT_float_blend Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_float_blend Extension"
+    "shortTitle": "WebGL EXT_float_blend Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/",
@@ -2428,7 +3056,13 @@
     },
     "title": "WebGL EXT_frag_depth Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_frag_depth Khronos Ratified Extension"
+    "shortTitle": "WebGL EXT_frag_depth Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/",
@@ -2446,7 +3080,13 @@
     },
     "title": "WebGL EXT_shader_texture_lod Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_shader_texture_lod Khronos Ratified Extension"
+    "shortTitle": "WebGL EXT_shader_texture_lod Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/",
@@ -2464,7 +3104,13 @@
     },
     "title": "WebGL EXT_sRGB Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_sRGB Extension"
+    "shortTitle": "WebGL EXT_sRGB Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
@@ -2482,7 +3128,13 @@
     },
     "title": "WebGL EXT_texture_compression_bptc Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_texture_compression_bptc Extension"
+    "shortTitle": "WebGL EXT_texture_compression_bptc Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
@@ -2500,7 +3152,13 @@
     },
     "title": "WebGL EXT_texture_compression_rgtc Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_texture_compression_rgtc Extension"
+    "shortTitle": "WebGL EXT_texture_compression_rgtc Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/",
@@ -2518,7 +3176,13 @@
     },
     "title": "WebGL EXT_texture_filter_anisotropic Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_texture_filter_anisotropic Khronos Ratified Extension"
+    "shortTitle": "WebGL EXT_texture_filter_anisotropic Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/",
@@ -2536,7 +3200,13 @@
     },
     "title": "WebGL EXT_texture_norm16 Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL EXT_texture_norm16 Extension"
+    "shortTitle": "WebGL EXT_texture_norm16 Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/",
@@ -2554,7 +3224,13 @@
     },
     "title": "WebGL KHR_parallel_shader_compile Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL KHR_parallel_shader_compile Extension"
+    "shortTitle": "WebGL KHR_parallel_shader_compile Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_draw_buffers_indexed/",
@@ -2572,7 +3248,13 @@
     },
     "title": "WebGL OES_draw_buffers_indexed Extension Draft Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_draw_buffers_indexed Extension Draft"
+    "shortTitle": "WebGL OES_draw_buffers_indexed Extension Draft",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/",
@@ -2590,7 +3272,13 @@
     },
     "title": "WebGL OES_element_index_uint Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_element_index_uint Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_element_index_uint Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/",
@@ -2608,7 +3296,13 @@
     },
     "title": "WebGL OES_fbo_render_mipmap Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_fbo_render_mipmap Extension"
+    "shortTitle": "WebGL OES_fbo_render_mipmap Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/",
@@ -2626,7 +3320,13 @@
     },
     "title": "WebGL OES_standard_derivatives Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_standard_derivatives Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_standard_derivatives Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/",
@@ -2644,7 +3344,13 @@
     },
     "title": "WebGL OES_texture_float_linear Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_texture_float_linear Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_texture_float_linear Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float/",
@@ -2662,7 +3368,13 @@
     },
     "title": "WebGL OES_texture_float Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_texture_float Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_texture_float Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/",
@@ -2680,7 +3392,13 @@
     },
     "title": "WebGL OES_texture_half_float_linear Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_texture_half_float_linear Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_texture_half_float_linear Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/",
@@ -2698,7 +3416,13 @@
     },
     "title": "WebGL OES_texture_half_float Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_texture_half_float Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_texture_half_float Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
@@ -2716,7 +3440,13 @@
     },
     "title": "WebGL OES_vertex_array_object Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OES_vertex_array_object Khronos Ratified Extension"
+    "shortTitle": "WebGL OES_vertex_array_object Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
@@ -2734,7 +3464,13 @@
     },
     "title": "WebGL OVR_multiview2 Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL OVR_multiview2 Extension"
+    "shortTitle": "WebGL OVR_multiview2 Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
@@ -2752,7 +3488,13 @@
     },
     "title": "WebGL WEBGL_blend_equation_advanced_coherent Extension Draft Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_blend_equation_advanced_coherent Extension Draft"
+    "shortTitle": "WebGL WEBGL_blend_equation_advanced_coherent Extension Draft",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/",
@@ -2770,7 +3512,13 @@
     },
     "title": "WebGL WEBGL_color_buffer_float Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_color_buffer_float Extension"
+    "shortTitle": "WebGL WEBGL_color_buffer_float Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/",
@@ -2788,7 +3536,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_astc Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_astc Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_astc Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/",
@@ -2806,7 +3560,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_etc Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_etc Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_etc Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/",
@@ -2824,7 +3584,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_etc1 Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_etc1 Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_etc1 Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
@@ -2842,7 +3608,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_pvrtc Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_pvrtc Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_pvrtc Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
@@ -2860,7 +3632,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_s3tc_srgb Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_s3tc_srgb Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_s3tc_srgb Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/",
@@ -2878,7 +3656,13 @@
     },
     "title": "WebGL WEBGL_compressed_texture_s3tc Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_compressed_texture_s3tc Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_compressed_texture_s3tc Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/",
@@ -2896,7 +3680,13 @@
     },
     "title": "WebGL WEBGL_debug_renderer_info Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_debug_renderer_info Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_debug_renderer_info Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/",
@@ -2914,7 +3704,13 @@
     },
     "title": "WebGL WEBGL_debug_shaders Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_debug_shaders Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_debug_shaders Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/",
@@ -2932,7 +3728,13 @@
     },
     "title": "WebGL WEBGL_depth_texture Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_depth_texture Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_depth_texture Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/",
@@ -2950,7 +3752,13 @@
     },
     "title": "WebGL WEBGL_draw_buffers Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_draw_buffers Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_draw_buffers Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/",
@@ -2968,7 +3776,13 @@
     },
     "title": "WebGL WEBGL_draw_instanced_base_vertex_base_instance Extension Draft Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_draw_instanced_base_vertex_base_instance Extension Draft"
+    "shortTitle": "WebGL WEBGL_draw_instanced_base_vertex_base_instance Extension Draft",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
@@ -2986,7 +3800,13 @@
     },
     "title": "WebGL WEBGL_lose_context Khronos Ratified Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_lose_context Khronos Ratified Extension"
+    "shortTitle": "WebGL WEBGL_lose_context Khronos Ratified Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
@@ -3004,7 +3824,13 @@
     },
     "title": "WebGL WEBGL_multi_draw_instanced_base_vertex_base_instance Extension Draft Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_multi_draw_instanced_base_vertex_base_instance Extension Draft"
+    "shortTitle": "WebGL WEBGL_multi_draw_instanced_base_vertex_base_instance Extension Draft",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
@@ -3022,7 +3848,13 @@
     },
     "title": "WebGL WEBGL_multi_draw Extension Specification",
     "source": "spec",
-    "shortTitle": "WebGL WEBGL_multi_draw Extension"
+    "shortTitle": "WebGL WEBGL_multi_draw Extension",
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites"
+      ]
+    }
   },
   {
     "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
@@ -3038,6 +3870,12 @@
       "sourcePath": "specs/latest/1.0/index.html",
       "repository": "https://github.com/KhronosGroup/WebGL",
       "filename": "index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites/1.0.3"
+      ]
     },
     "title": "WebGL Specification",
     "source": "spec",
@@ -3057,6 +3895,12 @@
       "sourcePath": "specs/latest/2.0/index.html",
       "repository": "https://github.com/KhronosGroup/WebGL",
       "filename": "index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites/2.0.0"
+      ]
     },
     "title": "WebGL 2.0 Specification",
     "source": "spec",
@@ -3082,7 +3926,13 @@
     },
     "title": "Accelerometer",
     "source": "w3c",
-    "shortTitle": "Accelerometer"
+    "shortTitle": "Accelerometer",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "accelerometer"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/accname-1.2/",
@@ -3105,7 +3955,13 @@
     },
     "title": "Accessible Name and Description Computation 1.2",
     "source": "w3c",
-    "shortTitle": "Accessible Name and Description Computation 1.2"
+    "shortTitle": "Accessible Name and Description Computation 1.2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "accname"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/ambient-light/",
@@ -3127,7 +3983,13 @@
     },
     "title": "Ambient Light Sensor",
     "source": "w3c",
-    "shortTitle": "Ambient Light Sensor"
+    "shortTitle": "Ambient Light Sensor",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "ambient-light"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/appmanifest/",
@@ -3149,7 +4011,13 @@
     },
     "title": "Web App Manifest",
     "source": "w3c",
-    "shortTitle": "Web App Manifest"
+    "shortTitle": "Web App Manifest",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "appmanifest"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/audio-output/",
@@ -3171,7 +4039,13 @@
     },
     "title": "Audio Output Devices API",
     "source": "w3c",
-    "shortTitle": "Audio Output Devices API"
+    "shortTitle": "Audio Output Devices API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "audio-output"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/battery-status/",
@@ -3193,7 +4067,13 @@
     },
     "title": "Battery Status API",
     "source": "w3c",
-    "shortTitle": "Battery Status API"
+    "shortTitle": "Battery Status API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "battery-status"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/beacon/",
@@ -3215,7 +4095,13 @@
     },
     "title": "Beacon",
     "source": "w3c",
-    "shortTitle": "Beacon"
+    "shortTitle": "Beacon",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "beacon"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/clear-site-data/",
@@ -3237,7 +4123,13 @@
     },
     "title": "Clear Site Data",
     "source": "w3c",
-    "shortTitle": "Clear Site Data"
+    "shortTitle": "Clear Site Data",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "clear-site-data"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/clipboard-apis/",
@@ -3259,7 +4151,13 @@
     },
     "title": "Clipboard API and events",
     "source": "w3c",
-    "shortTitle": "Clipboard API and events"
+    "shortTitle": "Clipboard API and events",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "clipboard-apis"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/compositing-1/",
@@ -3283,7 +4181,13 @@
       "filename": "Overview.html"
     },
     "title": "Compositing and Blending Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/compositing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/core-aam-1.2/",
@@ -3306,7 +4210,13 @@
     },
     "title": "Core Accessibility API Mappings 1.2",
     "source": "w3c",
-    "shortTitle": "Core Accessibility API Mappings 1.2"
+    "shortTitle": "Core Accessibility API Mappings 1.2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "core-aam"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/credential-management-1/",
@@ -3329,7 +4239,13 @@
     },
     "title": "Credential Management Level 1",
     "source": "w3c",
-    "shortTitle": "Credential Management 1"
+    "shortTitle": "Credential Management 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "credential-management"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/csp-embedded-enforcement/",
@@ -3351,7 +4267,13 @@
     },
     "title": "Content Security Policy: Embedded Enforcement",
     "source": "w3c",
-    "shortTitle": "Content Security Policy: Embedded Enforcement"
+    "shortTitle": "Content Security Policy: Embedded Enforcement",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "content-security-policy/embedded-enforcement"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/CSP3/",
@@ -3374,7 +4296,16 @@
     },
     "title": "Content Security Policy Level 3",
     "source": "w3c",
-    "shortTitle": "Content Security Policy 3"
+    "shortTitle": "Content Security Policy 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "content-security-policy"
+      ],
+      "excludePaths": [
+        "content-security-policy/embedded-enforcement"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-align-3/",
@@ -3397,7 +4328,13 @@
     },
     "title": "CSS Box Alignment Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Box Alignment 3"
+    "shortTitle": "CSS Box Alignment 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-align"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-animation-worklet-1/",
@@ -3420,7 +4357,13 @@
     },
     "title": "CSS Animation Worklet API",
     "source": "w3c",
-    "shortTitle": "CSS Animation Worklet API"
+    "shortTitle": "CSS Animation Worklet API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "animation-worklet"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-animations-1/",
@@ -3444,7 +4387,13 @@
     },
     "title": "CSS Animations Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Animations 1"
+    "shortTitle": "CSS Animations 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-animations"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-backgrounds-3/",
@@ -3468,7 +4417,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Backgrounds and Borders Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-backgrounds"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-box-3/",
@@ -3492,7 +4447,13 @@
     },
     "title": "CSS Box Model Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Box Model 3"
+    "shortTitle": "CSS Box Model 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-box"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-box-4/",
@@ -3516,7 +4477,13 @@
     },
     "title": "CSS Box Model Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Box Model 4"
+    "shortTitle": "CSS Box Model 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-box"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-break-3/",
@@ -3540,7 +4507,13 @@
     },
     "title": "CSS Fragmentation Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Fragmentation 3"
+    "shortTitle": "CSS Fragmentation 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-break"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-break-4/",
@@ -3564,7 +4537,13 @@
     },
     "title": "CSS Fragmentation Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Fragmentation 4"
+    "shortTitle": "CSS Fragmentation 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-break"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-cascade-3/",
@@ -3588,7 +4567,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-cascade"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-cascade-4/",
@@ -3613,7 +4598,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Cascading and Inheritance Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-cascade"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-color-4/",
@@ -3637,7 +4628,13 @@
     },
     "title": "CSS Color Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Color 4"
+    "shortTitle": "CSS Color 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-color"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-color-5/",
@@ -3661,7 +4658,13 @@
     },
     "title": "CSS Color Module Level 5",
     "source": "w3c",
-    "shortTitle": "CSS Color 5"
+    "shortTitle": "CSS Color 5",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-color"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-color-adjust-1/",
@@ -3684,7 +4687,13 @@
     },
     "title": "CSS Color Adjustment Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Color Adjustment 1"
+    "shortTitle": "CSS Color Adjustment 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-color-adjust"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-conditional-3/",
@@ -3708,7 +4717,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-conditional"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-conditional-4/",
@@ -3732,7 +4747,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Conditional Rules Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-conditional"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-contain-2/",
@@ -3755,7 +4776,13 @@
     },
     "title": "CSS Containment Module Level 2",
     "source": "w3c",
-    "shortTitle": "CSS Containment 2"
+    "shortTitle": "CSS Containment 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-contain"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-content-3/",
@@ -3778,7 +4805,13 @@
     },
     "title": "CSS Generated Content Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Generated Content 3"
+    "shortTitle": "CSS Generated Content 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-content"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-counter-styles-3/",
@@ -3801,7 +4834,13 @@
     },
     "title": "CSS Counter Styles Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Counter Styles 3"
+    "shortTitle": "CSS Counter Styles 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-counter-styles"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-device-adapt-1/",
@@ -3824,7 +4863,13 @@
     },
     "title": "CSS Device Adaptation Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Device Adaptation 1"
+    "shortTitle": "CSS Device Adaptation 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-device-adapt"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-display-3/",
@@ -3847,7 +4892,13 @@
     },
     "title": "CSS Display Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Display 3"
+    "shortTitle": "CSS Display 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-display"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-easing-1/",
@@ -3870,7 +4921,13 @@
     },
     "title": "CSS Easing Functions Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Easing Functions 1"
+    "shortTitle": "CSS Easing Functions 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-easing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-flexbox-1/",
@@ -3893,7 +4950,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Flexible Box Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-flexbox"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-font-loading-3/",
@@ -3916,7 +4979,13 @@
     },
     "title": "CSS Font Loading Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Font Loading 3"
+    "shortTitle": "CSS Font Loading 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-font-loading"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-fonts-4/",
@@ -3939,7 +5008,13 @@
     },
     "title": "CSS Fonts Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Fonts 4"
+    "shortTitle": "CSS Fonts 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-fonts"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-gcpm-3/",
@@ -3963,7 +5038,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Generated Content for Paged Media Module",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-gcpm"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-grid-2/",
@@ -3987,7 +5068,13 @@
     },
     "title": "CSS Grid Layout Module Level 2",
     "source": "w3c",
-    "shortTitle": "CSS Grid Layout 2"
+    "shortTitle": "CSS Grid Layout 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-grid"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-highlight-api-1/",
@@ -4034,7 +5121,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Images Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-images"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-images-4/",
@@ -4058,7 +5151,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Image Values and Replaced Content Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-images"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-inline-3/",
@@ -4081,7 +5180,13 @@
     },
     "title": "CSS Inline Layout Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Inline Layout 3"
+    "shortTitle": "CSS Inline Layout 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-inline"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-layout-api-1/",
@@ -4104,7 +5209,13 @@
     },
     "title": "CSS Layout API Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Layout API 1"
+    "shortTitle": "CSS Layout API 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-layout-api"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-line-grid-1/",
@@ -4150,7 +5261,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Lists Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-lists"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-logical-1/",
@@ -4173,7 +5290,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Logical Properties and Values Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-logical"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-masking-1/",
@@ -4196,7 +5319,13 @@
     },
     "title": "CSS Masking Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Masking 1"
+    "shortTitle": "CSS Masking 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-masking"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-multicol-1/",
@@ -4220,7 +5349,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Multi-column Layout Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-multicol"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-namespaces-3/",
@@ -4243,7 +5378,13 @@
     },
     "title": "CSS Namespaces Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Namespaces 3"
+    "shortTitle": "CSS Namespaces 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-namespaces"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-nav-1/",
@@ -4290,7 +5431,13 @@
     },
     "title": "CSS Overflow Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Overflow 3"
+    "shortTitle": "CSS Overflow 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-overflow"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-overflow-4/",
@@ -4314,7 +5461,13 @@
     },
     "title": "CSS Overflow Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Overflow 4"
+    "shortTitle": "CSS Overflow 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-overflow"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-overscroll-1/",
@@ -4337,7 +5490,13 @@
     },
     "title": "CSS Overscroll Behavior Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Overscroll Behavior 1"
+    "shortTitle": "CSS Overscroll Behavior 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-overscroll-behavior"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-page-3/",
@@ -4361,7 +5520,13 @@
     },
     "title": "CSS Paged Media Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Paged Media 3"
+    "shortTitle": "CSS Paged Media 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-page"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-page-floats-3/",
@@ -4407,7 +5572,13 @@
     },
     "title": "CSS Painting API Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Painting API 1"
+    "shortTitle": "CSS Painting API 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-paint-api"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-position-3/",
@@ -4430,7 +5601,13 @@
     },
     "title": "CSS Positioned Layout Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Positioned Layout 3"
+    "shortTitle": "CSS Positioned Layout 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-position"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-properties-values-api-1/",
@@ -4453,7 +5630,13 @@
     },
     "title": "CSS Properties and Values API Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Properties and Values API 1"
+    "shortTitle": "CSS Properties and Values API 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-properties-values-api"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-pseudo-4/",
@@ -4476,7 +5659,13 @@
     },
     "title": "CSS Pseudo-Elements Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Pseudo-Elements 4"
+    "shortTitle": "CSS Pseudo-Elements 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-pseudo"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-regions-1/",
@@ -4545,7 +5734,13 @@
     },
     "title": "CSS Round Display Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Round Display 1"
+    "shortTitle": "CSS Round Display 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-round-display"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-ruby-1/",
@@ -4568,7 +5763,13 @@
     },
     "title": "CSS Ruby Layout Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Ruby Layout 1"
+    "shortTitle": "CSS Ruby Layout 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-ruby"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-scoping-1/",
@@ -4591,7 +5792,13 @@
     },
     "title": "CSS Scoping Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Scoping 1"
+    "shortTitle": "CSS Scoping 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-scoping"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-scroll-anchoring-1/",
@@ -4607,14 +5814,20 @@
       "filename": "Overview.html"
     },
     "nightly": {
-      "url": "https://drafts.csswg.org/css-scroll-anchoring",
+      "url": "https://drafts.csswg.org/css-scroll-anchoring/",
       "repository": "https://github.com/w3c/csswg-drafts",
       "sourcePath": "css-scroll-anchoring-1/Overview.bs",
       "filename": "Overview.html"
     },
     "title": "CSS Scroll Anchoring Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Scroll Anchoring 1"
+    "shortTitle": "CSS Scroll Anchoring 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-scroll-anchoring"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-scroll-snap-1/",
@@ -4637,7 +5850,13 @@
     },
     "title": "CSS Scroll Snap Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Scroll Snap 1"
+    "shortTitle": "CSS Scroll Snap 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-scroll-snap"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-scrollbars-1/",
@@ -4660,7 +5879,13 @@
     },
     "title": "CSS Scrollbars Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Scrollbars 1"
+    "shortTitle": "CSS Scrollbars 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-scrollbars"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-shadow-parts-1/",
@@ -4683,7 +5908,13 @@
     },
     "title": "CSS Shadow Parts",
     "source": "w3c",
-    "shortTitle": "CSS Shadow Parts"
+    "shortTitle": "CSS Shadow Parts",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-shadow-parts"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-shapes-1/",
@@ -4707,7 +5938,13 @@
     },
     "title": "CSS Shapes Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Shapes 1"
+    "shortTitle": "CSS Shapes 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-shapes"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-sizing-3/",
@@ -4731,7 +5968,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Box Sizing Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-sizing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-sizing-4/",
@@ -4755,7 +5998,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Box Sizing Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-sizing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-speech-1/",
@@ -4778,7 +6027,13 @@
     },
     "title": "CSS Speech Module",
     "source": "w3c",
-    "shortTitle": "CSS Speech"
+    "shortTitle": "CSS Speech",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-speech"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-style-attr/",
@@ -4800,7 +6055,13 @@
     },
     "title": "CSS Style Attributes",
     "source": "w3c",
-    "shortTitle": "CSS Style Attributes"
+    "shortTitle": "CSS Style Attributes",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-style-attr"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-syntax-3/",
@@ -4823,7 +6084,13 @@
     },
     "title": "CSS Syntax Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Syntax 3"
+    "shortTitle": "CSS Syntax 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-syntax"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-tables-3/",
@@ -4846,7 +6113,13 @@
     },
     "title": "CSS Table Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Table 3"
+    "shortTitle": "CSS Table 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-tables"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-text-3/",
@@ -4870,7 +6143,13 @@
     },
     "title": "CSS Text Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Text 3"
+    "shortTitle": "CSS Text 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-text"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-text-4/",
@@ -4894,7 +6173,13 @@
     },
     "title": "CSS Text Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Text 4"
+    "shortTitle": "CSS Text 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-text"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-text-decor-3/",
@@ -4918,7 +6203,13 @@
     },
     "title": "CSS Text Decoration Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Text Decoration 3"
+    "shortTitle": "CSS Text Decoration 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-text-decor"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-text-decor-4/",
@@ -4942,7 +6233,13 @@
     },
     "title": "CSS Text Decoration Module Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Text Decoration 4"
+    "shortTitle": "CSS Text Decoration 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-text-decor"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-transforms-1/",
@@ -4966,7 +6263,13 @@
     },
     "title": "CSS Transforms Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Transforms 1"
+    "shortTitle": "CSS Transforms 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-transforms"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-transforms-2/",
@@ -4990,7 +6293,13 @@
     },
     "title": "CSS Transforms Module Level 2",
     "source": "w3c",
-    "shortTitle": "CSS Transforms 2"
+    "shortTitle": "CSS Transforms 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-transforms"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-transitions-1/",
@@ -5014,7 +6323,13 @@
     },
     "title": "CSS Transitions",
     "source": "w3c",
-    "shortTitle": "CSS Transitions"
+    "shortTitle": "CSS Transitions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-transitions"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-typed-om-1/",
@@ -5038,7 +6353,13 @@
     },
     "title": "CSS Typed OM Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Typed OM 1"
+    "shortTitle": "CSS Typed OM 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-typed-om"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-ui-4/",
@@ -5061,7 +6382,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Basic User Interface Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-ui"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-values-3/",
@@ -5085,7 +6412,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 3",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-values"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-values-4/",
@@ -5109,7 +6442,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Values and Units Module Level 4",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-values"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-variables-1/",
@@ -5132,7 +6471,13 @@
       "filename": "Overview.html"
     },
     "title": "CSS Custom Properties for Cascading Variables Module Level 1",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-variables"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-will-change-1/",
@@ -5155,7 +6500,13 @@
     },
     "title": "CSS Will Change Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Will Change 1"
+    "shortTitle": "CSS Will Change 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-will-change"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css-writing-modes-4/",
@@ -5178,7 +6529,13 @@
     },
     "title": "CSS Writing Modes Level 4",
     "source": "w3c",
-    "shortTitle": "CSS Writing Modes 4"
+    "shortTitle": "CSS Writing Modes 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-writing-modes"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/CSS21/",
@@ -5231,7 +6588,13 @@
     },
     "title": "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification",
     "source": "w3c",
-    "shortTitle": "CSS 2.1"
+    "shortTitle": "CSS 2.1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/CSS2"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/CSS22/",
@@ -5284,7 +6647,13 @@
     },
     "title": "Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification",
     "source": "w3c",
-    "shortTitle": "CSS 2.2"
+    "shortTitle": "CSS 2.2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/CSS2"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",
@@ -5307,7 +6676,13 @@
     },
     "title": "CSS Exclusions Module Level 1",
     "source": "w3c",
-    "shortTitle": "CSS Exclusions 1"
+    "shortTitle": "CSS Exclusions 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-exclusions"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/cssom-1/",
@@ -5330,7 +6705,13 @@
     },
     "title": "CSS Object Model (CSSOM)",
     "source": "w3c",
-    "shortTitle": "CSSOM"
+    "shortTitle": "CSSOM",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/cssom"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/cssom-view-1/",
@@ -5353,7 +6734,13 @@
     },
     "title": "CSSOM View Module",
     "source": "w3c",
-    "shortTitle": "CSSOM View"
+    "shortTitle": "CSSOM View",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/cssom-view"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/device-memory-1/",
@@ -5376,7 +6763,13 @@
     },
     "title": "Device Memory",
     "source": "w3c",
-    "shortTitle": "Device Memory"
+    "shortTitle": "Device Memory",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "device-memory"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/DOM-Parsing/",
@@ -5398,7 +6791,13 @@
     },
     "title": "DOM Parsing and Serialization",
     "source": "w3c",
-    "shortTitle": "DOM Parsing and Serialization"
+    "shortTitle": "DOM Parsing and Serialization",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "domparsing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/encoding/",
@@ -5420,7 +6819,13 @@
     },
     "title": "Encoding",
     "source": "w3c",
-    "shortTitle": "Encoding"
+    "shortTitle": "Encoding",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "encoding"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/encrypted-media/",
@@ -5442,7 +6847,13 @@
     },
     "title": "Encrypted Media Extensions",
     "source": "w3c",
-    "shortTitle": "Encrypted Media Extensions"
+    "shortTitle": "Encrypted Media Extensions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "encrypted-media"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
@@ -5464,7 +6875,13 @@
       "filename": "index.html"
     },
     "title": "Fetch Metadata Request Headers",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "fetch/metadata"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/FileAPI/",
@@ -5486,7 +6903,13 @@
     },
     "title": "File API",
     "source": "w3c",
-    "shortTitle": "File API"
+    "shortTitle": "File API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "FileAPI"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/fill-stroke-3/",
@@ -5509,7 +6932,13 @@
     },
     "title": "CSS Fill and Stroke Module Level 3",
     "source": "w3c",
-    "shortTitle": "CSS Fill and Stroke 3"
+    "shortTitle": "CSS Fill and Stroke 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/css-fill-stroke"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/filter-effects-1/",
@@ -5533,7 +6962,13 @@
     },
     "title": "Filter Effects Module Level 1",
     "source": "w3c",
-    "shortTitle": "Filter Effects 1"
+    "shortTitle": "Filter Effects 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/filter-effects"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/gamepad/",
@@ -5555,7 +6990,13 @@
     },
     "title": "Gamepad",
     "source": "w3c",
-    "shortTitle": "Gamepad"
+    "shortTitle": "Gamepad",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "gamepad"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/generic-sensor/",
@@ -5577,7 +7018,13 @@
     },
     "title": "Generic Sensor API",
     "source": "w3c",
-    "shortTitle": "Generic Sensor API"
+    "shortTitle": "Generic Sensor API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "generic-sensor"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/geolocation-API/",
@@ -5599,7 +7046,13 @@
     },
     "title": "Geolocation API Specification 2nd Edition",
     "source": "w3c",
-    "shortTitle": "Geolocation API Specification 2nd Edition"
+    "shortTitle": "Geolocation API Specification 2nd Edition",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "geolocation-API"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/geolocation-sensor/",
@@ -5621,7 +7074,13 @@
     },
     "title": "Geolocation Sensor",
     "source": "w3c",
-    "shortTitle": "Geolocation Sensor"
+    "shortTitle": "Geolocation Sensor",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "geolocation-sensor"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/geometry-1/",
@@ -5644,7 +7103,13 @@
     },
     "title": "Geometry Interfaces Module Level 1",
     "source": "w3c",
-    "shortTitle": "Geometry Interfaces 1"
+    "shortTitle": "Geometry Interfaces 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/geometry"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/graphics-aam-1.0/",
@@ -5667,7 +7132,13 @@
     },
     "title": "Graphics Accessibility API Mappings",
     "source": "w3c",
-    "shortTitle": "Graphics Accessibility API Mappings"
+    "shortTitle": "Graphics Accessibility API Mappings",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "graphics-aam"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/graphics-aria-1.0/",
@@ -5712,7 +7183,13 @@
     },
     "title": "Gyroscope",
     "source": "w3c",
-    "shortTitle": "Gyroscope"
+    "shortTitle": "Gyroscope",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "gyroscope"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/hr-time-3/",
@@ -5735,7 +7212,13 @@
     },
     "title": "High Resolution Time",
     "source": "w3c",
-    "shortTitle": "High Resolution Time"
+    "shortTitle": "High Resolution Time",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "hr-time"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/html-aam-1.0/",
@@ -5802,7 +7285,13 @@
     },
     "title": "HTML Media Capture",
     "source": "w3c",
-    "shortTitle": "HTML Media Capture"
+    "shortTitle": "HTML Media Capture",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "html-media-capture"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/image-capture/",
@@ -5824,7 +7313,13 @@
     },
     "title": "\"MediaStream Image Capture\"",
     "source": "w3c",
-    "shortTitle": "\"MediaStream Image Capture\""
+    "shortTitle": "\"MediaStream Image Capture\"",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediacapture-image"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/image-resource/",
@@ -5869,7 +7364,13 @@
       "filename": "index.html"
     },
     "title": "Indexed Database API 2.0",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "IndexedDB"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/input-events-2/",
@@ -5892,7 +7393,13 @@
     },
     "title": "Input Events Level 2",
     "source": "w3c",
-    "shortTitle": "Input Events 2"
+    "shortTitle": "Input Events 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "input-events"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/intersection-observer/",
@@ -5914,7 +7421,13 @@
     },
     "title": "Intersection Observer",
     "source": "w3c",
-    "shortTitle": "Intersection Observer"
+    "shortTitle": "Intersection Observer",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "intersection-observer"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/longtasks-1/",
@@ -5937,7 +7450,13 @@
     },
     "title": "Long Tasks API 1",
     "source": "w3c",
-    "shortTitle": "Long Tasks API 1"
+    "shortTitle": "Long Tasks API 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "longtask-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/magnetometer/",
@@ -5959,7 +7478,13 @@
     },
     "title": "Magnetometer",
     "source": "w3c",
-    "shortTitle": "Magnetometer"
+    "shortTitle": "Magnetometer",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "magnetometer"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/media-capabilities/",
@@ -5981,7 +7506,13 @@
     },
     "title": "Media Capabilities",
     "source": "w3c",
-    "shortTitle": "Media Capabilities"
+    "shortTitle": "Media Capabilities",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "media-capabilities"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/media-source/",
@@ -6003,7 +7534,13 @@
     },
     "title": "Media Source Extensions™",
     "source": "w3c",
-    "shortTitle": "Media Source Extensions™"
+    "shortTitle": "Media Source Extensions™",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "media-source"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-depth/",
@@ -6025,7 +7562,13 @@
     },
     "title": "Media Capture Depth Stream Extensions",
     "source": "w3c",
-    "shortTitle": "Media Capture Depth Stream Extensions"
+    "shortTitle": "Media Capture Depth Stream Extensions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediacapture-depth"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-fromelement/",
@@ -6047,7 +7590,13 @@
     },
     "title": "Media Capture from DOM Elements",
     "source": "w3c",
-    "shortTitle": "Media Capture from DOM Elements"
+    "shortTitle": "Media Capture from DOM Elements",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediacapture-fromelement"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediacapture-streams/",
@@ -6069,7 +7618,13 @@
     },
     "title": "Media Capture and Streams",
     "source": "w3c",
-    "shortTitle": "Media Capture and Streams"
+    "shortTitle": "Media Capture and Streams",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediacapture-streams"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediaqueries-4/",
@@ -6093,7 +7648,13 @@
     },
     "title": "Media Queries Level 4",
     "source": "w3c",
-    "shortTitle": "Media Queries 4"
+    "shortTitle": "Media Queries 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/mediaqueries"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediaqueries-5/",
@@ -6117,7 +7678,13 @@
     },
     "title": "Media Queries Level 5",
     "source": "w3c",
-    "shortTitle": "Media Queries 5"
+    "shortTitle": "Media Queries 5",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/mediaqueries"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediasession/",
@@ -6139,7 +7706,13 @@
     },
     "title": "Media Session Standard",
     "source": "w3c",
-    "shortTitle": "Media Session"
+    "shortTitle": "Media Session",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediasession"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mediastream-recording/",
@@ -6161,7 +7734,13 @@
     },
     "title": "MediaStream Recording",
     "source": "w3c",
-    "shortTitle": "MediaStream Recording"
+    "shortTitle": "MediaStream Recording",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mediacapture-record"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mixed-content/",
@@ -6183,7 +7762,13 @@
     },
     "title": "Mixed Content",
     "source": "w3c",
-    "shortTitle": "Mixed Content"
+    "shortTitle": "Mixed Content",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mixed-content"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/motion-1/",
@@ -6206,7 +7791,13 @@
     },
     "title": "Motion Path Module Level 1",
     "source": "w3c",
-    "shortTitle": "Motion Path 1"
+    "shortTitle": "Motion Path 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/motion"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/mst-content-hint/",
@@ -6228,7 +7819,13 @@
     },
     "title": "MediaStreamTrack Content Hints",
     "source": "w3c",
-    "shortTitle": "MediaStreamTrack Content Hints"
+    "shortTitle": "MediaStreamTrack Content Hints",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "mst-content-hint"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/navigation-timing-2/",
@@ -6251,7 +7848,13 @@
     },
     "title": "Navigation Timing Level 2",
     "source": "w3c",
-    "shortTitle": "Navigation Timing 2"
+    "shortTitle": "Navigation Timing 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "navigation-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/network-error-logging-1/",
@@ -6274,7 +7877,13 @@
     },
     "title": "Network Error Logging",
     "source": "w3c",
-    "shortTitle": "Network Error Logging"
+    "shortTitle": "Network Error Logging",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "network-error-logging"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/orientation-event/",
@@ -6296,7 +7905,13 @@
     },
     "title": "DeviceOrientation Event Specification",
     "source": "w3c",
-    "shortTitle": "DeviceOrientation Event"
+    "shortTitle": "DeviceOrientation Event",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "orientation-event"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/orientation-sensor/",
@@ -6318,7 +7933,13 @@
     },
     "title": "Orientation Sensor",
     "source": "w3c",
-    "shortTitle": "Orientation Sensor"
+    "shortTitle": "Orientation Sensor",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "orientation-sensor"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/page-visibility-2/",
@@ -6341,7 +7962,13 @@
     },
     "title": "Page Visibility Level 2",
     "source": "w3c",
-    "shortTitle": "Page Visibility 2"
+    "shortTitle": "Page Visibility 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "page-visibility"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/paint-timing/",
@@ -6363,7 +7990,13 @@
     },
     "title": "Paint Timing 1",
     "source": "w3c",
-    "shortTitle": "Paint Timing 1"
+    "shortTitle": "Paint Timing 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "paint-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/payment-handler/",
@@ -6385,7 +8018,13 @@
     },
     "title": "Payment Handler API",
     "source": "w3c",
-    "shortTitle": "Payment Handler API"
+    "shortTitle": "Payment Handler API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "payment-handler"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/payment-method-basic-card/",
@@ -6407,7 +8046,13 @@
       "filename": "index.html"
     },
     "title": "Payment Method: Basic Card",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "payment-method-basic-card"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/payment-method-id/",
@@ -6429,7 +8074,13 @@
     },
     "title": "Payment Method Identifiers",
     "source": "w3c",
-    "shortTitle": "Payment Method Identifiers"
+    "shortTitle": "Payment Method Identifiers",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "payment-method-id"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/payment-method-manifest/",
@@ -6473,7 +8124,13 @@
     },
     "title": "Payment Request API",
     "source": "w3c",
-    "shortTitle": "Payment Request API"
+    "shortTitle": "Payment Request API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "payment-request"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/performance-timeline-2/",
@@ -6496,7 +8153,13 @@
     },
     "title": "Performance Timeline Level 2",
     "source": "w3c",
-    "shortTitle": "Performance Timeline 2"
+    "shortTitle": "Performance Timeline 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "performance-timeline"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/permissions-policy-1/",
@@ -6519,7 +8182,13 @@
     },
     "title": "Permissions Policy",
     "source": "w3c",
-    "shortTitle": "Permissions Policy"
+    "shortTitle": "Permissions Policy",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "permissions-policy"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/permissions/",
@@ -6541,7 +8210,13 @@
     },
     "title": "Permissions",
     "source": "w3c",
-    "shortTitle": "Permissions"
+    "shortTitle": "Permissions",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "permissions"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/picture-in-picture/",
@@ -6563,7 +8238,13 @@
     },
     "title": "Picture-in-Picture",
     "source": "w3c",
-    "shortTitle": "Picture-in-Picture"
+    "shortTitle": "Picture-in-Picture",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "picture-in-picture"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/pointerevents3/",
@@ -6586,7 +8267,13 @@
     },
     "title": "Pointer Events Level 3",
     "source": "w3c",
-    "shortTitle": "Pointer Events 3"
+    "shortTitle": "Pointer Events 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "pointerevents"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/pointerlock-2/",
@@ -6609,7 +8296,13 @@
     },
     "title": "Pointer Lock 2.0",
     "source": "w3c",
-    "shortTitle": "Pointer Lock 2.0"
+    "shortTitle": "Pointer Lock 2.0",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "pointerlock"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/preload/",
@@ -6631,7 +8324,13 @@
     },
     "title": "Preload",
     "source": "w3c",
-    "shortTitle": "Preload"
+    "shortTitle": "Preload",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "preload"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/presentation-api/",
@@ -6653,7 +8352,13 @@
     },
     "title": "Presentation API",
     "source": "w3c",
-    "shortTitle": "Presentation API"
+    "shortTitle": "Presentation API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "presentation-api"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/proximity/",
@@ -6675,7 +8380,13 @@
     },
     "title": "Proximity Sensor",
     "source": "w3c",
-    "shortTitle": "Proximity Sensor"
+    "shortTitle": "Proximity Sensor",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "proximity"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/push-api/",
@@ -6697,7 +8408,13 @@
     },
     "title": "Push API",
     "source": "w3c",
-    "shortTitle": "Push API"
+    "shortTitle": "Push API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "push-api"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/referrer-policy/",
@@ -6719,7 +8436,13 @@
     },
     "title": "Referrer Policy",
     "source": "w3c",
-    "shortTitle": "Referrer Policy"
+    "shortTitle": "Referrer Policy",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "referrer-policy"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/remote-playback/",
@@ -6741,7 +8464,13 @@
     },
     "title": "Remote Playback API",
     "source": "w3c",
-    "shortTitle": "Remote Playback API"
+    "shortTitle": "Remote Playback API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "remote-playback"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/reporting-1/",
@@ -6764,7 +8493,13 @@
     },
     "title": "Reporting API",
     "source": "w3c",
-    "shortTitle": "Reporting API"
+    "shortTitle": "Reporting API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "reporting"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/requestidlecallback/",
@@ -6786,7 +8521,13 @@
     },
     "title": "Cooperative Scheduling of Background Tasks",
     "source": "w3c",
-    "shortTitle": "Cooperative Scheduling of Background Tasks"
+    "shortTitle": "Cooperative Scheduling of Background Tasks",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "requestidlecallback"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/resize-observer-1/",
@@ -6809,7 +8550,13 @@
     },
     "title": "Resize Observer",
     "source": "w3c",
-    "shortTitle": "Resize Observer"
+    "shortTitle": "Resize Observer",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "resize-observer"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/resource-hints/",
@@ -6854,7 +8601,13 @@
     },
     "title": "Resource Timing Level 2",
     "source": "w3c",
-    "shortTitle": "Resource Timing 2"
+    "shortTitle": "Resource Timing 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "resource-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/screen-capture/",
@@ -6876,7 +8629,13 @@
     },
     "title": "Screen Capture",
     "source": "w3c",
-    "shortTitle": "Screen Capture"
+    "shortTitle": "Screen Capture",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "screen-capture"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/screen-fold/",
@@ -6920,7 +8679,13 @@
     },
     "title": "The Screen Orientation API",
     "source": "w3c",
-    "shortTitle": "The Screen Orientation API"
+    "shortTitle": "The Screen Orientation API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "screen-orientation"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/screen-wake-lock/",
@@ -6942,7 +8707,13 @@
     },
     "title": "Screen Wake Lock API",
     "source": "w3c",
-    "shortTitle": "Screen Wake Lock API"
+    "shortTitle": "Screen Wake Lock API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "screen-wake-lock"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/secure-contexts/",
@@ -6964,7 +8735,13 @@
     },
     "title": "Secure Contexts",
     "source": "w3c",
-    "shortTitle": "Secure Contexts"
+    "shortTitle": "Secure Contexts",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "secure-contexts"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/selection-api/",
@@ -6986,7 +8763,13 @@
     },
     "title": "Selection API",
     "source": "w3c",
-    "shortTitle": "Selection API"
+    "shortTitle": "Selection API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "selection"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/selectors-4/",
@@ -7009,7 +8792,13 @@
     },
     "title": "Selectors Level 4",
     "source": "w3c",
-    "shortTitle": "Selectors 4"
+    "shortTitle": "Selectors 4",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/selectors"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/selectors-nonelement-1/",
@@ -7054,7 +8843,13 @@
     },
     "title": "Server Timing",
     "source": "w3c",
-    "shortTitle": "Server Timing"
+    "shortTitle": "Server Timing",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "server-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/service-workers-1/",
@@ -7077,7 +8872,13 @@
     },
     "title": "Service Workers 1",
     "source": "w3c",
-    "shortTitle": "Service Workers 1"
+    "shortTitle": "Service Workers 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "service-workers"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/SRI/",
@@ -7099,7 +8900,13 @@
       "filename": "index.html"
     },
     "title": "Subresource Integrity",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "subresource-integrity"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/svg-aam-1.0/",
@@ -7122,7 +8929,13 @@
     },
     "title": "SVG Accessibility API Mappings",
     "source": "w3c",
-    "shortTitle": "SVG Accessibility API Mappings"
+    "shortTitle": "SVG Accessibility API Mappings",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "svg-aam"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/svg-integration/",
@@ -7291,7 +9104,13 @@
     },
     "title": "Scalable Vector Graphics (SVG) 2",
     "source": "w3c",
-    "shortTitle": "SVG 2"
+    "shortTitle": "SVG 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "svg"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/timing-entrytypes-registry/",
@@ -7313,7 +9132,13 @@
     },
     "title": "Timing Entry Names Registry",
     "source": "w3c",
-    "shortTitle": "Timing Entry Names Registry"
+    "shortTitle": "Timing Entry Names Registry",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "timing-entrytypes-registry"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/touch-events/",
@@ -7335,7 +9160,13 @@
     },
     "title": "Touch Events",
     "source": "w3c",
-    "shortTitle": "Touch Events"
+    "shortTitle": "Touch Events",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "touch-events"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/trace-context-1/",
@@ -7424,7 +9255,13 @@
     },
     "title": "UI Events",
     "source": "w3c",
-    "shortTitle": "UI Events"
+    "shortTitle": "UI Events",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "uievents"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/upgrade-insecure-requests/",
@@ -7446,7 +9283,13 @@
     },
     "title": "Upgrade Insecure Requests",
     "source": "w3c",
-    "shortTitle": "Upgrade Insecure Requests"
+    "shortTitle": "Upgrade Insecure Requests",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "upgrade-insecure-requests"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/user-timing-2/",
@@ -7470,7 +9313,13 @@
     },
     "title": "User Timing Level 2",
     "source": "w3c",
-    "shortTitle": "User Timing 2"
+    "shortTitle": "User Timing 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "user-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/user-timing-3/",
@@ -7494,7 +9343,13 @@
     },
     "title": "User Timing Level 3",
     "source": "w3c",
-    "shortTitle": "User Timing 3"
+    "shortTitle": "User Timing 3",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "user-timing"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/vibration/",
@@ -7516,7 +9371,13 @@
     },
     "title": "Vibration API (Second Edition)",
     "source": "w3c",
-    "shortTitle": "Vibration API"
+    "shortTitle": "Vibration API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "vibration"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/wai-aria-1.2/",
@@ -7539,7 +9400,13 @@
     },
     "title": "Accessible Rich Internet Applications (WAI-ARIA) 1.2",
     "source": "w3c",
-    "shortTitle": "WAI-ARIA 1.2"
+    "shortTitle": "WAI-ARIA 1.2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "wai-aria"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/wasm-core-1/",
@@ -7550,6 +9417,12 @@
       "currentSpecification": "wasm-core-1"
     },
     "seriesVersion": "1",
+    "tests": {
+      "repository": "https://github.com/WebAssembly/spec/",
+      "testPaths": [
+        "test/core"
+      ]
+    },
     "release": {
       "url": "https://www.w3.org/TR/wasm-core-1/",
       "filename": "Overview.html"
@@ -7585,7 +9458,13 @@
     },
     "title": "WebAssembly JavaScript Interface",
     "source": "w3c",
-    "shortTitle": "WebAssembly JavaScript Interface"
+    "shortTitle": "WebAssembly JavaScript Interface",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "wasm/jsapi"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/wasm-web-api-1/",
@@ -7608,7 +9487,13 @@
     },
     "title": "WebAssembly Web API",
     "source": "w3c",
-    "shortTitle": "WebAssembly Web API"
+    "shortTitle": "WebAssembly Web API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "wasm/webapi"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/web-animations-1/",
@@ -7631,7 +9516,13 @@
     },
     "title": "Web Animations",
     "source": "w3c",
-    "shortTitle": "Web Animations"
+    "shortTitle": "Web Animations",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "web-animations"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/web-share/",
@@ -7653,7 +9544,13 @@
     },
     "title": "Web Share API",
     "source": "w3c",
-    "shortTitle": "Web Share API"
+    "shortTitle": "Web Share API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "web-share"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webaudio/",
@@ -7675,7 +9572,13 @@
     },
     "title": "Web Audio API",
     "source": "w3c",
-    "shortTitle": "Web Audio API"
+    "shortTitle": "Web Audio API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webaudio"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webauthn-2/",
@@ -7698,7 +9601,13 @@
       "filename": "index.html"
     },
     "title": "Web Authentication: An API for accessing Public Key Credentials - Level 2",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webauthn"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/WebCryptoAPI/",
@@ -7720,7 +9629,13 @@
     },
     "title": "Web Cryptography API",
     "source": "w3c",
-    "shortTitle": "Web Cryptography API"
+    "shortTitle": "Web Cryptography API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "WebCryptoAPI"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webdriver2/",
@@ -7743,7 +9658,13 @@
     },
     "title": "WebDriver - Level 2",
     "source": "w3c",
-    "shortTitle": "WebDriver 2"
+    "shortTitle": "WebDriver 2",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webdriver"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/WebIDL-1/",
@@ -7766,7 +9687,13 @@
     },
     "title": "WebIDL Level 1",
     "source": "w3c",
-    "shortTitle": "WebIDL 1"
+    "shortTitle": "WebIDL 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "WebIDL"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webmidi/",
@@ -7788,7 +9715,13 @@
     },
     "title": "Web MIDI API",
     "source": "w3c",
-    "shortTitle": "Web MIDI API"
+    "shortTitle": "Web MIDI API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webmidi"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webrtc-identity/",
@@ -7810,7 +9743,13 @@
     },
     "title": "Identity for WebRTC 1.0",
     "source": "w3c",
-    "shortTitle": "Identity for WebRTC 1.0"
+    "shortTitle": "Identity for WebRTC 1.0",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc-identity"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webrtc-priority/",
@@ -7832,7 +9771,13 @@
     },
     "title": "WebRTC Priority Control API",
     "source": "w3c",
-    "shortTitle": "WebRTC Priority Control API"
+    "shortTitle": "WebRTC Priority Control API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc-priority"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webrtc-stats/",
@@ -7854,7 +9799,13 @@
       "filename": "index.html"
     },
     "title": "Identifiers for WebRTC's Statistics API",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc-stats"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webrtc-svc/",
@@ -7876,7 +9827,13 @@
     },
     "title": "Scalable Video Coding (SVC) Extension for WebRTC",
     "source": "w3c",
-    "shortTitle": "SVC"
+    "shortTitle": "SVC",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc-svc"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webrtc/",
@@ -7898,7 +9855,13 @@
       "filename": "index.html"
     },
     "title": "WebRTC 1.0: Real-Time Communication Between Browsers",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webvtt1/",
@@ -7921,7 +9884,13 @@
     },
     "title": "WebVTT: The Web Video Text Tracks Format",
     "source": "w3c",
-    "shortTitle": "WebVTT: The Web Video Text Tracks Format"
+    "shortTitle": "WebVTT: The Web Video Text Tracks Format",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webvtt"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webxr-ar-module-1/",
@@ -7944,7 +9913,13 @@
     },
     "title": "WebXR Augmented Reality Module - Level 1",
     "source": "w3c",
-    "shortTitle": "WebXR Augmented Reality 1"
+    "shortTitle": "WebXR Augmented Reality 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/ar-module"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webxr-gamepads-module-1/",
@@ -7967,7 +9942,13 @@
     },
     "title": "WebXR Gamepads Module - Level 1",
     "source": "w3c",
-    "shortTitle": "WebXR Gamepads 1"
+    "shortTitle": "WebXR Gamepads 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/gamepads-module"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webxr-hand-input-1/",
@@ -7990,7 +9971,13 @@
     },
     "title": "WebXR Hand Input Module - Level 1",
     "source": "w3c",
-    "shortTitle": "WebXR Hand Input 1"
+    "shortTitle": "WebXR Hand Input 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/hand-input"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webxr/",
@@ -8012,7 +9999,22 @@
     },
     "title": "WebXR Device API",
     "source": "w3c",
-    "shortTitle": "WebXR Device API"
+    "shortTitle": "WebXR Device API",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr"
+      ],
+      "excludePaths": [
+        "webxr/anchors",
+        "webxr/ar-module",
+        "webxr/dom-overlay",
+        "webxr/gamepads-module",
+        "webxr/hand-input",
+        "webxr/hit-test",
+        "webxr/layers"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/webxrlayers-1/",
@@ -8035,7 +10037,13 @@
     },
     "title": "WebXR Layers API Level 1",
     "source": "w3c",
-    "shortTitle": "WebXR Layers API 1"
+    "shortTitle": "WebXR Layers API 1",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webxr/layers"
+      ]
+    }
   },
   {
     "url": "https://www.w3.org/TR/WOFF2/",
@@ -8058,7 +10066,13 @@
       "filename": "Overview.html"
     },
     "title": "WOFF File Format 2.0",
-    "source": "w3c"
+    "source": "w3c",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "css/WOFF2"
+      ]
+    }
   },
   {
     "url": "https://xhr.spec.whatwg.org/",
@@ -8076,6 +10090,12 @@
     },
     "title": "XMLHttpRequest Standard",
     "source": "specref",
-    "shortTitle": "XMLHttpRequest"
+    "shortTitle": "XMLHttpRequest",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "xhr"
+      ]
+    }
   }
 ]

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -86,6 +86,25 @@
         "repository": { "$ref": "#/proptype/url" }
       },
       "additionalProperties": false
+    },
+
+    "tests": {
+      "type": "object",
+      "properties": {
+        "repository": { "$ref": "#/proptype/url" },
+        "testPaths": {
+          "type": "array",
+          "items": { "$ref": "#/proptype/relativePath" },
+          "minItems": 1
+        },
+        "excludePaths": {
+          "type": "array",
+          "items": { "$ref": "#/proptype/relativePath" },
+          "minItems": 1
+        }
+      },
+      "required": ["repository"],
+      "additionalProperties": false
     }
   }
 }

--- a/schema/index.json
+++ b/schema/index.json
@@ -14,6 +14,7 @@
       "seriesPrevious": { "$ref": "definitions.json#/proptype/shortname" },
       "seriesNext": { "$ref": "definitions.json#/proptype/shortname" },
       "nightly": { "$ref": "definitions.json#/proptype/nightly" },
+      "tests": { "$ref": "definitions.json#/proptype/tests" },
       "release": { "$ref": "definitions.json#/proptype/release" },
       "title": { "$ref": "definitions.json#/proptype/title" },
       "shortTitle": { "$ref": "definitions.json#/proptype/title" },

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -18,6 +18,7 @@
           "seriesVersion": { "$ref": "definitions.json#/proptype/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/proptype/seriesComposition" },
           "nightly": { "$ref": "definitions.json#/proptype/nightly" },
+          "tests": { "$ref": "definitions.json#/proptype/tests" },
           "shortTitle": { "$ref": "definitions.json#/proptype/title" },
           "forceCurrent": { "type": "boolean" },
           "multipage": { "type": "boolean" }

--- a/specs.json
+++ b/specs.json
@@ -48,7 +48,9 @@
     "url": "https://gpuweb.github.io/gpuweb/",
     "tests": {
       "repository": "https://github.com/gpuweb/cts",
-      "testPaths": ["src/webgpu"]
+      "testPaths": [
+        "src/webgpu"
+      ]
     }
   },
   {
@@ -77,8 +79,12 @@
     "shortTitle": "ECMAScript",
     "tests": {
       "repository": "https://github.com/tc39/test262",
-      "testPaths": ["test"],
-      "excludePaths": ["test/intl402"]
+      "testPaths": [
+        "test"
+      ],
+      "excludePaths": [
+        "test/intl402"
+      ]
     }
   },
   {
@@ -86,7 +92,9 @@
     "shortname": "ecma-402",
     "tests": {
       "repository": "https://github.com/tc39/test262",
-      "testPaths": ["test/intl402"]
+      "testPaths": [
+        "test/intl402"
+      ]
     }
   },
   "https://tc39.es/proposal-atomics-wait-async/",
@@ -232,7 +240,9 @@
     },
     "tests": {
       "repository": "https://github.com/KhronosGroup/WebGL",
-      "testPaths": ["conformance-suites/1.0.3"]
+      "testPaths": [
+        "conformance-suites/1.0.3"
+      ]
     }
   },
   {
@@ -246,7 +256,9 @@
     },
     "tests": {
       "repository": "https://github.com/KhronosGroup/WebGL",
-      "testPaths": ["conformance-suites/2.0.0"]
+      "testPaths": [
+        "conformance-suites/2.0.0"
+      ]
     }
   },
   "https://www.w3.org/TR/accelerometer/",
@@ -574,7 +586,9 @@
     "url": "https://www.w3.org/TR/wasm-core-1/",
     "tests": {
       "repository": "https://github.com/WebAssembly/spec/",
-      "testPaths": ["test/core"]
+      "testPaths": [
+        "test/core"
+      ]
     }
   },
   "https://www.w3.org/TR/wasm-js-api-1/",

--- a/specs.json
+++ b/specs.json
@@ -44,7 +44,13 @@
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://fetch.spec.whatwg.org/",
   "https://fullscreen.spec.whatwg.org/",
-  "https://gpuweb.github.io/gpuweb/",
+  {
+    "url": "https://gpuweb.github.io/gpuweb/",
+    "tests": {
+      "repository": "https://github.com/gpuweb/cts",
+      "testPaths": ["src/webgpu"]
+    }
+  },
   {
     "url": "https://html.spec.whatwg.org/multipage/",
     "multipage": true,
@@ -68,11 +74,20 @@
   {
     "url": "https://tc39.es/ecma262/",
     "shortname": "ecmascript",
-    "shortTitle": "ECMAScript"
+    "shortTitle": "ECMAScript",
+    "tests": {
+      "repository": "https://github.com/tc39/test262",
+      "testPaths": ["test"],
+      "excludePaths": ["test/intl402"]
+    }
   },
   {
     "url": "https://tc39.es/ecma402/",
-    "shortname": "ecma-402"
+    "shortname": "ecma-402",
+    "tests": {
+      "repository": "https://github.com/tc39/test262",
+      "testPaths": ["test/intl402"]
+    }
   },
   "https://tc39.es/proposal-atomics-wait-async/",
   "https://tc39.es/proposal-class-fields/",
@@ -214,6 +229,10 @@
     },
     "nightly": {
       "sourcePath": "specs/latest/1.0/index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": ["conformance-suites/1.0.3"]
     }
   },
   {
@@ -224,6 +243,10 @@
     },
     "nightly": {
       "sourcePath": "specs/latest/2.0/index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": ["conformance-suites/2.0.0"]
     }
   },
   "https://www.w3.org/TR/accelerometer/",
@@ -547,7 +570,13 @@
   "https://www.w3.org/TR/user-timing-3/",
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/wai-aria-1.2/",
-  "https://www.w3.org/TR/wasm-core-1/",
+  {
+    "url": "https://www.w3.org/TR/wasm-core-1/",
+    "tests": {
+      "repository": "https://github.com/WebAssembly/spec/",
+      "testPaths": ["test/core"]
+    }
+  },
   "https://www.w3.org/TR/wasm-js-api-1/",
   "https://www.w3.org/TR/wasm-web-api-1/",
   "https://www.w3.org/TR/web-animations-1/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -14,6 +14,7 @@ const computeCurrentLevel = require("./compute-currentlevel.js");
 const computeRepository = require("./compute-repository.js");
 const computeShortTitle = require("./compute-shorttitle.js");
 const determineFilename = require("./determine-filename.js");
+const determineTestPath = require("./determine-testpath.js");
 const extractPages = require("./extract-pages.js");
 const fetchInfo = require("./fetch-info.js");
 const { w3cApiKey } = require("../config.json");
@@ -140,6 +141,9 @@ fetchInfo(specs, { w3cApiKey })
 
   // Complete with repository
   .then(index => computeRepository(index, { githubToken }))
+
+  // Complete with info on test suite
+  .then(index => determineTestPath(index, { githubToken }))
 
   // Complete with list of pages for multipage specs
   .then(index => Promise.all(

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -137,18 +137,7 @@ module.exports = async function (specs, options) {
     };
 
     if (spec.tests) {
-      if (spec.tests.repository) {
-        info.repository = spec.tests.repository;
-      }
-
-      if (spec.tests.testPaths) {
-        const testPaths = spec.tests.testPaths;
-        info.testPaths = testPaths;
-        if (spec.tests.excludePaths) {
-          info.excludePaths = spec.tests.excludePaths;
-        }
-      }
-      return info;
+      return Object.assign(info, spec.tests);
     }
 
     if (spec.url.startsWith("https://www.khronos.org/")) {

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -1,0 +1,210 @@
+/**
+ * Module that takes a list of spec objects as input and returns, for each spec,
+ * the URL of the repository that contains the test suite of the spec along with
+ * the path under which the tests are to be found in that repository.
+ *
+ * The function will run git commands on the command-line and populate the local
+ * ".cache" folder.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const execSync = require("child_process").execSync;
+
+// Cache folder under which the WPT repository will be cloned
+const cacheFolder = path.resolve(__dirname, "..", ".cache");
+const wptFolder = path.resolve(cacheFolder, "wpt");
+
+/**
+ * Helper function to setup the cache folder
+ */
+function setupCacheFolder() {
+  try {
+    fs.mkdirSync(cacheFolder);
+  }
+  catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Helper function that returns true when the WPT folder already exists
+ * (which is taken to mean that the repository has already been cloned)
+ */
+function wptFolderExists() {
+  try {
+    fs.accessSync(wptFolder);
+    return true;
+  }
+  catch (err) {
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
+    return false;
+  }
+}
+
+/**
+ * Helper function that fetches the latest version of the WPT repository,
+ * restricting the checkout to META.yml files
+ */
+function fetchWPT() {
+  setupCacheFolder();
+  if (wptFolderExists()) {
+    // Pull latest commit from master branch
+    execSync("git pull origin master", { cwd: wptFolder });
+  }
+  else {
+    // Clone repo using sparse mode: the repo is huge and we're only interested
+    // in META.yml files
+    execSync("git clone https://github.com/web-platform-tests/wpt.git --depth 1 --sparse", { cwd: cacheFolder });
+    execSync("git sparse-checkout add **/META.yml", { cwd: wptFolder });
+  }
+}
+
+/**
+ * Helper function that reads "spec" entries in all META.yml files of the WPT
+ * repository.
+ *
+ * Note the function parses META.yml files as regular text files. That works
+ * well but a proper YAML parser would be needed if we need to handle things
+ * such as comments.
+ */
+async function readWptMetaFiles() {
+  async function readFolder(folder) {
+    let res = [];
+    const contents = await fs.promises.readdir(folder);
+    for (const name of contents) {
+      const filename = path.resolve(folder, name);
+      const stat = await fs.promises.stat(filename);
+      if (stat.isDirectory()) {
+        const nestedFiles = await readFolder(filename);
+        res = res.concat(nestedFiles);
+      }
+      else if (name === "META.yml") {
+        const file = await fs.promises.readFile(filename, "utf8");
+        const match = file.match(/(?:^|\n)spec: (.*)$/m);
+        if (match) {
+          res.push({
+            folder: folder.substring(wptFolder.length + 1).replace(/\\/g, "/"),
+            spec: match[1]
+          });
+        }
+      }
+    }
+    return res;
+  }
+
+  fetchWPT();
+  return await readFolder(wptFolder);
+}
+
+
+/**
+ * Returns the first item in the list found in the array, or null if none of
+ * the items exists in the array.
+ */
+function getFirstFoundInArray(paths, ...items) {
+  for (const item of items) {
+    const path = paths.find(p => p === item);
+    if (path) {
+      return path;
+    }
+  }
+  return null;
+}
+
+
+/**
+ * Exports main function that takes a list of specs as input, completes entries
+ * with a tests property when possible and returns the list.
+ *
+ * The options parameter is used to specify the GitHub API authentication token.
+ */
+module.exports = async function (specs, options) {
+  if (!specs || specs.find(spec => !spec.shortname || !spec.series || !spec.series.shortname)) {
+    throw "Invalid list of specifications passed as parameter";
+  }
+  options = options || {};
+
+  const wptFolders = await readWptMetaFiles();
+
+  function determineTestInfo(spec) {
+    const info = {
+      repository: "https://github.com/web-platform-tests/wpt"
+    };
+
+    if (spec.tests) {
+      if (spec.tests.repository) {
+        info.repository = spec.tests.repository;
+      }
+
+      if (spec.tests.testPaths) {
+        const testPaths = spec.tests.testPaths;
+        info.testPaths = testPaths;
+        if (spec.tests.excludePaths) {
+          info.excludePaths = spec.tests.excludePaths;
+        }
+      }
+      return info;
+    }
+
+    if (spec.url.startsWith("https://www.khronos.org/")) {
+      info.repository = "https://github.com/KhronosGroup/WebGL";
+      info.testPaths = ["conformance-suites"];
+      // TODO: Be more specific, tests for extensions should one of the files in:
+      // https://github.com/KhronosGroup/WebGL/tree/master/conformance-suites/2.0.0/conformance2/extensions
+      // https://github.com/KhronosGroup/WebGL/tree/master/conformance-suites/2.0.0/conformance/extensions
+      // https://github.com/KhronosGroup/WebGL/tree/master/conformance-suites/1.0.3/conformance/extensions
+      return info;
+    }
+
+    if (spec.url.startsWith("https://tc39.es/proposal-")) {
+      // TODO: proposals may or may not have tests under tc39/test262, it would
+      // be good to have that info here. However, that seems hard to assess
+      // automatically and tedious to handle as exceptions in specs.json.
+      return null;
+    }
+
+    // Note the use of startsWith below, needed to cover cases where a META.yml
+    // file targets a specific page in a multipage spec (for HTML, typically),
+    // or a fragment within a spec.
+    const folders = wptFolders
+      .filter(item =>
+        item.spec.startsWith(spec.nightly.url) ||
+        item.spec.startsWith(spec.nightly.url.replace(/-\d+\/$/, "/")))
+      .map(item => item.folder);
+    if (folders.length > 0) {
+      // Don't list subfolders when parent folder is already in the list
+      info.testPaths = folders.filter(p1 => !folders.find(p2 => (p1 !== p2) && p1.startsWith(p2)));
+
+      // Exclude subfolders of listed folders when they map to another spec
+      const excludePaths = folders
+        .map(path => wptFolders.filter(item =>
+          (item.folder !== path) &&
+          item.folder.startsWith(path + "/") &&
+          !item.spec.startsWith(spec.nightly.url) &&
+          !item.spec.startsWith(spec.nightly.url.replace(/-\d+\/$/, "/"))))
+        .flat()
+        .map(item => item.folder);
+      if (excludePaths.length > 0) {
+        info.excludePaths = excludePaths;
+      }
+
+      return info;
+    }
+    return null;
+  }
+
+  const testInfos = specs.map(determineTestInfo);
+  for (const spec of specs) {
+    const testInfo = testInfos.shift();
+    if (testInfo) {
+      spec.tests = testInfo;
+    }
+  }
+
+  return specs;
+};


### PR DESCRIPTION
This update exposes a new `tests` property that details, when that is possible:
1. the URL of the repository that contains the test suite for the spec
2. the actual paths in that repository that contain the test suite
3. if needed, the sub-paths to exclude from the list of paths because they actually contain tests for another specification

@foolip That information should allow you to drop all `testrepo` and `testpath` entries in [day-to-day/specs-fixes.json](https://github.com/foolip/day-to-day/blob/main/specs-fixes.json) and associated logic. FWIW, the list of folders for HTML in that file does not seem fully correct anymore (`shadow-dom` should rather be associated with DOM, `2dcontext`, `innerText` and `offscreen-canvas` no longer exist, and `x-frame-options` should also be in the list).

A few exceptions need to be handled in specs.json:
- The ECMAScript spec
- WebGL 1 and 2
- The WebAssembly Core spec, which uses its own repository
- The WebGPU spec. The spec does have a folder under WPT but it is empty for now as the actual test suite is developed in the gpuweb/cts repository.

A few notes:
- The information is based on `META.yml` files in the Web Platform Tests (WPT) repository.
- The code associates WebGL extension specs with the main WebGL test repository. The association could be more fine-grained.
- Similarly, the code skips TC39 proposals for now, which may or may not have tests in the main ECMAScript test repository.
- The code clones the WPT repository to a local cache folder because the repo is too large to be processed using the GitHub API (we'd be quickly rate limited, even with an API token). To avoid creating too many files, the checkout is restricted to META.yml files.
- `testPaths` is an array that contains one entry in most cases, except for DOM, HTML and a couple of other specs. An alternative would be to use a space- or comma-separated list as in foolip/day-to-day but then that would require parsing the values.
- The whole thing cannot deal with cases where a test suite is composed of tests defined in multiple repositories. That should not happen, although I note that there are apparently ECMAScript tests in the [`js`](https://github.com/web-platform-tests/wpt/tree/master/js) WPT folder which I'm ignoring for the time being...
- The code does not include provisions to detect changes. For instance, it would seem useful to review the ~50 specs that don't have a test suite once in a while to make sure that they still don't have one. To be done separately.

This would close #201.