### PR TITLE
Add Autoplay Policy Detection

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -134,6 +134,7 @@
   "https://tc39.es/proposal-temporal/",
   "https://tc39.es/proposal-top-level-await/",
   "https://url.spec.whatwg.org/",
+  "https://w3c.github.io/autoplay/",
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contact-api/spec/",
   "https://w3c.github.io/contentEditable/",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -28,9 +28,9 @@
       "comment": "empty spec",
       "lastreviewed": "2021-11-01"
     },
-    "WICG/raw-sockets": {
+    "WICG/direct-sockets": {
       "comment": "No clear implementation plan, considered as harmful by Mozilla https://github.com/mozilla/standards-positions/issues/431",
-      "lastreviewed": "2021-11-01"
+      "lastreviewed": "2022-01-03"
     },
     "WICG/sw-launch": {
       "comment": "no spec yet",


### PR DESCRIPTION
The Autoplay Policy Detection document is being developed in the Media Working Group.

This update also updates the name of the Raw Sockets WICG repository, renamed from `raw-sockets` to `direct-sockets`, in the monitor list. Implementation plans are still unclear for the API.

Fixes #464.