### PR TITLE
Throttle network requests

### DIFF
--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -7,7 +7,7 @@
  * The function needs an authentication token for the GitHub API.
  */
 
-const { Octokit } = require("@octokit/rest");
+const Octokit = require("./octokit");
 const parseSpecUrl = require("./parse-spec-url.js");
 
 

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -8,7 +8,7 @@
  */
 
 const fetch = require("node-fetch");
-const { Octokit } = require("@octokit/rest");
+const Octokit = require("./octokit");
 const parseSpecUrl = require("./parse-spec-url.js");
 
 

--- a/src/octokit.js
+++ b/src/octokit.js
@@ -21,7 +21,7 @@ module.exports = function (params) {
           return false;
         }
       },
-      onAbuseLimit: (retryAfter, options) => {
+      onSecondaryRateLimit: (retryAfter, options) => {
         if (options.request.retryCount < MAX_RETRIES) {
           console.warn(`Abuse detection triggered, retrying after ${retryAfter} seconds`)
           return true;

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -1,0 +1,35 @@
+/**
+ * Provides a throttling wrapper to a function
+ */
+
+module.exports = function (fn, max) {
+  let ongoing = 0;
+  const pending = [];
+
+  return async function throttled(...args) {
+    if (ongoing >= max) {
+      // Too many tasks in parallel, need to throttle
+      return new Promise((resolve, reject) => {
+        pending.push({ params: [...args], resolve, reject });
+      });
+    }
+    else {
+      // Task can run immediately
+      ongoing += 1;
+      const res = await fn.call(null, ...args);
+      ongoing -= 1;
+
+      // Done with current task, trigger next pending task in the background
+      setTimeout(() => {
+        if (pending.length && ongoing < max) {
+          const next = pending.shift();
+          throttled.apply(null, next.params)
+            .then(res => next.resolve(res))
+            .catch(err => next.reject(err));
+        }
+      }, 0);
+
+      return res;
+    }
+  };
+}


### PR DESCRIPTION
This adds throttling to network requests that used to be issued in parallel and that did not have explicit throttling, so as to be more gentle with web servers that the code needs to gather info from.

The `throttle` module exports a generic function that can be used to throttle another function to a maximum number of concurrent tasks. This module is used to throttle parallel requests to the W3C API server (in the hope that this can prevent 503 failures that we keep receiving), and to JSDOM (in the hope that being more gentle with the draft CSS server may help with its stability).

Code that uses Octokit now always goes through the throttled version as well.

Note that throttling is not used in `fetch-groups` simply because that module does not send requests in parallel for now (it uses a `for ... of ...` loop). We may actually want to speed up the module a bit later on through parallelism, but let's do that once build becomes more stable!

Creating a draft PR for now as I could not test the code thoroughly with an actual full re-build (build currently fails because the draft CSS server is down).