### PR TITLE
Add CSS Cascade 6, Scripting Policy, Close Watcher

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -11,6 +11,7 @@
   "https://drafts.css-houdini.org/font-metrics-api-1/",
   "https://drafts.csswg.org/css-animations-2/ delta",
   "https://drafts.csswg.org/css-backgrounds-4/ delta",
+  "https://drafts.csswg.org/css-cascade-6/ delta",
   "https://drafts.csswg.org/css-env-1/",
   "https://drafts.csswg.org/css-extensions-1/",
   "https://drafts.csswg.org/css-fonts-5/ delta",
@@ -26,7 +27,6 @@
     "shortTitle": "CSS Multicol 2"
   },
   "https://drafts.csswg.org/css-page-4/ delta",
-  "https://drafts.csswg.org/css-scoping-2/ delta",
   "https://drafts.csswg.org/css-shapes-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
@@ -126,6 +126,7 @@
     "shortTitle": "Background Sync"
   },
   "https://wicg.github.io/client-hints-infrastructure/",
+  "https://wicg.github.io/close-watcher/",
   "https://wicg.github.io/compression/",
   "https://wicg.github.io/contact-api/spec/",
   "https://wicg.github.io/content-index/spec/",
@@ -133,6 +134,7 @@
   "https://wicg.github.io/cookie-store/",
   "https://wicg.github.io/crash-reporting/",
   "https://wicg.github.io/credentiallessness/",
+  "https://wicg.github.io/csp-next/scripting-policy.html",
   "https://wicg.github.io/css-parser-api/",
   "https://wicg.github.io/custom-state-pseudo-class/",
   "https://wicg.github.io/datacue/",


### PR DESCRIPTION
This update adds CSS Cascade 6 and drops CSS Scoping 2 as a result (the latter spec now redirects to the former).

It also adds the Scripting Policy and Close Watcher API. The two specs are still at early stages and in a grey zone vis-à-vis our spec selection criteria but development is active and proposals are backed by implementers, see:
https://github.com/WICG/proposals/issues/18
https://github.com/WICG/proposals/issues/36

Fixes #375