### PR TITLE
Remove Trace Context

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -595,7 +595,6 @@
   "https://www.w3.org/TR/SVG2/ multipage",
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
-  "https://www.w3.org/TR/trace-context-1/",
   "https://www.w3.org/TR/tracking-dnt/",
   {
     "url": "https://www.w3.org/TR/uievents-code/",


### PR DESCRIPTION
Does not match the browser-spec requirements
Bis of https://github.com/w3c/browser-specs/pull/195 which one way or another didn't work?