### PR TITLE
Drop UUID incubation, now integrated in WebCrypto API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -228,7 +228,6 @@
   "https://wicg.github.io/ua-client-hints/",
   "https://wicg.github.io/urlpattern/",
   "https://wicg.github.io/user-preference-media-features-headers/",
-  "https://wicg.github.io/uuid/",
   "https://wicg.github.io/video-rvfc/",
   "https://wicg.github.io/visual-viewport/",
   "https://wicg.github.io/web-otp/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -196,6 +196,9 @@
     },
     "WICG/frame-timing": {
       "comment": "No longer being pursued, see https://github.com/w3c/browser-specs/pull/394"
+    },
+    "WICG/uuid": {
+      "comment": "Proposal integrated in WebCrypto API: https://github.com/WICG/uuid/issues/27"
     }
   },
   "specs": {


### PR DESCRIPTION
The randomUUID method was merged in the WebCrypto API spec, see:
https://github.com/w3c/webcrypto/pull/285

This update adds the WICG repository to the ignore list.