### PR TITLE
Switch to /TR URL for WebTransport

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -124,7 +124,6 @@
   "https://w3c.github.io/webdriver-bidi/",
   "https://w3c.github.io/webrtc-encoded-transform/",
   "https://w3c.github.io/webrtc-ice/",
-  "https://w3c.github.io/webtransport/",
   "https://webbluetoothcg.github.io/web-bluetooth/",
   "https://wicg.github.io/background-fetch/",
   {
@@ -636,6 +635,7 @@
     "url": "https://www.w3.org/TR/webrtc/",
     "shortTitle": "WebRTC 1.0"
   },
+  "https://www.w3.org/TR/webtransport/",
   "https://www.w3.org/TR/webvtt1/",
   "https://www.w3.org/TR/webxr-ar-module-1/",
   "https://www.w3.org/TR/webxr-gamepads-module-1/",


### PR DESCRIPTION
Spec published as First Public Working Draft.

Close #293 