### PR TITLE
Fix release workflow

### DIFF
--- a/src/bump-packages-minor.js
+++ b/src/bump-packages-minor.js
@@ -23,7 +23,7 @@ function specsMatch(s1, s2) {
 function isMinorBumpNeeded(type) {
   // Retrieve contents of last committed index file
   const res = execSync(
-    `git show HEAD:index.json`,
+    `git show ${type}@latest:index.json`,
     { encoding: 'utf8' }).trim();
   let lastIndexFile = JSON.parse(res);
 
@@ -32,13 +32,14 @@ function isMinorBumpNeeded(type) {
 
   // Filter specs if needed
   if (type === "browser-specs") {
-    lastIndexFile = lastIndexFile.filter(s => s.categories.includes('browser'));
+    lastIndexFile = lastIndexFile.filter(s => !s.categories || s.categories.includes('browser'));
     newIndexFile = newIndexFile.filter(s => s.categories.includes('browser'));
   }
 
-  return
+  return !!(
     lastIndexFile.find(spec => !newIndexFile.find(s => specsMatch(spec, s))) ||
-    newIndexFile.find(spec => !lastIndexFile.find(s => specsMatch(spec, s)));
+    newIndexFile.find(spec => !lastIndexFile.find(s => specsMatch(spec, s)))
+  );
 }
 
 

--- a/src/prepare-release.js
+++ b/src/prepare-release.js
@@ -71,7 +71,15 @@ function computeDiff(name, folder) {
   // code to 0 to avoid the exception.
   const installedFiles = path.join(tmpFolder, "node_modules", name);
   let diff = execSync(
-    `diff ${installedFiles} packages/${folder} --ignore-trailing-space --exclude=package.json --unified=3 || echo -n`,
+    `diff ${installedFiles} packages/${folder} --ignore-trailing-space --exclude=package.json --exclude=README.md --exclude=LICENSE.md --unified=3 || echo -n`,
+    { encoding: "utf8" });
+
+  const diffReadme = execSync(
+    `diff ${installedFiles}/README.md packages/${folder}/README.md --ignore-trailing-space --unified=3 || echo -n`,
+    { encoding: "utf8" });
+
+  const diffLicense = execSync(
+    `diff ${installedFiles}/LICENSE.md packages/${folder}/LICENSE.md --ignore-trailing-space --unified=3 || echo -n`,
     { encoding: "utf8" });
 
   // Diff includes added/removed files but they are hard to detect inline,
@@ -122,6 +130,14 @@ function computeDiff(name, folder) {
   if (added.length > 0) {
     diff = "New repo files that are not yet in the released package:\n" +
       added.map(file => `+ ${file}`).join("\n") +
+      "\n\n" +
+      diff;
+  }
+
+  if (diffReadme || diffLicense) {
+    diff = "Static file(s) changed:\n" +
+      (diffReadme ? "+ README.md\n" : "") +
+      (diffLicense ? "+ LICENSE.md\n" : "") +
       "\n\n" +
       diff;
   }


### PR DESCRIPTION
- Fixes the minor version bump logic. When a `return` statement returns something, that something must appear on the same line... The `isMinorBumpNeeded` function always returned a result that evaluated to `false` in practice. The function now also uses the `xxx@latest` branches as basis for comparison so as to compare the current list with the list that was last published.

- Fixes handling of "static" files in diff: The `README.md` and `LICENSE.md` should not change much and cannot be easily integrated in the diff without triggering markdown formatting issues. They are now reported separately at the beginning of the diff as "Files that changed" without details as to what changed.