### PR TITLE
Fix the logic that retrieves GH_TOKEN env variable

### DIFF
--- a/src/prepare-release.js
+++ b/src/prepare-release.js
@@ -332,13 +332,14 @@ ${diff}
 /*******************************************************************************
 Retrieve GH_TOKEN from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (() => {
+const GH_TOKEN = (_ => {
   try {
     return require("../config.json").GH_TOKEN;
-  } catch {
-    return process.env.GH_TOKEN;
   }
-})();
+  catch {
+    return "";
+  }
+})() || process.env.GH_TOKEN;
 if (!GH_TOKEN) {
   console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);

--- a/src/release-package.js
+++ b/src/release-package.js
@@ -119,13 +119,14 @@ async function releasePackage(prNumber) {
 /*******************************************************************************
 Retrieve tokens from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (() => {
+const GH_TOKEN = (_ => {
   try {
     return require("../config.json").GH_TOKEN;
-  } catch {
-    return process.env.GH_TOKEN;
   }
-})();
+  catch {
+    return "";
+  }
+})() || process.env.GH_TOKEN;
 if (!GH_TOKEN) {
   console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);

--- a/src/request-pr-review.js
+++ b/src/request-pr-review.js
@@ -58,13 +58,14 @@ async function requestReview(type) {
 /*******************************************************************************
 Retrieve GH_TOKEN from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (() => {
+const GH_TOKEN = (_ => {
   try {
     return require("../config.json").GH_TOKEN;
-  } catch {
-    return process.env.GH_TOKEN;
   }
-})();
+  catch {
+    return "";
+  }
+})() || process.env.GH_TOKEN;
 if (!GH_TOKEN) {
   console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);


### PR DESCRIPTION
Jobs get both a `config.json` file (without a GitHub token) and a GitHub token provided as an environment variable. The scripts assumed that, whenever `config.json` existed, it would contain the GitHub token.