### PR TITLE
Recognize tc39-transfer as equivalent to tc39 when finding specs

### DIFF
--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -191,7 +191,7 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
                                  .filter(isInScope));
 
   // Check for new TC39 Stage 3 proposals
-  candidates = candidates.concat(ecmaProposals.map(s => { return {repo: s.replace('https://github.com/', ''), spec: s.replace('https://github.com/tc39/', 'https://tc39.es/') + '/'};})
+  candidates = candidates.concat(ecmaProposals.map(s => { return {repo: s.replace('https://github.com/', ''), spec: s.replace('https://github.com/tc39/', 'https://tc39.es/').replace('https://github.com/tc39-transfer/', 'https://tc39.es/') + '/'};})
                                  .filter(hasUntrackedURL)
                                  .filter(isInScope));
 


### PR DESCRIPTION
Per https://github.com/w3c/browser-specs/issues/308#issuecomment-856084703