### PR TITLE
Use latest version of github-push-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
         git config user.email "<>"
         git commit -m "[data] Update spec info" -a || true
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
         git config user.email "<>"
         git commit -m "[data] Update spec info" -a || true
     - name: Push changes
-      uses: ad-m/github-push-action@v0.5.0
+      uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Build workflow used an old version of github-push-action, which used `master`as default branch name. The latest version uses the actual default branch.