### PR TITLE
Make all jobs use Node.js v16 and "npm ci"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   fetch:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
-    - run: npm install
+        node-version: 16.x
+    - run: npm ci
     - run: node src/check-base-url.js # sets check_list env variable
     - uses: JasonEtco/create-an-issue@v2
       if: ${{ env.check_list }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo contents
         uses: actions/checkout@v1
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
-    - run: npm install
+        node-version: 16.x
+    - run: npm ci
     - run: node src/monitor-specs.js # sets review_list env variable
     - uses: peter-evans/create-pull-request@v3
       env:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 16.x
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v2

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
-    - run: npm install
+        node-version: 16.x
+    - run: npm ci
     - run: node src/find-specs.js # sets candidate_list env variable
     - uses: JasonEtco/create-an-issue@v2
       if: ${{ env.candidate_list }}

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 16.x
 
     - name: Checkout webref
       uses: actions/checkout@v2


### PR DESCRIPTION
Jobs were still using Node.js v14, which works fine for the scripts, but comes with a version of npm that does not support version 2 of the file format for `package-lock.json`. On top of that, a couple of scripts were running `npm install` instead of `npm ci`, and former updates `package-lock.json` when needed. This could trigger the creation of pull requests that included the `package-lock.json` file whereas they shouldn't as in #539.

This update makes all jobs switch to Node.js v16 (and ubuntu-latest, which seems like a safe setting to use) and use `npm ci` to install dependencies.