### PR TITLE
Add W3C Process and Patent Policy document, adjust tools and tests

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -320,6 +320,34 @@
   "https://www.rfc-editor.org/rfc/rfc8246",
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
+  {
+    "url": "https://www.w3.org/Consortium/Patent-Policy/",
+    "shortname": "w3c-patent-policy",
+    "organization": "W3C",
+    "groups": [
+      {
+        "name": "Patents and Standards Interest Group",
+        "url": "https://www.w3.org/2004/pp/psig/"
+      }
+    ]
+  },
+  {
+    "url": "https://www.w3.org/Consortium/Process/",
+    "shortname": "w3c-process",
+    "groups": [
+      {
+        "name": "Advisory Board",
+        "url": "https://www.w3.org/Member/Board/"
+      },
+      {
+        "name": "W3C Process Community Group ",
+        "url": "https://www.w3.org/community/w3process/"
+      }
+    ],
+    "nightly": {
+      "repository": "https://github.com/w3c/w3process/"
+    }
+  },
   "https://www.w3.org/TR/accelerometer/",
   "https://www.w3.org/TR/accname-1.2/",
   "https://www.w3.org/TR/ambient-light/",

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -73,10 +73,12 @@ module.exports = async function (specs, options) {
           throw new Error(`Could not identify IETF group producing ${spec.url}`);
         }
       }
-      throw new Error(`Cannot extract any useful info from ${spec.url}`);
+      if (!spec.groups) {
+        throw new Error(`Cannot extract any useful info from ${spec.url}`);
+      }
     }
 
