### PR TITLE
Add miniapp specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -673,6 +673,24 @@
       "sourcePath": "MediaRecorder.bs"
     }
   },
+  {
+    "url": "https://www.w3.org/TR/miniapp-lifecycle/",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/miniapp-manifest/",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/miniapp-packaging/",
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://www.w3.org/TR/mixed-content/",
   "https://www.w3.org/TR/motion-1/",
   "https://www.w3.org/TR/mst-content-hint/",


### PR DESCRIPTION
This PR enables "exported" terms in MiniApp specs to be automatically cross-referenced using https://respec.org/xref/
