### PR TITLE
[tests] Update URL of Web Apps WG home page

### DIFF
--- a/test/fetch-groups-w3c.js
+++ b/test/fetch-groups-w3c.js
@@ -52,7 +52,7 @@ describe("fetch-groups module (with API keys)", function () {
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
         name: "Web Applications Working Group",
-        url: "https://www.w3.org/2019/webapps/"
+        url: "https://www.w3.org/groups/wg/webapps"
       }]);
     });
 
@@ -65,7 +65,7 @@ describe("fetch-groups module (with API keys)", function () {
       assert.equal(res[0].organization, "W3C");
       assert.deepStrictEqual(res[0].groups, [{
         name: "Web Applications Working Group",
-        url: "https://www.w3.org/2019/webapps/"
+        url: "https://www.w3.org/groups/wg/webapps"
       }]);
       assert.equal(res[1].organization, "W3C");
       assert.deepStrictEqual(res[1].groups, [{


### PR DESCRIPTION
Reflects the new home page URL for the Web Apps WG, which is used in tests to check the link with the W3C API.