### PR TITLE
Minor version bump script: use full remote ref name

### DIFF
--- a/src/bump-packages-minor.js
+++ b/src/bump-packages-minor.js
@@ -21,9 +21,20 @@ function specsMatch(s1, s2) {
 }
 
 function isMinorBumpNeeded(type) {
-  // Retrieve contents of last committed index file
+  // Retrieve the fullname of the remote ref "${type}@latest"
+  const refs = execSync(`git show-ref ${type}@latest`, { encoding: 'utf8' })
+    .trim().split('\n').map(ref => ref.split(' ')[1])
+    .filter(ref => ref.startsWith('refs/remotes/'));
+  if (refs.length > 1) {
+    throw new Error(`More than one remote refs found for ${type}@latest`);
+  }
+  if (refs === 0) {
+    throw new Error(`No remote ref found for ${type}@latest`);
+  }
+
+  // Retrieve contents of last released index file
   const res = execSync(
-    `git show ${type}\\@latest:index.json`,
+    `git show ${refs[0]}:index.json`,
     { encoding: 'utf8' }).trim();
   let lastIndexFile = JSON.parse(res);
 


### PR DESCRIPTION
This update makes the script look for the fullname of the remote ref for `web-specs@latest` and `browser-specs@latest`. On top of being more accurate (no point basing the logic on a commit that only exists locally), this is needed when the repo is cloned from scratch and does not have local versions of these branches, which is typically what happens in a job.

This update also drops the escaping which I don't think is needed.

See additional context in: https://github.com/w3c/browser-specs/pull/504#issuecomment-1034062322