### PR TITLE
Force title for TC39 Intl proposals

### DIFF
--- a/schema/specs.json
+++ b/schema/specs.json
@@ -19,6 +19,7 @@
           "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },
           "nightly": { "$ref": "definitions.json#/$defs/nightly" },
           "tests": { "$ref": "definitions.json#/$defs/tests" },
+          "title": { "$ref": "definitions.json#/$defs/title" },
           "shortTitle": { "$ref": "definitions.json#/$defs/title" },
           "organization": { "$ref": "definitions.json#/$defs/organization" },
           "groups": { "$ref": "definitions.json#/$defs/groups" },

--- a/specs.json
+++ b/specs.json
@@ -122,6 +122,7 @@
   {
     "url": "https://tc39.es/proposal-intl-numberformat-v3/out/annexes/proposed.html",
     "shortname": "tc39-intl-annexes",
+    "title": "Intl Annexes",
     "nightly": {
       "sourcePath": "out/annexes/proposed.html"
     }
@@ -129,6 +130,7 @@
   {
     "url": "https://tc39.es/proposal-intl-numberformat-v3/out/negotiation/proposed.html",
     "shortname": "tc39-intl-negotiation",
+    "title": "Intl Parameter Resolution",
     "nightly": {
       "sourcePath": "out/negotiation/proposed.html"
     }
@@ -136,6 +138,7 @@
   {
     "url": "https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html",
     "shortname": "tc39-intl-numberformat",
+    "title": "Intl.NumberFormat",
     "nightly": {
       "sourcePath": "out/numberformat/proposed.html"
     }
@@ -143,6 +146,7 @@
   {
     "url": "https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html",
     "shortname": "tc39-intl-pluralrules",
+    "title": "Intl.PluralRules",
     "nightly": {
       "sourcePath": "out/pluralrules/proposed.html"
     }


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/488#issuecomment-1027908030

The specs don't strictly follow the same overall structure as other TC39 proposals, and the headings they contain would not make particularly good titles in any case.

The titles are based on the ones advertized in:
https://tc39.es/proposal-intl-numberformat-v3/