### PR TITLE
Drop nightly URL override for Fetch Metadata

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -459,10 +459,7 @@
   },
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
-    "shortTitle": "Fetch Metadata",
-    "nightly": {
-      "url": "https://w3c.github.io/webappsec-fetch-metadata/"
-    }
+    "shortTitle": "Fetch Metadata"
   },
   "https://www.w3.org/TR/FileAPI/",
   "https://www.w3.org/TR/fill-stroke-3/",


### PR DESCRIPTION
URL was fixed in the spec:
https://github.com/w3c/webappsec-fetch-metadata/pull/69