### PR TITLE
Drop https://www.w3.org/TR/tracking-dnt/

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -582,7 +582,6 @@
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
   "https://www.w3.org/TR/trace-context-1/",
-  "https://www.w3.org/TR/tracking-dnt/",
   {
     "url": "https://www.w3.org/TR/uievents-code/",
     "nightly": {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -306,6 +306,9 @@
     },
     "https://tc39.es/proposal-hashbang/": {
       "comment": "not meant for browsers environments"
+    },
+    "https://www.w3.org/TR/tracking-dnt/": {
+      "comment": "retired as a Working Group Note"
     }
   }
 }


### PR DESCRIPTION
https://www.w3.org/TR/tracking-dnt/ never made it to Recommendation; instead it was retired as a Working Group Note:

https://www.w3.org/TR/2019/NOTE-tracking-dnt-20190117/

Its formal status is Retired:

https://www.w3.org/TR/?tag=privacy&status=ret

And its Status section says:

> Since its last publication as a Candidate Recommendation, there has not been sufficient deployment of these extensions (as defined) to justify further advancement, nor have there been indications of planned support among user agents, third parties, and the ecosystem at large.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10469
Related MDN change: https://github.com/mdn/content/pull/4960