### PR TITLE
Switch ecma262 spec to multipage version

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -65,7 +65,8 @@
   "https://streams.spec.whatwg.org/",
   "https://svgwg.org/specs/animations/",
   {
-    "url": "https://tc39.es/ecma262/",
+    "url": "https://tc39.es/ecma262/multipage/",
+    "multipage": true,
     "shortname": "ecmascript",
     "shortTitle": "ECMAScript",
     "tests": {


### PR DESCRIPTION
There’s now a multipage version of the ECMAScript spec, at https://tc39.es/ecma262/multipage/. This change switches to the multipage version, rather than the single-page version. cc @Elchi3