### PR TITLE
Add dapt repo to ignore list

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -56,6 +56,9 @@
     "w3c/adpt": {
       "comment": "not targeted at browsers"
     },
+    "w3c/dapt": {
+      "comment": "not targeted at browsers"
+    },
     "w3c/imsc": {
       "comment": "not targeted at browsers"
     },


### PR DESCRIPTION
Repo is a placeholder for now; it may be that it should be added to web-specs eventually, but since we already have adpt and imsc-* in ignore, they would probably be added as a cluster in any case