### PR TITLE
Fix release packages job: prepare files first!

### DIFF
--- a/src/release-package.js
+++ b/src/release-package.js
@@ -67,9 +67,8 @@ async function releasePackage(prNumber) {
     console.log(`- Installation folder: ${installFolder}`);
 
     console.log("- Prepare package files");
-    execSync("npm ci", {
-      cwd: installFolder
-    });
+    execSync("npm ci", { cwd: installFolder });
+    execSync("node src/prepare-packages.js", { cwd: installFolder });
 
     console.log(`- Publish packages/${type} folder to npm`);
     const packageFolder = path.join(installFolder, "packages", type, "package.json");


### PR DESCRIPTION
The release job failed to run the prepare script, so updates to README and `index.json` file was not present in the released package.

I wouldn't be surprised if the job that creates pre-release PRs fails next time due to released packages no longer containing index.json. I'll release a new version manually. I don't think there is a way to unpublish an NPM package unfortunately (we can just flag it as deprecated)
Edit: There is, I'll unpublish the versions.
Edit2: There isn't, we don't meet the [unpublishing criteria](https://docs.npmjs.com/policies/unpublish).