### PR TITLE
Drop Page Visibility

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -600,7 +600,6 @@
   "https://www.w3.org/TR/openscreenprotocol/",
   "https://www.w3.org/TR/orientation-event/",
   "https://www.w3.org/TR/orientation-sensor/",
-  "https://www.w3.org/TR/page-visibility-2/",
   "https://www.w3.org/TR/paint-timing/",
   "https://www.w3.org/TR/payment-handler/",
   {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -324,6 +324,9 @@
     },
     "https://tc39.es/proposal-hashbang/": {
       "comment": "not meant for browsers environments"
+    },
+    "https://www.w3.org/TR/page-visibility-2/": {
+      "comment": "folded in HTML, see: https://github.com/w3c/page-visibility/issues/74"
     }
   }
 }


### PR DESCRIPTION
Spec got folded into HTML, see:
https://github.com/w3c/page-visibility/issues/74