### PR TITLE
Use /TR URL for SVG 1.1 spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -571,7 +571,8 @@
     "url": "https://www.w3.org/TR/SVG11/",
     "multipage": true,
     "nightly": {
-      "url": "https://svgwg.org/svg2-draft/"
+      "url": "https://www.w3.org/TR/SVG11/",
+      "repository": "https://github.com/w3c/svgwg"
     }
   },
   "https://www.w3.org/TR/SVG2/ multipage",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -19,6 +19,11 @@ function urlToGitHubRepository(url) {
     throw "No URL passed as parameter";
   }
 
+  const githubcom = url.match(/^https:\/\/github\.com\/([^\/]*)\/([^\/]*)\/?/);
+  if (githubcom) {
+    return { owner: githubcom[1], name: githubcom[2] };
+  }
+
   const githubio = url.match(/^https:\/\/([^\.]*)\.github\.io\/([^\/]*)\/?/);
   if (githubio) {
     return { owner: githubio[1], name: githubio[2] };
@@ -197,7 +202,7 @@ module.exports = async function (specs, options) {
   }
 
   // Compute GitHub repositories with lowercase owner names
-  const repos = specs.map(spec => urlToGitHubRepository(spec.nightly.url));
+  const repos = specs.map(spec => urlToGitHubRepository(spec.nightly.repository ?? spec.nightly.url));
 
   if (options.githubToken) {
     // Fetch the real name of repository owners (preserving case)

--- a/src/compute-series-urls.js
+++ b/src/compute-series-urls.js
@@ -58,7 +58,9 @@ function computeSeriesUrls(spec) {
 module.exports = function (spec, list) {
   list = list || [];
 
-  const res = computeSeriesUrls(spec);
+  // Compute series info for current version of the spec if it is in the list
+  const currentSpec = list.find(s => s.shortname === spec.series?.currentSpecification);
+  const res = computeSeriesUrls(currentSpec ?? spec);
 
   // Look for a release URL in previous versions of the spec if one exists
   if (!res.releaseUrl) {

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -8,6 +8,12 @@ describe("compute-repository module", async () => {
     return result[0].nightly.repository;
   };
 
+  it("handles github.com URLs", async () => {
+    assert.equal(
+      await computeSingleRepo("https://github.com/orgname/specname"),
+      "https://github.com/orgname/specname");
+  });
+
   it("handles xxx.github.io URLs", async () => {
     assert.equal(
       await computeSingleRepo("https://orgname.github.io/specname"),

--- a/test/compute-series-urls.js
+++ b/test/compute-series-urls.js
@@ -125,4 +125,32 @@ describe("compute-series-urls module", () => {
       { releaseUrl: "https://www.w3.org/TR/css-fonts/",
         nightlyUrl: "https://drafts.csswg.org/css-fonts/" });
   });
+
+
+  it("computes info based on current specification", () => {
+    const spec = {
+      url: "https://www.w3.org/TR/SVG11/",
+      seriesComposition: "full",
+      shortname: "SVG11",
+      series: { shortname: "SVG", currentSpecification: "SVG2" },
+      release: { url: "https://www.w3.org/TR/SVG11/" },
+      nightly: { url: "https://www.w3.org/TR/SVG11/" }
+    };
+
+    const list = [
+      spec,
+      {
+        url: "https://www.w3.org/TR/SVG2/",
+        seriesComposition: "full",
+        shortname: "SVG2",
+        series: { shortname: "SVG", currentSpecification: "SVG2" },
+        release: { url: "https://www.w3.org/TR/SVG2/" },
+        nightly: { url: "https://svgwg.org/svg2-draft/" }
+      }
+    ];
+
+    assert.deepStrictEqual(computeSeriesUrls(spec, list),
+      { releaseUrl: "https://www.w3.org/TR/SVG/",
+        nightlyUrl: "https://svgwg.org/svg2-draft/" });
+  });
 });


### PR DESCRIPTION
Fixes #312.

This update required a couple of additional code updates:
- in the code that computes the URL of the repository to use the `repository` info if it is specified in `specs.json`.
- in the code that computes the `releaseUrl` and `nightlyUrl` to use the current specification in a series as basis for the info (the code happily produced a different nightly URL for SVG 1.1 and SVG 2)