### PR TITLE
Remove FLOC API from browser-specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -217,7 +217,6 @@
   "https://wicg.github.io/entries-api/",
   "https://wicg.github.io/eyedropper-api/",
   "https://wicg.github.io/file-system-access/",
-  "https://wicg.github.io/floc/",
   "https://wicg.github.io/get-installed-related-apps/spec/",
   "https://wicg.github.io/idle-detection/",
   "https://wicg.github.io/import-maps/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -208,6 +208,9 @@
     },
     "WICG/uuid": {
       "comment": "Proposal integrated in WebCrypto API: https://github.com/WICG/uuid/issues/27"
+    },
+    "WICG/floc": {
+      "comment": "proposal replaced by the Topics API"
     }
   },
   "specs": {


### PR DESCRIPTION
no longer being pursued

```json
{
  "added": [],
  "updated": [],
  "deleted": [
    {
      "url": "https://wicg.github.io/floc/",
      "seriesComposition": "full",
      "shortname": "floc",
      "series": {
        "shortname": "floc",
        "currentSpecification": "floc",
        "title": "Federated Learning of Cohorts",
        "shortTitle": "Federated Learning of Cohorts",
        "nightlyUrl": "https://wicg.github.io/floc/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Platform Incubator Community Group",
          "url": "https://www.w3.org/community/wicg/"
        }
      ],
      "nightly": {
        "url": "https://wicg.github.io/floc/",
        "repository": "https://github.com/WICG/floc",
        "sourcePath": "floc.bs",
        "filename": "index.html"
      },
      "title": "Federated Learning of Cohorts",
      "source": "spec",
      "shortTitle": "Federated Learning of Cohorts",
      "categories": [
        "browser"
      ]
    }
  ]
}
```