### PR TITLE
Add TC39 Intl proposals, Compute Pressure, Conditional Focus

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -85,6 +85,10 @@
       ]
     }
   },
+  {
+    "url": "https://tc39.es/intl-displaynames-v2/",
+    "shortname": "intl-displaynames-v2"
+  },
   "https://tc39.es/proposal-accessible-object-hasownproperty/",
   "https://tc39.es/proposal-array-find-from-last/",
   "https://tc39.es/proposal-atomics-wait-async/",
@@ -92,7 +96,11 @@
   "https://tc39.es/proposal-class-static-block/",
   "https://tc39.es/proposal-error-cause/",
   "https://tc39.es/proposal-import-assertions/",
+  "https://tc39.es/proposal-intl-enumeration/",
+  "https://tc39.es/proposal-intl-extend-timezonename/",
   "https://tc39.es/proposal-intl-locale-info/",
+  "https://tc39.es/proposal-intl-numberformat-v3/",
+  "https://tc39.es/proposal-intl-segmenter/",
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-private-fields-in-in/",
   "https://tc39.es/proposal-private-methods/",
@@ -128,6 +136,8 @@
   "https://wicg.github.io/client-hints-infrastructure/",
   "https://wicg.github.io/close-watcher/",
   "https://wicg.github.io/compression/",
+  "https://wicg.github.io/compute-pressure/",
+  "https://wicg.github.io/conditional-focus/",
   "https://wicg.github.io/contact-api/spec/",
   "https://wicg.github.io/content-index/spec/",
   "https://wicg.github.io/conversion-measurement-api/",

--- a/specs.json
+++ b/specs.json
@@ -137,7 +137,6 @@
   "https://wicg.github.io/close-watcher/",
   "https://wicg.github.io/compression/",
   "https://wicg.github.io/compute-pressure/",
-  "https://wicg.github.io/conditional-focus/",
   "https://wicg.github.io/contact-api/spec/",
   "https://wicg.github.io/content-index/spec/",
   "https://wicg.github.io/conversion-measurement-api/",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -283,6 +283,14 @@
     "w3c/PNG-spec": {
       "lastreviewed": "2021-09-20",
       "comment": "spec does not yet follow usual formatting rules (dfns, refs)"
+    },
+    "WICG/conditional-focus": {
+      "lastreviewed": "2021-09-27",
+      "comment": "spec should get integrated in Screen Capture, see https://github.com/w3c/mediacapture-screen-share/issues/190"
+    },
+    "whatwg/testutils": {
+      "lastreviewed": "2021-09-27",
+      "comment": "Repo does not exist yet but should come to life at some point"
     }
   },
   "specs": {

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -258,7 +258,10 @@ async function fetchInfoFromSpecs(specs, options) {
     const dom = await JSDOM.fromURL(spec.url);
 
     if (spec.url.startsWith("https://tc39.es/")) {
-      const h1ecma = [...dom.window.document.querySelectorAll("h1")][1];
+      // Title is either flagged with specific class or the second h1
+      const h1ecma =
+        dom.window.document.querySelector('#spec-container h1.title') ??
+        dom.window.document.querySelectorAll("h1")[1];
       if (h1ecma) {
         return {
           nightly: { url: spec.url },

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -82,5 +82,17 @@ describe("fetch-info module (without W3C API key)", function () {
       assert.equal(info[spec.shortname].nightly.url, spec.url);
       assert.equal(info[spec.shortname].title, "TPAC 2019 - New Features");
     });
+
+    it("extracts right title from an ECMAScript proposal spec", async () => {
+      const spec = {
+        url: "https://tc39.es/proposal-intl-segmenter/",
+        shortname: "tc39-intl-segmenter"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].nightly.url, spec.url);
+      assert.equal(info[spec.shortname].title, "Intl.Segmenter Proposal");
+    });
   });
 });


### PR DESCRIPTION
This update also improves the title extraction logic for TC39 specs, because one of the Intl proposals actually puts the title in the third `<h1>` and not the second one.

Close #386.