### PR TITLE
Add DNT, SVG 1.1, and Manifest App info specs

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -10,7 +10,7 @@
 
     "filename": {
       "type": "string",
-      "pattern": "^\\w+\\.html$"
+      "pattern": "^[\\w\\-]+\\.html$"
     },
 
     "relativePath": {

--- a/specs.json
+++ b/specs.json
@@ -487,6 +487,7 @@
   "https://www.w3.org/TR/intersection-observer/",
   "https://www.w3.org/TR/longtasks-1/",
   "https://www.w3.org/TR/magnetometer/",
+  "https://www.w3.org/TR/manifest-app-info/",
   "https://www.w3.org/TR/media-capabilities/",
   {
     "url": "https://www.w3.org/TR/media-source/",
@@ -566,10 +567,18 @@
   "https://www.w3.org/TR/svg-aam-1.0/",
   "https://www.w3.org/TR/svg-integration/",
   "https://www.w3.org/TR/svg-strokes/",
+  {
+    "url": "https://www.w3.org/TR/SVG11/",
+    "multipage": true,
+    "nightly": {
+      "url": "https://svgwg.org/svg2-draft/"
+    }
+  },
   "https://www.w3.org/TR/SVG2/ multipage",
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
   "https://www.w3.org/TR/trace-context-1/",
+  "https://www.w3.org/TR/tracking-dnt/",
   {
     "url": "https://www.w3.org/TR/uievents-code/",
     "nightly": {

--- a/test/fetch-info-w3c.js
+++ b/test/fetch-info-w3c.js
@@ -46,7 +46,7 @@ describe("fetch-info module (with W3C API key)", function () {
       assert.equal(info[spec.shortname].title, "High Resolution Time Level 2");
 
       assert.ok(info.__current);
-      assert.equal(info.__current["hr-time"], "hr-time-2");
+      assert.equal(info.__current["hr-time"], "hr-time-3");
     });
 
     it("can operate on multiple specs at once", async () => {
@@ -66,7 +66,7 @@ describe("fetch-info module (with W3C API key)", function () {
       assert.equal(info[other.shortname].title, "Presentation API");
 
       assert.ok(info.__current);
-      assert.equal(info.__current["hr-time"], "hr-time-2");
+      assert.equal(info.__current["hr-time"], "hr-time-3");
       assert.equal(info.__current["presentation-api"], "presentation-api");
     });
 


### PR DESCRIPTION
This adds three requested specs that sit at the boundary of spec selection
criteria for browser-specs:

1. DNT, requested in #281
2. SVG 1.1, requested in #273
3. Web App Manifest - App info, requested in #283

The SVG 1.1 entry uses SVG 2 as nightly URL for lack of a better alternative.

JSON schema has to be slightly adjusted to account for the "-" in
"tracking-dnt.html". Also, a test started to fail because "hr-time-3" is now
the default level for HR Time.