### PR TITLE
Add "workflow_dispatch" where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
+name: Update spec info
+
 on:
   schedule:
     - cron: '10 */6 * * *'
   push:
     branches:
     - main
-name: Update spec info
+  workflow_dispatch:
+
 jobs:
   fetch:
     runs-on: ubuntu-18.04

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -3,6 +3,8 @@ name: Check base URL
 on:
   schedule:
     - cron: '30 0 * * 1'
+  workflow_dispatch:
+
 jobs:
   find-specs:
     name: Check base URL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+name: Test and lint
+
 on:
   push:
     branches:
@@ -5,7 +7,8 @@ on:
   pull_request:
     branches:
       - main
-name: Test and lint
+  workflow_dispatch:
+
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -3,6 +3,8 @@ name: Monitor specs
 on:
   schedule:
     - cron: '0 0 1 */2 *'
+  workflow_dispatch:
+
 jobs:
   find-specs:
     name: Update the list of monitored specs and highlights those that have changed

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -3,6 +3,8 @@ name: Report new specs
 on:
   schedule:
     - cron: '0 0 * * 1'
+  workflow_dispatch:
+
 jobs:
   find-specs:
     name: Find potential new specs


### PR DESCRIPTION
The `workflow_dispatch` trigger allows admins to run the job manually through GitHub's admin UI instead of having to wait for the job to run based on other automatic triggers.

The update also puts the job's name first when that was not already the case.