### PR TITLE
Replace app-history with navigation-api

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -188,7 +188,6 @@
   "https://webbluetoothcg.github.io/web-bluetooth/",
   "https://webidl.spec.whatwg.org/",
   "https://websockets.spec.whatwg.org/",
-  "https://wicg.github.io/app-history/",
   "https://wicg.github.io/background-fetch/",
   {
     "url": "https://wicg.github.io/background-sync/spec/",
@@ -233,6 +232,7 @@
   "https://wicg.github.io/local-font-access/",
   "https://wicg.github.io/manifest-incubations/",
   "https://wicg.github.io/media-feeds/",
+  "https://wicg.github.io/navigation-api/",
   "https://wicg.github.io/netinfo/",
   "https://wicg.github.io/origin-policy/",
   "https://wicg.github.io/overscroll-scrollend-events/",


### PR DESCRIPTION
see also https://github.com/w3c/browser-specs/pull/542#pullrequestreview-903950652

output of build-diff:
```json
{
  "added": [
    {
      "url": "https://wicg.github.io/navigation-api/",
      "seriesComposition": "full",
      "shortname": "navigation-api",
      "series": {
        "shortname": "navigation-api",
        "currentSpecification": "navigation-api",
        "title": "Navigation API",
        "shortTitle": "Navigation API",
        "nightlyUrl": "https://wicg.github.io/navigation-api/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Platform Incubator Community Group",
          "url": "https://www.w3.org/community/wicg/"
        }
      ],
      "nightly": {
        "url": "https://wicg.github.io/navigation-api/",
        "repository": "https://github.com/wicg/navigation-api",
        "filename": "index.html"
      },
      "title": "Navigation API",
      "source": "spec",
      "shortTitle": "Navigation API",
      "categories": [
        "browser"
      ]
    }
  ],
  "updated": [],
  "deleted": [
    {
      "url": "https://wicg.github.io/app-history/",
      "seriesComposition": "full",
      "shortname": "app-history",
      "series": {
        "shortname": "app-history",
        "currentSpecification": "app-history",
        "title": "Redirecting to https://wicg.github.io/navigation-api/",
        "shortTitle": "Redirecting to https://wicg.github.io/navigation-api/",
        "nightlyUrl": "https://wicg.github.io/app-history/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Platform Incubator Community Group",
          "url": "https://www.w3.org/community/wicg/"
        }
      ],
      "nightly": {
        "url": "https://wicg.github.io/app-history/",
        "repository": "https://github.com/WICG/app-history",
        "sourcePath": "spec.bs",
        "filename": "index.html"
      },
      "title": "Redirecting to https://wicg.github.io/navigation-api/",
      "source": "spec",
      "shortTitle": "Redirecting to https://wicg.github.io/navigation-api/",
      "categories": [
        "browser"
      ],
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "app-history"
        ]
      }
    }
  ]
}
```