### PR TITLE
Drop Incremental Font Transfer Range Request

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -699,12 +699,6 @@
   "https://www.w3.org/TR/presentation-api/",
   "https://www.w3.org/TR/proximity/",
   "https://www.w3.org/TR/push-api/",
-  {
-    "url": "https://www.w3.org/TR/RangeRequest/",
-    "nightly": {
-      "sourcePath": "RangeRequest.html"
-    }
-  },
   "https://www.w3.org/TR/referrer-policy/",
   "https://www.w3.org/TR/remote-playback/",
   "https://www.w3.org/TR/reporting-1/",


### PR DESCRIPTION
The contents of the spec were integrated into the main IFT spec and the ED no longer exists as a result:
https://github.com/w3c/IFT/commit/d6780dfdb781115030a647f476ef58e4cb73d10c

The FPWD still exists in /TR but I suppose it will be re-published as a discontinued draft at some point.