### PR TITLE
Improve error messages for the extract pages module

### DIFF
--- a/src/extract-pages.js
+++ b/src/extract-pages.js
@@ -7,14 +7,19 @@
 const { JSDOM } = require("jsdom");
 
 module.exports = async function (url) {
-  const dom = await JSDOM.fromURL(url);
-  const window = dom.window;
-  const document = window.document;
+  try {
+    const dom = await JSDOM.fromURL(url);
+    const window = dom.window;
+    const document = window.document;
 
-  const allPages = [...document.querySelectorAll('.toc a[href]')]
-    .map(link => link.href)
-    .map(url => url.split('#')[0])
-    .filter(url => url !== window.location.href);
-  const pageSet = new Set(allPages);
-  return [...pageSet];
+    const allPages = [...document.querySelectorAll('.toc a[href]')]
+      .map(link => link.href)
+      .map(url => url.split('#')[0])
+      .filter(url => url !== window.location.href);
+    const pageSet = new Set(allPages);
+    return [...pageSet];
+  }
+  catch (err) {
+    throw new Error(`Could not extract pages from ${url} with JSDOM: ${err.message}`);
+  }
 };


### PR DESCRIPTION
Build sometimes fails with a 500 internal server error in the extract pages module. That error was correctly reported but did not include the URL of the spec that triggered the error, making it hard to know which spec is causing troubles.