### PR TITLE
Reflect new source file for painttiming

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -532,12 +532,7 @@
   "https://www.w3.org/TR/orientation-event/",
   "https://www.w3.org/TR/orientation-sensor/",
   "https://www.w3.org/TR/page-visibility-2/",
-  {
-    "url": "https://www.w3.org/TR/paint-timing/",
-    "nightly": {
-      "sourcePath": "painttiming.bs"
-    }
-  },
+  "https://www.w3.org/TR/paint-timing/",
   "https://www.w3.org/TR/payment-handler/",
   {
     "url": "https://www.w3.org/TR/payment-method-basic-card/",


### PR DESCRIPTION
No longer user an exception per https://github.com/w3c/paint-timing/pull/91
close https://github.com/w3c/browser-specs/issues/330