### PR TITLE
Add new composition level: "fork"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,9 @@ properties:
 - `url`: same as the [`url`](README.md#url) property in `index.json`.
 - `shortname`: same as the [`shortname`](README.md#shortname) property in
 `index.json`.
+- `forkOf`: same as the [`forkOf`](README.md#forkof) property in `index.json`.
+No need to set `seriesComposition` to `"fork"` when this property is set, the
+build logic will take care of that automatically.
 - `series`: same as the [`series`](README.md#series) property in `index.json`,
 but note the `currentSpecification` property will be ignored.
 - `seriesVersion`: same as the [`seriesVersion`](README.md#seriesversion)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ properties:
 
 - `url`: same as the [`url`](README.md#url) property in `index.json`.
 - `shortname`: same as the [`shortname`](README.md#shortname) property in
-`index.json`.
+`index.json`. When the `forkOf` property is also set, note that the actual
+shortname in the final list will be prefixed by the shortname of the base
+spec (as in: `${forkOf}-fork-${shortname}`).
 - `forkOf`: same as the [`forkOf`](README.md#forkof) property in `index.json`.
 No need to set `seriesComposition` to `"fork"` when this property is set, the
 build logic will take care of that automatically.
@@ -63,8 +65,9 @@ but note the `currentSpecification` property will be ignored.
 - `seriesVersion`: same as the [`seriesVersion`](README.md#seriesversion)
 property in `index.json`.
 - `seriesComposition`: same as the [`seriesComposition`](README.md#seriesComposition)
-property in `index.json`. The property must only be set for delta spec (since
-full is the default).
+property in `index.json`. The property must only be set for delta spec, since
+full is the default and fork specs are identified through the `forkOf` property
+in `specs.json`.
 - `organization`: same as the [`organization`](README.md#organization) property
 in `index.json` to specify the name of the organization that owns the spec.
 - `groups`: same as the [`groups`](README.md#groups) property in `index.json`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cross-references, WebIDL, quality, etc.
   - [`seriesComposition`](#seriescomposition)
   - [`seriesPrevious`](#seriesprevious)
   - [`seriesNext`](#seriesnext)
+  - [`forkOf`](#forkof)
+  - [`forks`](#forks)
   - [`organization`](#organization)
   - [`groups`](#groups)
   - [`release`](#release)
@@ -304,6 +306,28 @@ version.
 The `shortname` of the next spec in the series.
 
 The `seriesNext` property is only set where there is a next level or version.
+
+
+### `forkOf`
+
+The shortname of the spec that this spec is a fork of.
+
+The `forkOf` property is only set when the spec is a fork of another one. The
+[`seriesComposition`](#seriescomposition) property is always `"fork"` when the
+`forkOf` property is set.
+
+A forked specs is supposed to be temporary by nature. It will be removed from
+the list as soon as it gets merged into the main spec, or as soon as it gets
+abandoned.
+
+
+### `forks`
+
+An array that lists shortnames of known forks of the spec in the list.
+
+The `forks` property is only set when there exists at least one fork of the
+spec in the list, meaning when there is an entry in the list that has a
+[`forkOf`](#forkof) property set to the spec's shortname.
 
 
 ### `organization`

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ For WHATWG specs, this is the shortname that appears at the beginning of the URL
 (e.g. `compat` for `https://compat.spec.whatwg.org/`). For specs developed on
 GitHub, this is usually the name of repository that holds the spec.
 
+When the spec is a fork (see [`forkOf`](#forkof)) of a base spec, its shortname
+will start with the shortname of the base spec completed by `-fork-` and the
+actual shortname of the fork spec. For instance, given an exception handling
+fork of the WebAssembly spec for which the raw shortname would be
+`exception-handling`, the actual spec shortname will be
+`wasm-js-api-1-fork-exception-handling`.
+
 The `shortname` property is always set.
 
 
@@ -287,8 +294,9 @@ number.
 
 ### `seriesComposition`
 
-Whether the spec is a standalone spec, or whether it is a delta spec over the
-previous level or version in the series. Possible values are `full` or `delta`.
+Whether the spec is a standalone spec, whether it is a delta spec over the
+previous level or version in the series, or whether it is a temporary fork of
+another spec. Possible values are `full`, `delta`, or `fork`.
 
 The `seriesComposition` property is always set.
 

--- a/packages/browser-specs/package.json
+++ b/packages/browser-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-specs",
-  "version": "2.30.1",
+  "version": "3.0.0",
   "description": "Curated list of technical Web specifications that are directly implemented or that will be implemented by Web browsers.",
   "repository": {
     "type": "git",

--- a/packages/web-specs/package.json
+++ b/packages/web-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-specs",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Curated list of technical Web specifications",
   "repository": {
     "type": "git",

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -151,6 +151,11 @@
           "minItems": 1
         }
       ]
+    },
+
+    "forks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/shortname" }
     }
   }
 }

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -47,7 +47,7 @@
 
     "seriesComposition": {
       "type": "string",
-      "enum": ["full", "delta"]
+      "enum": ["full", "delta", "fork"]
     },
 
     "forceCurrent": {

--- a/schema/index.json
+++ b/schema/index.json
@@ -8,6 +8,8 @@
     "properties": {
       "url": { "$ref": "definitions.json#/$defs/url" },
       "shortname": { "$ref": "definitions.json#/$defs/shortname" },
+      "forkOf": { "$ref": "definitions.json#/$defs/shortname" },
+      "forks": { "$ref": "definitions.json#/$defs/forks" },
       "series": { "$ref": "definitions.json#/$defs/series" },
       "seriesVersion": { "$ref": "definitions.json#/$defs/seriesVersion" },
       "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -7,13 +7,14 @@
     "oneOf": [
       {
         "type": "string",
-        "pattern": "^https://[^\\s]+(\\s(delta|fork|current|multipage))?$"
+        "pattern": "^https://[^\\s]+(\\s(delta|current|multipage))?$"
       },
       {
         "type": "object",
         "properties": {
           "url": { "$ref": "definitions.json#/$defs/url" },
           "shortname": { "$ref": "definitions.json#/$defs/shortname" },
+          "forkOf": { "$ref": "definitions.json#/$defs/shortname" },
           "series": { "$ref": "definitions.json#/$defs/series" },
           "seriesVersion": { "$ref": "definitions.json#/$defs/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -7,7 +7,7 @@
     "oneOf": [
       {
         "type": "string",
-        "pattern": "^https://[^\\s]+(\\s(delta|current|multipage))?$"
+        "pattern": "^https://[^\\s]+(\\s(delta|fork|current|multipage))?$"
       },
       {
         "type": "object",

--- a/specs.json
+++ b/specs.json
@@ -183,8 +183,7 @@
   "https://w3c.github.io/webrtc-ice/",
   {
     "url": "https://webassembly.github.io/exception-handling/js-api/",
-    "shortname": "wasm-js-api-1",
-    "seriesComposition": "fork"
+    "forkOf": "wasm-js-api-1"
   },
   "https://webbluetoothcg.github.io/web-bluetooth/",
   "https://webidl.spec.whatwg.org/",

--- a/specs.json
+++ b/specs.json
@@ -181,6 +181,11 @@
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
   "https://w3c.github.io/webdriver-bidi/",
   "https://w3c.github.io/webrtc-ice/",
+  {
+    "url": "https://webassembly.github.io/exception-handling/js-api/",
+    "shortname": "wasm-js-api-1",
+    "seriesComposition": "fork"
+  },
   "https://webbluetoothcg.github.io/web-bluetooth/",
   "https://webidl.spec.whatwg.org/",
   "https://websockets.spec.whatwg.org/",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -120,7 +120,10 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
 
     // Complete information with forks
     .map((spec, _, list) => {
-      const forks = list.filter(s => s.series.shortname === spec.series.shortname && s.seriesComposition === "fork")
+      const forks = list.filter(s =>
+          s.series.shortname === spec.series.shortname &&
+          s.seriesComposition === "fork" &&
+          s.forkOf === spec.shortname)
         .map(s => s.shortname);
       if (forks.length > 0) {
         spec.forks = forks;

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -64,13 +64,16 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
   log("Prepare initial list of specs...");
   specs = specs
     // Turn all specs into objects
-    // (and handle syntactic sugar notation for delta/current flags)
+    // (and handle syntactic sugar notation for delta/current/fork flags)
     .map(spec => {
       if (typeof spec === "string") {
         const parts = spec.split(" ");
         const res = { url: parts[0] };
         if (parts[1] === "delta") {
           res.seriesComposition = "delta";
+        }
+        else if (parts[1] === "fork") {
+          res.seriesComposition = "fork";
         }
         else if (parts[1] === "current") {
           res.forceCurrent = true;

--- a/src/compute-currentlevel.js
+++ b/src/compute-currentlevel.js
@@ -9,7 +9,7 @@
  * (if needed) properties.
  *
  * By default, the current level is defined as the last level that is not a
- * delta spec, unless a level is explicitly flagged with a "forceCurrent"
+ * delta/fork spec, unless a level is explicitly flagged with a "forceCurrent"
  * property in the list of specs.
  */
 
@@ -27,9 +27,12 @@ module.exports = function (spec, list) {
 
   const current = list.reduce((candidate, curr) => {
     if (curr.series.shortname === candidate.series.shortname &&
-      !candidate.forceCurrent &&
-      curr.seriesComposition !== "delta" &&
-        (curr.forceCurrent || candidate.seriesComposition === "delta" ||
+        !candidate.forceCurrent &&
+        curr.seriesComposition !== "fork" &&
+        curr.seriesComposition !== "delta" &&
+        (curr.forceCurrent ||
+          candidate.seriesComposition === "delta" ||
+          candidate.seriesComposition === "fork" ||
           (curr.seriesVersion || "0") > (candidate.seriesVersion || "0"))) {
       return curr;
     }

--- a/src/compute-prevnext.js
+++ b/src/compute-prevnext.js
@@ -22,7 +22,7 @@ module.exports = function (spec, list) {
   const level = spec.seriesVersion || "0";
 
   return list
-    .filter(s => s.series.shortname === spec.series.shortname)
+    .filter(s => s.series.shortname === spec.series.shortname && s.seriesComposition !== "fork")
     .sort((a, b) => (a.seriesVersion || "0").localeCompare(b.seriesVersion || "0"))
     .reduce((res, s) => {
       if ((s.seriesVersion || "0") < level) {

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -128,7 +128,7 @@ function computeShortname(url) {
 /**
  * Compute the shortname and level from the spec name, if possible.
  */
-function completeWithSeriesAndLevel(shortname, url) {
+function completeWithSeriesAndLevel(shortname, url, forkOf) {
   // Use latest convention for CSS specs
   function modernizeShortname(name) {
     if (name.startsWith("css3-")) {
@@ -142,22 +142,25 @@ function completeWithSeriesAndLevel(shortname, url) {
     }
   }
 
+  const seriesBasename = forkOf ?? shortname;
+  const specShortname = forkOf ? `${forkOf}-fork-${shortname}` : shortname;
+
   // Shortnames of WebGL extensions sometimes end up with digits which are *not*
   // to be interpreted as level numbers. Similarly, shortnames of ECMA specs
   // typically have the form "ecma-ddd", and "ddd" is *not* a level number.
-  if (shortname.match(/^ecma-/) || url.match(/^https:\/\/www\.khronos\.org\/registry\/webgl\/extensions\//)) {
+  if (seriesBasename.match(/^ecma-/) || url.match(/^https:\/\/www\.khronos\.org\/registry\/webgl\/extensions\//)) {
     return {
-      shortname,
-      series: { shortname }
+      shortname: specShortname,
+      series: { shortname: seriesBasename }
     };
   }
 
   // Extract X and X.Y levels, with form "name-X" or "name-X.Y".
   // (e.g. 5 for "mediaqueries-5", 1.2 for "wai-aria-1.2")
-  let match = shortname.match(/^(.*?)-(\d+)(.\d+)?$/);
+  let match = seriesBasename.match(/^(.*?)-(\d+)(.\d+)?$/);
   if (match) {
     return {
-      shortname,
+      shortname: specShortname,
       series: { shortname: modernizeShortname(match[1]) },
       seriesVersion: match[3] ? match[2] + match[3] : match[2]
     };
@@ -165,10 +168,10 @@ function completeWithSeriesAndLevel(shortname, url) {
 
   // Extract X and X.Y levels with form "nameX" or "nameXY" (but not "nameXXY")
   // (e.g. 2.1 for "CSS21", 1.1 for "SVG11", 4 for "selectors4")
-  match = shortname.match(/^(.*?)(?<!\d)(\d)(\d?)$/);
+  match = seriesBasename.match(/^(.*?)(?<!\d)(\d)(\d?)$/);
   if (match) {
     return {
-      shortname,
+      shortname: specShortname,
       series: { shortname: modernizeShortname(match[1]) },
       seriesVersion: match[3] ? match[2] + "." + match[3] : match[2]
     };
@@ -176,8 +179,8 @@ function completeWithSeriesAndLevel(shortname, url) {
 
   // No level found
   return {
-    shortname,
-    series: { shortname: modernizeShortname(shortname) }
+    shortname: specShortname,
+    series: { shortname: modernizeShortname(seriesBasename) }
   };
 }
 
@@ -186,9 +189,9 @@ function completeWithSeriesAndLevel(shortname, url) {
  * Exports main function that takes a URL (or a spec name) and returns an
  * object with a name, a shortname and a level (if needed).
  */
-module.exports = function (url) {
+module.exports = function (url, forkOf) {
   if (!url) {
     throw "No URL passed as parameter";
   }
-  return completeWithSeriesAndLevel(computeShortname(url), url);
+  return completeWithSeriesAndLevel(computeShortname(url), url, forkOf);
 }

--- a/src/lint.js
+++ b/src/lint.js
@@ -15,6 +15,7 @@ function shortenDefinition(spec) {
   const short = {};
   for (const property of Object.keys(spec)) {
     if (!((property === "seriesComposition" && spec[property] === "full") ||
+        (property === "seriesComposition" && spec[property] === "fork") ||
         (property === "multipage" && !spec[property]) ||
         (property === "forceCurrent" && !spec[property]))) {
       short[property] = spec[property];
@@ -26,10 +27,6 @@ function shortenDefinition(spec) {
   else if (Object.keys(short).length === 2 &&
       spec.seriesComposition === "delta") {
     return `${spec.url} delta`;
-  }
-  else if (Object.keys(short).length === 2 &&
-      spec.seriesComposition === "fork") {
-    return `${spec.url} fork`;
   }
   else if (Object.keys(short).length === 2 &&
       spec.forceCurrent) {
@@ -57,8 +54,7 @@ function lintStr(specsStr) {
     .map(spec => (typeof spec === "string") ?
       {
         url: new URL(spec.split(" ")[0]).toString(),
-        seriesComposition: (spec.split(' ')[1] === "delta") ? "delta" :
-          (spec.split(' ')[1] === "fork") ? "fork" : "full",
+        seriesComposition: (spec.split(' ')[1] === "delta") ? "delta" : "full",
         forceCurrent: (spec.split(' ')[1] === "current"),
         multipage: (spec.split(' ')[1] === "multipage"),
       } :

--- a/src/lint.js
+++ b/src/lint.js
@@ -28,6 +28,10 @@ function shortenDefinition(spec) {
     return `${spec.url} delta`;
   }
   else if (Object.keys(short).length === 2 &&
+      spec.seriesComposition === "fork") {
+    return `${spec.url} fork`;
+  }
+  else if (Object.keys(short).length === 2 &&
       spec.forceCurrent) {
     return `${spec.url} current`;
   }
@@ -53,7 +57,8 @@ function lintStr(specsStr) {
     .map(spec => (typeof spec === "string") ?
       {
         url: new URL(spec.split(" ")[0]).toString(),
-        seriesComposition: (spec.split(' ')[1] === "delta") ? "delta" : "full",
+        seriesComposition: (spec.split(' ')[1] === "delta") ? "delta" :
+          (spec.split(' ')[1] === "fork") ? "fork" : "full",
         forceCurrent: (spec.split(' ')[1] === "current"),
         multipage: (spec.split(' ')[1] === "multipage"),
       } :
@@ -74,7 +79,8 @@ function lintStr(specsStr) {
       const next = linked.seriesNext ?
         linkedList.find(p => p.shortname === linked.seriesNext) :
         null;
-      const isLast = !next || next.seriesComposition === "delta";
+      const isLast = !next || next.seriesComposition === "delta" ||
+        next.seriesComposition === "fork";
       if (spec.forceCurrent && isLast) {
         spec.forceCurrent = false;
       }

--- a/test/compute-currentlevel.js
+++ b/test/compute-currentlevel.js
@@ -49,11 +49,27 @@ describe("compute-currentlevel module", () => {
       spec.shortname);
   });
 
+  it("returns the name of the latest level that is not a fork spec", () => {
+    const spec = getSpec({ seriesVersion: "1" });
+    const fork = getSpec({ seriesVersion: "2", seriesComposition: "fork" });
+    assert.equal(
+      getCurrentName(spec, [spec, fork]),
+      spec.shortname);
+  });
+
   it("gets back to the latest level when spec is a delta spec", () => {
     const spec = getSpec({ seriesVersion: "1" });
     const delta = getSpec({ seriesVersion: "2", seriesComposition: "delta" });
     assert.equal(
       getCurrentName(delta, [spec, delta]),
+      spec.shortname);
+  });
+
+  it("gets back to the latest level when spec is a fork spec", () => {
+    const spec = getSpec({ seriesVersion: "1" });
+    const fork = getSpec({ seriesVersion: "2", seriesComposition: "fork" });
+    assert.equal(
+      getCurrentName(fork, [spec, fork]),
       spec.shortname);
   });
 

--- a/test/compute-currentlevel.js
+++ b/test/compute-currentlevel.js
@@ -8,7 +8,7 @@ describe("compute-currentlevel module", () => {
   function getSpec(options) {
     options = options || {};
     const res = {
-      shortname: (options.seriesVersion ? `spec-${options.seriesVersion}` : "spec"),
+      shortname: options.shortname ?? (options.seriesVersion ? `spec-${options.seriesVersion}` : "spec"),
       series: { shortname: "spec" },
     };
     for (const property of Object.keys(options)) {
@@ -96,5 +96,13 @@ describe("compute-currentlevel module", () => {
     assert.equal(
       getCurrentName(spec, [spec, other]),
       spec.shortname);
+  });
+
+  it("does not take forks into account", () => {
+    const spec = getSpec({ shortname: "spec-1-fork-1", seriesVersion: "1", seriesComposition: "fork" });
+    const base = getSpec({ seriesVersion: "1" });
+    assert.equal(
+      getCurrentName(spec, [spec, base]),
+      base.shortname);
   });
 });

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -105,6 +105,11 @@ describe("compute-shortname module", () => {
         () => computeInfo("https://w3c.github.io/spec4.2/"),
         /^Specification name contains unexpected characters/);
     });
+
+    it("handles forks", () => {
+      const url = "https://www.w3.org/TR/extension/";
+      assert.equal(computeInfo(url, "source-2").shortname, "source-2-fork-extension");
+    });
   });
 
 
@@ -151,6 +156,11 @@ describe("compute-shortname module", () => {
 
     it("preserves digits at the end of WebGL extension names", () => {
       assertSeries("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/", "EXT_wow32");
+    });
+
+    it("handles forks", () => {
+      const url = "https://www.w3.org/TR/the-ext/";
+      assert.equal(computeInfo(url, "source-2").series.shortname, "source");
     });
   });
 
@@ -202,6 +212,11 @@ describe("compute-shortname module", () => {
 
     it("does not confuse digits at the end of a WebGL extension spec with a series version", () => {
       assertNoSeriesVersion("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/");
+    });
+
+    it("handles forks", () => {
+      const url = "https://www.w3.org/TR/the-ext/";
+      assert.equal(computeInfo(url, "source-2").seriesVersion, "2");
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,12 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("has previous links for all fork specs", () => {
+    const wrong = specs.filter(s =>
+      s.seriesComposition === "fork" && !s.seriesPrevious);
+    assert.deepStrictEqual(wrong, []);
+  });
+
   it("has previous links that can be resolved to a spec", () => {
     const wrong = specs.filter(s =>
       s.seriesPrevious && !specs.find(p => p.shortname === s.seriesPrevious));

--- a/test/index.js
+++ b/test/index.js
@@ -168,6 +168,11 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("has a fork composition level for all fork specs", () => {
+    const wrong = specs.filter(s => s.forkOf && s.seriesComposition !== "fork");
+    assert.deepStrictEqual(wrong, []);
+  });
+
   it("only has forks of existing specs", () => {
     const wrong = specs.filter(s => s.forkOf && !specs.find(spec => spec.shortname === s.forkOf));
     assert.deepStrictEqual(wrong, []);

--- a/test/index.js
+++ b/test/index.js
@@ -56,12 +56,6 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
-  it("has previous links for all fork specs", () => {
-    const wrong = specs.filter(s =>
-      s.seriesComposition === "fork" && !s.seriesPrevious);
-    assert.deepStrictEqual(wrong, []);
-  });
-
   it("has previous links that can be resolved to a spec", () => {
     const wrong = specs.filter(s =>
       s.seriesPrevious && !specs.find(p => p.shortname === s.seriesPrevious));
@@ -93,6 +87,18 @@ describe("List of specs", () => {
       const next = specs.find(n => n.shortname === s.seriesNext);
       return !next || next.seriesPrevious !== s.shortname;
     });
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("does not have previous links for fork specs", () => {
+    const wrong = specs.filter(s =>
+      s.seriesComposition === "fork" && s.seriesPrevious);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("does not have next links for fork specs", () => {
+    const wrong = specs.filter(s =>
+      s.seriesComposition === "fork" && s.seriesNext);
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -154,6 +160,25 @@ describe("List of specs", () => {
 
   it("contains filenames for all release URLs", () => {
     const wrong = specs.filter(s => s.release && !s.release.filename);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has a forkOf property for all fork specs", () => {
+    const wrong = specs.filter(s => s.seriesComposition === "fork" && !s.forkOf);
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("only has forks of existing specs", () => {
+    const wrong = specs.filter(s => s.forkOf && !specs.find(spec => spec.shortname === s.forkOf));
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has consistent forks properties", () => {
+    const wrong = specs.filter(s => !!s.forks &&
+      s.forks.find(shortname => !specs.find(spec =>
+        spec.shortname === shortname &&
+        spec.seriesComposition === "fork" &&
+        spec.forkOf === s.shortname)));
     assert.deepStrictEqual(wrong, []);
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -28,6 +28,14 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), null);
     });
 
+    it("passes if specs contains a URL with a fork spec", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/",
+        "https://www.w3.org/TR/spec-2/ fork"
+      ];
+      assert.equal(lintStr(toStr(specs)), null);
+    });
+
     it("passes if specs contains a URL with a spec flagged as current", () => {
       const specs = [
         "https://www.w3.org/TR/spec-1/ current",
@@ -122,6 +130,17 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec-1/",
         "https://www.w3.org/TR/spec-2/ delta",
+      ]));
+    });
+
+    it("lints an object with a useless current flag (fork version)", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/ current",
+        "https://www.w3.org/TR/spec-2/ fork"
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec-1/",
+        "https://www.w3.org/TR/spec-2/ fork",
       ]));
     });
 

--- a/test/lint.js
+++ b/test/lint.js
@@ -171,5 +171,16 @@ describe("Linter", () => {
         lintStr(toStr(specs)),
         toStr(["https://www.w3.org/TR/duplicate/"]));
     });
+
+    it("lints an object with a forkOf and a seriesComposition property", () => {
+      const specs = [
+        "https://www.w3.org/TR/spec-1/",
+        { "url": "https://www.w3.org/TR/spec-2/", seriesComposition: "fork", forkOf: "spec-1" }
+      ];
+      assert.equal(lintStr(toStr(specs)), toStr([
+        "https://www.w3.org/TR/spec-1/",
+        { "url": "https://www.w3.org/TR/spec-2/", forkOf: "spec-1" }
+      ]));
+    });
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -28,14 +28,6 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), null);
     });
 
-    it("passes if specs contains a URL with a fork spec", () => {
-      const specs = [
-        "https://www.w3.org/TR/spec-1/",
-        "https://www.w3.org/TR/spec-2/ fork"
-      ];
-      assert.equal(lintStr(toStr(specs)), null);
-    });
-
     it("passes if specs contains a URL with a spec flagged as current", () => {
       const specs = [
         "https://www.w3.org/TR/spec-1/ current",
@@ -130,17 +122,6 @@ describe("Linter", () => {
       assert.equal(lintStr(toStr(specs)), toStr([
         "https://www.w3.org/TR/spec-1/",
         "https://www.w3.org/TR/spec-2/ delta",
-      ]));
-    });
-
-    it("lints an object with a useless current flag (fork version)", () => {
-      const specs = [
-        "https://www.w3.org/TR/spec-1/ current",
-        "https://www.w3.org/TR/spec-2/ fork"
-      ];
-      assert.equal(lintStr(toStr(specs)), toStr([
-        "https://www.w3.org/TR/spec-1/",
-        "https://www.w3.org/TR/spec-2/ fork",
       ]));
     });
 

--- a/test/specs.js
+++ b/test/specs.js
@@ -203,6 +203,16 @@ describe("Input list", () => {
       assert.strictEqual(problematicCurrent[0], undefined);
     });
 
+    it("does not have a spec with a 'fork' seriesComposition property", () => {
+      const wrong = specs.find(s => s.seriesComposition === "fork");
+      assert.strictEqual(wrong, undefined);
+    });
+
+    it("does not have a 'delta fork' spec", () => {
+      const wrong = specs.find(s => s.forkOf && s.seriesComposition === "delta");
+      assert.strictEqual(wrong, undefined);
+    });
+
     it("only has fork specs that reference existing specs", () => {
       const linkedList = specs2LinkedList(specs);
       const forkWithoutFull = linkedList.filter((s, _, list) => s.forkOf &&


### PR DESCRIPTION
This new composition level is meant for specs that are created as temporary forks of base specifications. First (and only so far) spec in that category is the "WebAssembly JavaScript Interface: Exception Handling" specification, as described in https://github.com/w3c/browser-specs/issues/508.

This will require a major version bump as this changes the semantics of the `seriesComposition` property.

(I'll work on an update to Reffy to handle fork specs)