### PR TITLE
[test] Drop temp exception for fingerprinting-guidance title

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -107,13 +107,11 @@ describe("List of specs", () => {
 
   it("has series titles that look consistent with spec titles", () => {
     // Note the WebRTC spec follows a slightly different pattern
-    // TEMP (2021-12-23): 2 temp exceptions to the rule: the W3C API returns an
-    // outdated title for fingerprinting-guidance (should get fixed soon),
-    // and published version of CSS Images Level 4 has an obscure title à la
-    // "CSS Image Values..." (should get fixed next time the spec gets published
-    // to /TR)
+    // TEMP (2022-01-05): temp exception to the rule: published version of CSS
+    // Images Level 4 has an obscure title à la "CSS Image Values..."
+    // (should get fixed next time the spec gets published to /TR)
     const wrong = specs.filter(s => !s.title.includes(s.series.title))
-      .filter(s => !["webrtc", "fingerprinting-guidance", "css-images-4"].includes(s.shortname));
+      .filter(s => !["webrtc", "css-images-4"].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
The W3C API now returns the right title for the spec, so exception-to-the-rule is no longer needed.