### PR TITLE
Drop WAI-ARIA version number from title

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -762,7 +762,10 @@
   "https://www.w3.org/TR/user-timing/",
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/virtual-keyboard/",
-  "https://www.w3.org/TR/wai-aria-1.2/",
+  {
+    "url": "https://www.w3.org/TR/wai-aria-1.2/",
+    "title": "Accessible Rich Internet Applications (WAI-ARIA)"
+  },
   {
     "url": "https://www.w3.org/TR/wasm-core-1/",
     "tests": {


### PR DESCRIPTION
The `title` property conveys the title of the release version but it often gets interpreted as the title of the nightly version and the versions do not match for WAI-ARIA (1.3 vs. 1.2).

See #360 and #517.