### PR TITLE
Update URLs of ED published to TR, monitor nav-speculation

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -14,7 +14,6 @@
   "https://drafts.csswg.org/css-cascade-6/ delta",
   "https://drafts.csswg.org/css-env-1/",
   "https://drafts.csswg.org/css-extensions-1/",
-  "https://drafts.csswg.org/css-fonts-5/ delta",
   {
     "url": "https://drafts.csswg.org/css-gcpm-4/",
     "seriesComposition": "delta",
@@ -50,7 +49,6 @@
     }
   },
   "https://immersive-web.github.io/anchors/",
-  "https://immersive-web.github.io/lighting-estimation/",
   "https://infra.spec.whatwg.org/",
   "https://mimesniff.spec.whatwg.org/",
   "https://notifications.spec.whatwg.org/",
@@ -117,9 +115,7 @@
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contentEditable/",
   "https://w3c.github.io/gamepad/extensions.html",
-  "https://w3c.github.io/IFT/Overview.html",
   "https://w3c.github.io/mathml-aam/",
-  "https://w3c.github.io/mathml-core/",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/mediacapture-automation/",
   "https://w3c.github.io/web-nfc/",
@@ -416,6 +412,7 @@
   },
   "https://www.w3.org/TR/css-font-loading-3/",
   "https://www.w3.org/TR/css-fonts-4/",
+  "https://www.w3.org/TR/css-fonts-5/ delta",
   {
     "url": "https://www.w3.org/TR/css-gcpm-3/",
     "shortTitle": "CSS GCPM 3"
@@ -566,6 +563,7 @@
   "https://www.w3.org/TR/html-aam-1.0/",
   "https://www.w3.org/TR/html-aria/",
   "https://www.w3.org/TR/html-media-capture/",
+  "https://www.w3.org/TR/IFT/",
   "https://www.w3.org/TR/image-capture/",
   "https://www.w3.org/TR/image-resource/",
   {
@@ -577,6 +575,7 @@
   "https://www.w3.org/TR/longtasks-1/",
   "https://www.w3.org/TR/magnetometer/",
   "https://www.w3.org/TR/manifest-app-info/",
+  "https://www.w3.org/TR/mathml-core/",
   "https://www.w3.org/TR/media-capabilities/",
   {
     "url": "https://www.w3.org/TR/media-source-2/",
@@ -740,6 +739,7 @@
   "https://www.w3.org/TR/webxr-gamepads-module-1/",
   "https://www.w3.org/TR/webxr-hand-input-1/",
   "https://www.w3.org/TR/webxr-hit-test-1/",
+  "https://www.w3.org/TR/webxr-lighting-estimation-1/",
   "https://www.w3.org/TR/webxr/",
   "https://www.w3.org/TR/webxrlayers-1/",
   {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -327,6 +327,9 @@
     },
     "https://www.w3.org/TR/page-visibility-2/": {
       "comment": "folded in HTML, see: https://github.com/w3c/page-visibility/issues/74"
+    },
+    "https://wicg.github.io/nav-speculation/": {
+      "comment": "document split into two specs"
     }
   }
 }

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -361,6 +361,14 @@
     "https://w3c.github.io/PFE/RangeRequest.html": {
       "comment": "being split-off from main spec https://github.com/w3c/PFE/pull/9/files; stub",
       "lastreviewed": "2021-11-01"
+    },
+    "https://wicg.github.io/nav-speculation/prerendering.html": {
+      "comment": "Early draft that contains a collection of specification patches, no clear implementation plans yet",
+      "lastreviewed": "2021-11-22"
+    },
+    "https://wicg.github.io/nav-speculation/speculation-rules.html": {
+      "comment": "Early draft, implementation, no clear implementation plans yet",
+      "lastreviewed": "2021-11-22"
     }
   }
 }


### PR DESCRIPTION
This updates the URLs of a few specs that started their journey on TR:
- CSS Fonts Level 5
- Incremental Font Transfer
- MathML Core
- WebXR AR Ligtning estimation

This also adds the navigation speculation specs to the monitoring list for now, ignoring the core spec that just targets these two specs.

Fixes #436