### PR TITLE
Drop Intl.displaynames and Intl.Segmenter, merged in Ecma402

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -107,13 +107,6 @@
       ]
     }
   },
-  {
-    "url": "https://tc39.es/intl-displaynames-v2/",
-    "shortname": "tc39-intl-displaynames-v2",
-    "series": {
-      "shortname": "tc39-intl-displaynames"
-    }
-  },
   "https://tc39.es/proposal-accessible-object-hasownproperty/",
   "https://tc39.es/proposal-array-find-from-last/",
   "https://tc39.es/proposal-array-grouping/",

--- a/specs.json
+++ b/specs.json
@@ -119,7 +119,6 @@
   "https://tc39.es/proposal-intl-enumeration/",
   "https://tc39.es/proposal-intl-extend-timezonename/",
   "https://tc39.es/proposal-intl-locale-info/",
-  "https://tc39.es/proposal-intl-segmenter/",
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-private-fields-in-in/",
   "https://tc39.es/proposal-private-methods/",


### PR DESCRIPTION
Both specs have moved to stage 4 and are now part of Ecma402.