-    if (info.owner === "whatwg") {
+    if (info && info.owner === "whatwg") {
       const workstreams = await fetchJSON("https://raw.githubusercontent.com/whatwg/sg/main/db.json");
       const workstream = workstreams.workstreams.find(ws => ws.standards.find(s => s.href === spec.url));
       if (!workstream) {
@@ -90,7 +92,7 @@ module.exports = async function (specs, options) {
       continue;
     }
 
-    if (info.owner === "tc39") {
+    if (info && info.owner === "tc39") {
       spec.organization = spec.organization ?? "Ecma International";
       spec.groups = spec.groups ?? [{
         name: "TC39",
@@ -99,7 +101,7 @@ module.exports = async function (specs, options) {
       continue;
     }
 
-    if (info.owner === "khronosgroup") {
+    if (info && info.owner === "khronosgroup") {
       spec.organization = spec.organization ?? "Khronos Group";
       spec.groups = spec.groups ?? [{
         name: "WebGL Working Group",
@@ -111,58 +113,58 @@ module.exports = async function (specs, options) {
     // All specs that remain should be developed by some W3C group.
     spec.organization = spec.organization ?? "W3C";
 
-    let groups = null;
-    if (info.name === "svgwg") {
-      groups = [19480];
-    }
-    else if (info.type === "tr") {
-      // Use the W3C API to find info about /TR specs
-      const url = `https://api.w3.org/specifications/${info.name}/versions/latest`;
-      let resp = await fetchJSON(url, w3cOptions);
-      if (!resp?._links?.deliverers) {
-        throw new Error(`W3C API did not return deliverers for the spec`);
+    if (!spec.groups) {
+      let groups = null;
+      if (info.name === "svgwg") {
+        groups = [19480];
       }
-      resp = await fetchJSON(resp._links.deliverers.href, w3cOptions);
-
-      if (!resp?._links?.deliverers) {
-        throw new Error(`W3C API did not return deliverers for the spec`);
-      }
-      groups = [];
-      for (const deliverer of resp._links.deliverers) {
-        groups.push(deliverer.href);
-      }
-    }
-    else {
-      // Use info in w3c.json file, which we'll either retrieve from the
-      // repository when one is defined or directly from the spec origin
-      // (we may need to go through the repository in all cases in the future,
-      // but that approach works for now)
-      let url = null;
-      if (info.type === "github") {
-        const octokit = new Octokit({ auth: options?.githubToken });
-        const cacheId = info.owner + "/" + info.name;
-        const repo = cache[cacheId] ??
-          await octokit.repos.get({ owner: info.owner, repo: info.name });
-        cache[cacheId] = repo;
-        const branch = repo?.data?.default_branch;
-        if (!branch) {
-          throw new Error(`Expected GitHub repository does not exist (${spec.url})`);
+      else if (info.type === "tr") {
+        // Use the W3C API to find info about /TR specs
+        const url = `https://api.w3.org/specifications/${info.name}/versions/latest`;
+        let resp = await fetchJSON(url, w3cOptions);
+        if (!resp?._links?.deliverers) {
+          throw new Error(`W3C API did not return deliverers for the spec`);
         }
-        url = new URL(`https://raw.githubusercontent.com/${info.owner}/${info.name}/${branch}/w3c.json`);
+        resp = await fetchJSON(resp._links.deliverers.href, w3cOptions);
+
+        if (!resp?._links?.deliverers) {
+          throw new Error(`W3C API did not return deliverers for the spec`);
+        }
+        groups = [];
+        for (const deliverer of resp._links.deliverers) {
+          groups.push(deliverer.href);
+        }
       }
       else {
-        url = new URL(spec.url);
-        url.pathname = "/w3c.json";
+        // Use info in w3c.json file, which we'll either retrieve from the
+        // repository when one is defined or directly from the spec origin
+        // (we may need to go through the repository in all cases in the future,
+        // but that approach works for now)
+        let url = null;
+        if (info.type === "github") {
+          const octokit = new Octokit({ auth: options?.githubToken });
+          const cacheId = info.owner + "/" + info.name;
+          const repo = cache[cacheId] ??
+            await octokit.repos.get({ owner: info.owner, repo: info.name });
+          cache[cacheId] = repo;
+          const branch = repo?.data?.default_branch;
+          if (!branch) {
+            throw new Error(`Expected GitHub repository does not exist (${spec.url})`);
+          }
+          url = new URL(`https://raw.githubusercontent.com/${info.owner}/${info.name}/${branch}/w3c.json`);
+        }
+        else {
+          url = new URL(spec.url);
+          url.pathname = "/w3c.json";
+        }
+        const body = await fetchJSON(url.toString());
+
+        // Note the "group" property is either an ID or an array of IDs
+        groups = [body?.group].flat().filter(g => !!g);
       }
-      const body = await fetchJSON(url.toString());
 
-      // Note the "group" property is either an ID or an array of IDs
-      groups = [body?.group].flat().filter(g => !!g);
-    }
-
-    // Retrieve info about W3C groups from W3C API
-    // (Note the "groups" array may contain numbers, strings or API URLs)
-    if (!spec.groups) {
+      // Retrieve info about W3C groups from W3C API
+      // (Note the "groups" array may contain numbers, strings or API URLs)
       spec.groups = [];
       for (const id of groups) {
         const url = ('' + id).startsWith("https://") ? id : `https://api.w3.org/groups/${id}`;

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -52,4 +52,20 @@ describe("fetch-groups module (without API keys)", function () {
     assert.equal(res[0].organization, spec.organization);
     assert.deepStrictEqual(res[0].groups, spec.groups);
   });
+
+  it("preserves provided info for Patent Policy", async () => {
+    const spec = {
+      "url": "https://www.w3.org/Consortium/Patent-Policy/",
+      "shortname": "w3c-patent-policy",
+      "groups": [
+        {
+          "name": "Patents and Standards Interest Group",
+          "url": "https://www.w3.org/2004/pp/psig/"
+        }
+      ]
+    };
+    const res = await fetchGroups([spec]);
+    assert.equal(res[0].organization, "W3C");
+    assert.deepStrictEqual(res[0].groups, spec.groups);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -103,12 +103,18 @@ describe("List of specs", () => {
   });
 
   it("contains repository URLs for all non IETF specs", () => {
-    const wrong = specs.filter(s => !s.nightly.repository && !s.nightly.url.match(/rfc-editor\.org/));
+    // No repo for the Patent Policy document either
+    const wrong = specs.filter(s => !s.nightly.repository &&
+      !s.nightly.url.match(/rfc-editor\.org/) &&
+      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/));
     assert.deepStrictEqual(wrong, []);
   });
 
   it("contains relative paths to source of nightly spec for all non IETF specs", () => {
-    const wrong = specs.filter(s => !s.nightly.sourcePath && !s.nightly.url.match(/rfc-editor\.org/));
+    // No repo for the Patent Policy document either
+    const wrong = specs.filter(s => !s.nightly.sourcePath &&
+      !s.nightly.url.match(/rfc-editor\.org/) &&
+      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
See #390. The specs don't belong to browser-specs in theory and we may want to separate or flag these documents somehow later on. In the meantime, they define useful terms that other specs may want to reference.

This required a few fixes to the `fetch-groups.js` utility which crashed on these entries (even though their groups are explicitly set in `specs.json`). Also, the Patent Policy document is not developed in any GitHub repository for now, so the tests that looked for `repository` on all non IETF specs needed to be adjusted as well.