### PR TITLE
Ignore specs from MiniApps Working Group

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -30,6 +30,9 @@
     "JSON-LD Working Group": {
       "comment": "specs not targeted at browsers"
     },
+    "MiniApps Working Group": {
+      "comment": "specs not targeted at browsers"
+    },
     "Verifiable Credentials Working Group": {
       "comment": "specs not targeted at browsers"
     },


### PR DESCRIPTION
Specs are not - or at least not yet - targeted at browsers.

Closes #254.