### PR TITLE
Document WG manually for RFC2397

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -6,7 +6,15 @@
     }
   },
   "https://console.spec.whatwg.org/",
-  "https://datatracker.ietf.org/doc/html/rfc2397",
+  {
+    "url": "https://datatracker.ietf.org/doc/html/rfc2397",
+    "groups": [
+      {
+        "name": "Network Working Group",
+        "url": "https://datatracker.ietf.org/group/app/"
+      }
+    ]
+  },
   "https://datatracker.ietf.org/doc/html/rfc6265",
   "https://datatracker.ietf.org/doc/html/rfc6266",
   "https://datatracker.ietf.org/doc/html/rfc6454",


### PR DESCRIPTION
The RFC talks of a Network Working Group, the same as the one quoted on https://datatracker.ietf.org/doc/html/rfc3987 which has a WG link to https://datatracker.ietf.org/group/app/

close #343