### PR TITLE
Always check repo against ignore/monitor lists

### DIFF
--- a/schema/data.json
+++ b/schema/data.json
@@ -4,6 +4,22 @@
 
   "type": "object",
   "properties": {
+    "groups": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": ["comment"],
+        "additionalProperties": false
+      }
+    },
     "repos": {
       "type": "object",
       "propertyNames": {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -1,4 +1,42 @@
 {
+  "groups": {
+    "Accessibility Guidelines Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Accessible Platform Architectures Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Audiobooks Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Automotive Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Dataset Exchange Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Decentralized Identifier Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Distributed Tracing Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Education and Outreach Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "EPUB 3 Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "JSON-LD Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Verifiable Credentials Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
+    "Web of Things Working Group": {
+      "comment": "specs not targeted at browsers"
+    }
+  },
   "repos": {
     "w3c/adpt": {
       "comment": "not targeted at browsers"
@@ -119,9 +157,6 @@
     },
     "WICG/media-source": {
       "comment": "Merged back into main spec in the Media WG"
-    },
-    "w3c/epub-specs": {
-      "comment": "not targeted at browsers"
     },
     "WICG/reducing-memory-copies": {
       "comment": "not for spec"

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -15,19 +15,7 @@ const monitorList = require("./data/monitor.json");
 
 const {repos: temporarilyIgnorableRepos, specs: temporarilyIgnorableSpecs} = monitorList;
 
-const nonBrowserSpecWgs = [
-  "Accessibility Guidelines Working Group",
-  "Accessible Platform Architectures Working Group",
-  "Audiobooks Working Group",
-  "Automotive Working Group",
-  "Dataset Exchange Working Group",
-  "Decentralized Identifier Working Group",
-  "Distributed Tracing Working Group",
-  "Education and Outreach Working Group",
-  "JSON-LD Working Group",
-  "Verifiable Credentials Working Group",
-  "Web of Things Working Group"
-];
+const nonBrowserSpecWgs = Object.keys(ignorable.groups);
 const watchedBrowserCgs = [
   "Web Platform Incubator Community Group",
   "Web Assembly Community Group",

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -59,7 +59,10 @@ function canonicalizeTRUrl(url) {
 const toGhUrl = repo => { return {repo: `${repo.owner.login}/${repo.name}`, spec: `https://${repo.owner.login.toLowerCase()}.github.io/${repo.name}/`}; };
 const matchRepoName = fullName => r => fullName === r.owner.login + '/' + r.name;
 const isRelevantRepo = fullName => !Object.keys(ignorable.repos).includes(fullName) && !Object.keys(temporarilyIgnorableRepos).includes(fullName);
-const isInScope = ({spec: url}) => !Object.keys(ignorable.specs).includes(url) && !Object.keys(temporarilyIgnorableSpecs).includes(url);
+const isInScope = ({spec: url, repo: fullName}) =>
+  !Object.keys(ignorable.specs).includes(url) &&
+  !Object.keys(temporarilyIgnorableSpecs).includes(url) &&
+  isRelevantRepo(fullName);
 // Set loose parameter when checking loosely if another version exists
 const hasMoreRecentLevel = (s, url, loose) => {
   try {
@@ -113,7 +116,6 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
   // WGs
   // * check repos with w3c.json/repo-type including rec-track
   const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
-        .filter(isRelevantRepo)
         .map(fullName => repos.find(matchRepoName(fullName)));
   const recTrackRepos = wgRepos.filter(hasRepoType('rec-track'));
 
@@ -142,7 +144,6 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
   // CGs
   //check repos with w3c.json/repo-type includes cg-report or with no w3c.json
   const cgRepos = cgs.map(g => g.repos.map(r => r.fullName)).flat()
-        .filter(isRelevantRepo)
         .map(fullName => repos.find(matchRepoName(fullName)));
 
   const cgSpecRepos = cgRepos.filter(r => !r.w3c


### PR DESCRIPTION
The tool that looks for potential new specs did not always check candidate repos against the list of repos in `ignore.json` and `monitor.json`. This update forces the code to look at these lists when it considers whether a candidate is in scope.

Note explicit checks on the initial list of repos are no longer stricto senso necessary and have been dropped.

Done to address #229, which should not have contained EPUB entries because the underlying repo is in the ignore list.