### PR TITLE
NTLM over HTTP spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -6,6 +6,7 @@
     }
   },
   "https://console.spec.whatwg.org/",
+  "https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/",
   "https://dom.spec.whatwg.org/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
   "https://drafts.css-houdini.org/font-metrics-api-1/",


### PR DESCRIPTION
This adds NTLM spec https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/ 

I am not sure if this is the "right" way to do this / link to the published version.

This is to allow linking to NTLM spec from MDN browser compatibility data: https://github.com/mdn/browser-compat-data/pull/12446