### PR TITLE
Add build-diff CLI to get a glimpse of updated data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ project.
   - [Compact form preferred](#compact-form-preferred)
   - [No `index.json` in the pull request](#no-indexjson-in-the-pull-request)
   - [Lint before push](#lint-before-push)
+  - [Check before push](#check-before-push)
 
 
 ## How to add/update/delete a spec
@@ -142,8 +143,8 @@ string format whenever possible.
 
 The `index.json` file will be automatically generated once your pull request has
 been merged. Please do not include it in your pull request. You may still wish
-to [re-generate the file](README.md#how-to-generate-indexjson-manually) if you
-want to check that the generated info will be correct, but please don't commit
+to re-generate the file (see the [Check before push](#check-before-push) section
+below) to check that the generated info will be correct, but please don't commit
 these changes.
 
 
@@ -166,3 +167,13 @@ npm run lint-fix
 
 **Note:** The linter cannot fix broken JSON and/or incorrect properties. Please
 fix these errors manually and run the linter again.
+
+
+### Check before push
+
+Before you push your changes and submit a pull request, you may also want to
+check that the changes will produce the right info. You may
+[re-generate the file](README.md#how-to-generate-indexjson-manually) but
+generation typically takes several minutes. To only generate the entries that
+match the specs that you changed in `specs.json`, you may use the
+[diff tool](README.md#build-a-diff-of-indexjson).

--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -1,0 +1,105 @@
+const path = require("path");
+const { execSync } = require("child_process");
+const { generateIndex } = require("./build-index");
+
+function compareSpecs(a, b) {
+  return a.url.localeCompare(b.url);
+}
+
+/**
+ * Generate the new index file from the given initial list file.
+ *
+ * The function throws in case of errors.
+ */
+async function compareIndex(newRef, baseRef, { diffType = "diff", log = console.log }) {
+  log(`Retrieve specs.json at "${newRef}"...`);
+  let newSpecs;
+  if (newRef.toLowerCase() === "working") {
+    newSpecs = require(path.resolve(__dirname, "..", "specs.json"));
+  }
+  else {
+    const newSpecsStr = execSync(`git show ${newRef}:specs.json`, { encoding: "utf8" });
+    newSpecs = JSON.parse(newSpecsStr);
+  }
+  log(`Retrieve specs.json at "${newRef}"... done`);
+
+  log(`Retrieve specs.json at "${baseRef}"...`);
+  const baseSpecsStr = execSync(`git show ${baseRef}:specs.json`, { encoding: "utf8" });
+  const baseSpecs = JSON.parse(baseSpecsStr);
+  log(`Retrieve specs.json at "${baseRef}"... done`);  
+
+  log(`Retrieve index.json at "${baseRef}"...`);
+  const baseIndexStr = execSync(`git show ${baseRef}:index.json`, { encoding: "utf8" });
+  const baseIndex = JSON.parse(baseIndexStr);
+  log(`Retrieve index.json at "${baseRef}"... done`);
+
+  log(`Compute specs.json diff...`);
+  function hasSameUrl(s1, s2) {
+    const url1 = (typeof s1 === "string") ? s1 : s1.url;
+    const url2 = (typeof s2 === "string") ? s2 : s2.url;
+    return url1 === url2;
+  }
+  const diff = {
+    added: newSpecs.filter(spec => !baseSpecs.find(s => hasSameUrl(s, spec))),
+    updated: newSpecs.filter(spec =>
+      !!baseSpecs.find(s => hasSameUrl(s, spec)) &&
+      !baseSpecs.find(s => JSON.stringify(s) === JSON.stringify(spec))),
+    deleted: baseSpecs.filter(spec => !newSpecs.find(s => hasSameUrl(s, spec)))
+  };
+  log(`Compute specs.json diff... done`);
+
+  log(`Build specs that were added...`);
+  diff.added = (diff.added.length === 0) ? [] :
+    await generateIndex(diff.added, {
+      previousIndex: baseIndex,
+      log: function(...msg) { log(' ', ...msg); } });
+  log(`Build specs that were added... done`);
+
+  log(`Build specs that were updated...`);
+  diff.updated = (diff.updated.length === 0) ? [] :
+    await generateIndex(diff.updated, {
+      previousIndex: baseIndex,
+      log: function(...msg) { log(' ', ...msg); } });
+  log(`Build specs that were updated... done`);
+
+  log(`Retrieve specs that were dropped...`);
+  diff.deleted = diff.deleted.map(spec => baseIndex.find(s => hasSameUrl(s, spec)));
+  log(`Retrieve specs that were dropped... done`);
+
+  if (diffType === "full") {
+    log(`Create full new index...`);
+    const newIndex = baseIndex
+      .map(spec => {
+        const updated = diff.updated.find(s => hasSameUrl(s, spec));
+        return updated ?? spec;
+      })
+      .filter(spec => !diff.deleted.find(s => hasSameUrl(s, spec)));
+    diff.added.forEach(spec => newIndex.push(spec));
+    newIndex.sort(compareSpecs);
+    log(`Create full new index... done`);
+    return newIndex;
+  }
+  else {
+    return diff;
+  }
+}
+
+
+/*******************************************************************************
+Main loop
+*******************************************************************************/
+const newRef = process.argv[2] ?? "working";
+const baseRef = process.argv[3] ?? "head";
+const diffType = process.argv[4] ?? "diff";
+
+compareIndex(newRef, baseRef, { diffType, log: console.warn })
+  .then(diff => {
+    // Note: using process.stdout.write to avoid creating a final newline in
+    // "full" diff mode. This makes it easier to compare the result with the
+    // index.json file in the repo (which does not have a final newline).
+    process.stdout.write(JSON.stringify(diff, null, 2));
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -31,95 +31,100 @@ const githubToken = (_ => {
   }
 })() || process.env.GH_TOKEN;;
 
-// If the index already exists, reuse the info it contains when info cannot
-// be refreshed due to some external (network) issue.
-const previousIndex = (function () {
-  try {
-    return require("../index.json");
-  }
-  catch (err) {
-    return [];
-  }
-})();
-
-// Use previous filename info when it cannot be determined (this usually means
-// that there was a transient network error)
-async function determineSpecFilename(spec, type) {
-  const filename = await determineFilename(spec[type].url);
-  if (filename) {
-    return filename;
-  }
-
-  const previous = previousIndex.find(s => s[type] && s.url === spec.url);
-  return previous ? previous[type].filename : null;
-}
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// Log function that can be inserted in a "then" chain
-function dolog(msg) {
-  return arg => {
-    console.log(msg);
-    return arg;
-  };
-}
 
-console.log("Prepare initial list of specs...");
-const specs = require("../specs.json")
-  // Turn all specs into objects
-  // (and handle syntactic sugar notation for delta/current flags)
-  .map(spec => {
-    if (typeof spec === "string") {
-      const parts = spec.split(" ");
-      const res = { url: parts[0] };
-      if (parts[1] === "delta") {
-        res.seriesComposition = "delta";
+/**
+ * Generate the new index of specs from the given initial list.
+ *
+ * The function takes the previous index as optional parameter if it exists and
+ * uses that list as fallback for filenames.
+ *
+ * The function also takes a log function to report progress (progress is
+ * reported on the console by default).
+ *
+ * The function throws in case of errors.
+ */
+async function generateIndex(specs, { previousIndex = null, log = console.log } = {}) {
+  // Use previous filename info when it cannot be determined (this usually means
+  // that there was a transient network error)
+  async function determineSpecFilename(spec, type) {
+    const filename = await determineFilename(spec[type].url);
+    if (filename) {
+      return filename;
+    }
+
+    const previous = previousIndex.find(s => s[type] && s.url === spec.url);
+    return previous ? previous[type].filename : null;
+  }
+
+  log("Prepare initial list of specs...");
+  specs = specs
+    // Turn all specs into objects
+    // (and handle syntactic sugar notation for delta/current flags)
+    .map(spec => {
+      if (typeof spec === "string") {
+        const parts = spec.split(" ");
+        const res = { url: parts[0] };
+        if (parts[1] === "delta") {
+          res.seriesComposition = "delta";
+        }
+        else if (parts[1] === "current") {
+          res.forceCurrent = true;
+        }
+        else if (parts[1] === "multipage") {
+          res.multipage = true;
+        }
+        return res;
       }
-      else if (parts[1] === "current") {
-        res.forceCurrent = true;
+      else {
+        return spec;
       }
-      else if (parts[1] === "multipage") {
-        res.multipage = true;
+    })
+
+    // Complete information and output result starting with the URL, names,
+    // level, and additional info
+    .map(spec => {
+      // Backup series info explicitly set in initial spec object
+      const series = spec.series;
+      delete spec.series;
+
+      // Complete information
+      const res = Object.assign(
+        { url: spec.url, seriesComposition: spec.seriesComposition || "full" },
+        computeShortname(spec.shortname || spec.url),
+        spec);
+
+      // Restore series info explicitly set in initial spec object
+      if (series) {
+        res.series = Object.assign(res.series, series);
       }
       return res;
-    }
-    else {
+    })
+
+    // Complete information with currentSpecification property and drop
+    // forceCurrent flags that no longer need to be exposed
+    .map((spec, _, list) => {
+      Object.assign(spec.series, computeCurrentLevel(spec, list));
       return spec;
-    }
-  })
+    })
+    .map(spec => { delete spec.forceCurrent; return spec; })
 
-  // Complete information and output result starting with the URL, names,
-  // level, and additional info
-  .map(spec => Object.assign(
-    { url: spec.url, seriesComposition: spec.seriesComposition || "full" },
-    computeShortname(spec.shortname || spec.url),
-    spec))
+    // Complete information with previous/next level links
+    .map((spec, _, list) => Object.assign(spec, computePrevNext(spec, list)));
+  log(`Prepare initial list of specs... found ${specs.length} specs`);
 
-  // Complete information with currentSpecification property and drop
-  // forceCurrent flags that no longer need to be exposed
-  .map((spec, _, list) => {
-    Object.assign(spec.series, computeCurrentLevel(spec, list));
-    return spec;
-  })
-  .map(spec => { delete spec.forceCurrent; return spec; })
+  // Fetch additional spec info from external sources and complete the list
+  log(`Fetch organization/groups info...`);
+  await fetchGroups(specs, { githubToken, w3cApiKey });
+  log(`Fetch organization/groups info... done`);
 
-  // Complete information with previous/next level links
-  .map((spec, _, list) => Object.assign(spec, computePrevNext(spec, list)));
-console.log(`Prepare initial list of specs... done with ${specs.length} specs`);
-
-
-// Fetch additional spec info from external sources and complete the list
-Promise.resolve()
-
-  .then(dolog(`Fetch organization/groups info...`))
-  .then(_ => fetchGroups(specs, { githubToken, w3cApiKey }))
-  .then(dolog(`Fetch organization/groups info... done`))
-
-  .then(dolog(`Fetch other spec info from external sources...`))
-  .then(_ => fetchInfo(specs, { w3cApiKey }))
-  .then(specInfo => specs.map(spec => {
+  log(`Fetch other spec info from external sources...`);
+  const specInfo = await fetchInfo(specs, { w3cApiKey });
+  const index = specs.map(spec => {
     // Make a copy of the spec object and extend it with the info we retrieved
     // from the source
     const res = Object.assign({}, spec, specInfo[spec.shortname]);
@@ -163,11 +168,11 @@ Promise.resolve()
     }
     delete res.series.forceCurrent;
     return res;
-  }))
-  .then(dolog(`Fetch other spec info from external sources... done`))
+  });
+  log(`Fetch other spec info from external sources... done`);
 
-  .then(dolog(`Compute short titles...`))
-  .then(index => index.map(spec => {
+  log(`Compute short titles...`);
+  index.forEach(spec => {
     if (spec.shortTitle) {
       // Use short title explicitly set in specs.json
       // and compute the series short title from it
@@ -181,34 +186,31 @@ Promise.resolve()
 
     // Drop level number from series short title
     spec.series.shortTitle = spec.series.shortTitle.replace(/ \d+(\.\d+)?$/, '');
-    return spec;
-  }))
-  .then(dolog(`Compute short titles... done`))
+  });
+  log(`Compute short titles... done`);
 
-  .then(dolog(`Compute repositories...`))
-  .then(index => computeRepository(index, { githubToken }))
-  .then(dolog(`Compute repositories... done`))
+  log(`Compute repositories...`);
+  await computeRepository(index, { githubToken });
+  log(`Compute repositories... done`);
 
-  .then(dolog(`Compute categories...`))
-  .then(index => index.map(spec => {
+  log(`Compute categories...`);
+  index.forEach(spec => {
     spec.categories = computeCategories(spec);
-    return spec;
-  }))
-  .then(dolog(`Compute categories... done`))
+  });
+  log(`Compute categories... done`);
 
-  .then(dolog(`Find info about test suites...`))
-  .then(index => determineTestPath(index, { githubToken }))
-  .then(dolog(`Find info about test suites... done`))
+  log(`Find info about test suites...`);
+  await determineTestPath(index, { githubToken });
+  log(`Find info about test suites... done`);
 
-  .then(dolog(`Compute unversioned URLs...`))
-  .then(index => index.map(spec => {
+  log(`Compute unversioned URLs...`);
+  index.forEach(spec => {
     Object.assign(spec.series, computeSeriesUrls(spec, index));
-    return spec;
-  }))
-  .then(dolog(`Compute unversioned URLs... done`))
+  });
+  log(`Compute unversioned URLs... done`);
 
-  .then(dolog(`Compute pages for multi-pages specs...`))
-  .then(index => Promise.all(
+  log(`Compute pages for multi-pages specs...`);
+  await Promise.all(
     index.map(async spec => {
       if (spec.multipage) {
         if (spec.release) {
@@ -221,11 +223,11 @@ Promise.resolve()
       }
       return spec;
     })
-  ))
-  .then(dolog(`Compute pages for multi-pages specs... done`))
+  );
+  log(`Compute pages for multi-pages specs... done`);
 
-  .then(dolog(`Determine spec filenames...`))
-  .then(index => Promise.all(
+  log(`Determine spec filenames...`);
+  await Promise.all(
     index.map(async spec => {
       spec.nightly.filename = await determineSpecFilename(spec, "nightly");
       if (spec.release) {
@@ -238,18 +240,61 @@ Promise.resolve()
 
       return spec;
     })
-  ))
-  .then(dolog(`Determine spec filenames... done`))
+  );
+  log(`Determine spec filenames... done`);
 
-  .then(dolog(`Write index.json...`))
-  .then(index => fs.writeFile(
-    path.resolve(__dirname, "..", "index.json"),
-    JSON.stringify(index, null, 2)
-  ))
-  .then(dolog(`Write index.json... done`))
+  return index;
+}
 
-  // Report any error along the way
-  .catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+
+/**
+ * Generate the new index file from the given initial list file.
+ *
+ * The function throws in case of errors.
+ */
+async function generateIndexFile(specsFile, targetFile) {
+  // If the index already exists, reuse the info it contains when info cannot
+  // be refreshed due to some external (network) issue.
+  const previousIndex = (function () {
+    try {
+      return require(path.resolve(targetFile));
+    }
+    catch (err) {
+      return [];
+    }
+  })();
+
+  const specs = require(path.resolve(specsFile));
+  const index = await generateIndex(specs, { previousIndex });
+  console.log(`Write ${targetFile}...`);
+  await fs.writeFile(indexFile, JSON.stringify(index, null, 2));
+  console.log(`Write ${targetFile}... done`);
+}
+
+
+/*******************************************************************************
+Export functions for use as module
+*******************************************************************************/
+module.exports = {
+  generateIndex,
+  generateIndexFile
+};
+
+
+/*******************************************************************************
+Main loop
+*******************************************************************************/
+if (require.main === module) {
+  const specsFile = process.argv[2] ?? path.join(__dirname, "..", "specs.json");
+  const indexFile = process.argv[3] ?? path.join(__dirname, "..", "index.json");
+
+  generateIndexFile(specsFile, indexFile)
+    .then(() => {
+      console.log();
+      console.log("== The end ==");
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
This adds a new command-line tool `src/build-diff.js` that can be used to generate only the specs that have changed in `specs.json` between two commits.

For instance, to compute the diff between the current updated (but not committed) list of specs in `specs.json` and the one at HEAD, run:

```
node src/build-diff.js working HEAD
```

... where `working` is a special ref that means: the version of `specs.json` in your working folder, and `HEAD` is Git's HEAD. Any Git reference may be used, such as a commit ID (SHA).

The tool outputs a JSON object with `added`, `updated` and `deleted` properties. If you rather want it to spit out the new `index.json` file, add a `full` parameter, as in:

```
node src/build-diff.js working HEAD full
```

... which you could redirect to `index.json` and follow with a `git diff` to study the exact differences.

Important: The tool only generates the specs that have changed in `specs.json`. Running a full build could perhaps update other parts as well (e.g. because spec info has changed, even though `specs.json` has not).

The tool is intended to be used for debugging. It is also intended to be used in the future as basis to compute a preview of the diff in a pull request, since a pull request usually does not contain `index.json` (see #17).

This update also re-writes `src/build-index.js` to wrap the code in async functions that can be parameterized with a list of specs (instead of using hardcoded values).