### PR TITLE
Monitor MathML 4 spec

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -41,6 +41,9 @@
     }
   },
   "repos": {
+    "w3c/mathml": {
+      "comment": "not targeted at browsers"
+    },
     "w3c/adpt": {
       "comment": "not targeted at browsers"
     },

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -1,9 +1,5 @@
 {
   "repos": {
-    "w3c/mathml": {
-      "comment": "not yet based on MathML Core and not yet clear spec will target browsers",
-      "lastreviewed": "2021-07-19"
-    },
     "WICG/prefer-current-tab": {
       "comment": "unofficial draft that defines a single new dictionary member",
       "lastreviewed": "2021-07-01"

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -1,5 +1,9 @@
 {
   "repos": {
+    "w3c/mathml": {
+      "comment": "not yet based on MathML Core and not yet clear spec will target browsers",
+      "lastreviewed": "2021-07-19"
+    },
     "WICG/prefer-current-tab": {
       "comment": "unofficial draft that defines a single new dictionary member",
       "lastreviewed": "2021-07-01"


### PR DESCRIPTION
I don't really know what to do with this spec, raised in #350. I propose to add it to the monitor list for now. Spec is under development within the MathML WG but it is mostly a copy of MathML 3 for now, is not yet based on MathML Core and, as opposed to MathML Core that specifically targets browsers, is likely going to define features that won't be implemented by browsers.