### PR TITLE
Improve short title logic for IETF specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -319,9 +319,15 @@
       }
     ]
   },
-  "https://www.rfc-editor.org/rfc/rfc4120",
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc4120",
+    "shortTitle": "Kerberos"
+  },
   "https://www.rfc-editor.org/rfc/rfc6265",
-  "https://www.rfc-editor.org/rfc/rfc6266",
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc6266",
+    "shortTitle": "Content-Disposition in HTTP"
+  },
   "https://www.rfc-editor.org/rfc/rfc6454",
   "https://www.rfc-editor.org/rfc/rfc6797",
   "https://www.rfc-editor.org/rfc/rfc7034",

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -20,13 +20,19 @@ module.exports = function (title) {
     return title;
   }
 
-  const level = title.match(/\s(\d+(\.\d+)?)$/);
+  // Handle HTTP/1.1 specs separately to preserve feature name after "HTTP/1.1"
+  const httpStart = 'Hypertext Transfer Protocol (HTTP/1.1): ';
+  if (title.startsWith(httpStart)) {
+    return 'HTTP/1.1 ' + title.substring(httpStart.length);
+  }
 
+  const level = title.match(/\s(\d+(\.\d+)?)$/);
   const shortTitle = title
     .replace(/\s/g, ' ')                // Replace non-breaking spaces
     .replace(/ \d+(\.\d+)?$/, '')       // Drop level number for now
     .replace(/( -)? Level$/, '')        // Drop "Level"
     .replace(/ Module$/, '')            // Drop "Module" (now followed by level)
+    .replace(/ Proposal$/, '')          // Drop "Proposal" (TC39 proposals)
     .replace(/ Specification$/, '')     // Drop "Specification"
     .replace(/ Standard$/, '')          // Drop "Standard" and "Living Standard"
     .replace(/ Living$/, '')

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -84,4 +84,16 @@ describe("compute-shorttitle module", () => {
       "Edition Module Standard Foo",
       "Edition Module Standard Foo");
   });
+
+  it("drops 'Proposal' from end of title", () => {
+    assertTitle(
+      "Hello world API Proposal",
+      "Hello world API");
+  });
+
+  it("preserves scope in HTTP/1.1 spec titles", () => {
+    assertTitle(
+      "Hypertext Transfer Protocol (HTTP/1.1): Foo bar",
+      "HTTP/1.1 Foo bar")
+  });
 });


### PR DESCRIPTION
HTTP/1.1 spec titles were incorrectly shortened as "HTTP/1.1" (see #364). With this update, they get shortened as "HTTP/1.1 [module name]".

This update also explicitly sets the short title of a couple of IETF specs in specs.json as they did not produce suitable short titles.

Short titles could still be further improved and shortened in some cases, but they should at least be correct.