### PR TITLE
Add RFC4120, 7616, 7617: Various Authentication protocols

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -299,6 +299,7 @@
       }
     ]
   },
+  "https://www.rfc-editor.org/rfc/rfc4120",
   "https://www.rfc-editor.org/rfc/rfc6265",
   "https://www.rfc-editor.org/rfc/rfc6266",
   "https://www.rfc-editor.org/rfc/rfc6454",

--- a/specs.json
+++ b/specs.json
@@ -317,6 +317,7 @@
   "https://www.rfc-editor.org/rfc/rfc7540",
   "https://www.rfc-editor.org/rfc/rfc7578",
   "https://www.rfc-editor.org/rfc/rfc7616",
+  "https://www.rfc-editor.org/rfc/rfc7617",
   "https://www.rfc-editor.org/rfc/rfc7725",
   "https://www.rfc-editor.org/rfc/rfc7838",
   "https://www.rfc-editor.org/rfc/rfc8246",

--- a/specs.json
+++ b/specs.json
@@ -316,6 +316,7 @@
   "https://www.rfc-editor.org/rfc/rfc7538",
   "https://www.rfc-editor.org/rfc/rfc7540",
   "https://www.rfc-editor.org/rfc/rfc7578",
+  "https://www.rfc-editor.org/rfc/rfc7616",
   "https://www.rfc-editor.org/rfc/rfc7725",
   "https://www.rfc-editor.org/rfc/rfc7838",
   "https://www.rfc-editor.org/rfc/rfc8246",


### PR DESCRIPTION
This is to allow the specification to be referenced in the MDN browser compatibility data: https://github.com/mdn/browser-compat-data/pull/12446

It adds
- RFC4120: The Kerberos Network Authentication Service (V5)
- rfc7616: HTTP Digest Access Authentication
- RFC7617: The 'Basic' HTTP Authentication Scheme