### PR TITLE
Add WHATWG File System API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -65,6 +65,7 @@
   },
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://fetch.spec.whatwg.org/",
+  "https://fs.spec.whatwg.org/",
   "https://fullscreen.spec.whatwg.org/",
   {
     "url": "https://html.spec.whatwg.org/multipage/",


### PR DESCRIPTION
This PR adds https://fs.spec.whatwg.org/ to the spec list.

As part of this PR to MDN BCD: https://github.com/mdn/browser-compat-data/pull/15537