### PR TITLE
Monitor Intl.NumberFormat, fix shortnames of Intl.DisplayNames

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -87,7 +87,10 @@
   },
   {
     "url": "https://tc39.es/intl-displaynames-v2/",
-    "shortname": "intl-displaynames-v2"
+    "shortname": "tc39-intl-displaynames-v2",
+    "series": {
+      "shortname": "tc39-intl-displaynames"
+    }
   },
   "https://tc39.es/proposal-accessible-object-hasownproperty/",
   "https://tc39.es/proposal-array-find-from-last/",
@@ -99,7 +102,6 @@
   "https://tc39.es/proposal-intl-enumeration/",
   "https://tc39.es/proposal-intl-extend-timezonename/",
   "https://tc39.es/proposal-intl-locale-info/",
-  "https://tc39.es/proposal-intl-numberformat-v3/",
   "https://tc39.es/proposal-intl-segmenter/",
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-private-fields-in-in/",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -291,6 +291,10 @@
     "whatwg/testutils": {
       "lastreviewed": "2021-09-27",
       "comment": "Repo does not exist yet but should come to life at some point"
+    },
+    "tc39/proposal-intl-numberformat-v3": {
+      "lastreviewed": "2021-09-27",
+      "comment": "Proposal just exists as a readme for now"
     }
   },
   "specs": {


### PR DESCRIPTION
The Intl.NumberFormat proposal may be at stage 3 but it only exists as a README for now (and README claims it is at stage 2...). Our code cannot set the `sourcePath` as a result and it seems premature to add the spec as a result.

Also, the `tc39-` prefix was missing from the Intl.DisplayNames shortname and the series shortname didn't look too good. Code could probably be fixed to support `-vXX` URL suffixes, but then there is only one occurrence of such a URL for the time being, so handling it directly in specs.json.

Close #388.