### PR TITLE
Don't run build job when pre-release PR gets merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,10 @@ on:
     - cron: '10 */6 * * *'
   push:
     branches:
-    - main
+      - main
+    paths-ignore:
+      - 'packages/*/package.json'
+      - 'test/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This update makes the build job ignore pushes to main that touch on the `package.json` files under `packages`, to avoid triggering the job when pre-release PRs get merged.

Updates on tests are also ignored. If we really need to run the job after a test got updated, this can be done manually through GitHub's UI.