### PR TITLE
Move SVG Paths and Markers to monitor list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -563,8 +563,6 @@
   },
   "https://www.w3.org/TR/svg-aam-1.0/",
   "https://www.w3.org/TR/svg-integration/",
-  "https://www.w3.org/TR/svg-markers/",
-  "https://www.w3.org/TR/svg-paths/",
   "https://www.w3.org/TR/svg-strokes/",
   "https://www.w3.org/TR/SVG2/ multipage",
   "https://www.w3.org/TR/timing-entrytypes-registry/",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -337,6 +337,22 @@
     "https://drafts.csswg.org/css-contain-3/": {
       "comment": "Marked as Exploratory Working Draft and empty for now",
       "lastreviewed": "2021-03-03"
+    },
+    "https://svgwg.org/specs/markers/": {
+      "comment": "incomplete draft not being maintained, should be classified only as rough proposal per https://github.com/w3c/svgwg/issues/824#issuecomment-790946863",
+      "lastreviewed": "2021-03-05"
+    },
+    "https://www.w3.org/TR/svg-markers/": {
+      "comment": "incomplete draft not being maintained, should be classified only as rough proposal per https://github.com/w3c/svgwg/issues/824#issuecomment-790946863",
+      "lastreviewed": "2021-03-05"
+    },
+    "https://svgwg.org/specs/paths/": {
+      "comment": "incomplete draft not being maintained, should be classified only as rough proposal per https://github.com/w3c/svgwg/issues/824#issuecomment-790946863",
+      "lastreviewed": "2021-03-05"
+    },
+    "https://www.w3.org/TR/svg-paths/": {
+      "comment": "incomplete draft not being maintained, should be classified only as rough proposal per https://github.com/w3c/svgwg/issues/824#issuecomment-790946863",
+      "lastreviewed": "2021-03-05"
     }
   }
 }


### PR DESCRIPTION
Per https://github.com/w3c/svgwg/issues/824#issuecomment-790920790 they're incomplete and unmaintained, and they end up creating conflicting IDL views with the main SVG2 specs.

They're included both with their editors and TR urls since they can't be tracked at the repo level (multi-spec repo).

close #247 