### PR TITLE
Drop Constructable Stylesheet Objects

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -129,7 +129,6 @@
   },
   "https://wicg.github.io/client-hints-infrastructure/",
   "https://wicg.github.io/compression/",
-  "https://wicg.github.io/construct-stylesheets/",
   "https://wicg.github.io/contact-api/spec/",
   "https://wicg.github.io/content-index/spec/",
   "https://wicg.github.io/cookie-store/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -176,6 +176,9 @@
     "WICG/virtual-scroller": {
       "comment": "No longer being actively developed"
     },
+    "WICG/construct-stylesheets": {
+      "comment": "Integrated in CSSOM"
+    },
     "w3c/merchant-validation": {
       "comment": "Deprecated API documenting legacy implementation"
     }


### PR DESCRIPTION
The IDL that the spec defined has now been fully integrated in CSSOM