### PR TITLE
Relax the sourcePath test for TC39 Decorators proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ That path is computed by parsing the contents of the repository for common
 patterns. The info must be specified in `specs.json` for specifications that do
 not follow a common pattern.
 
-The `sourcePath` property is always set when `repository` is set.
+The `sourcePath` property is always set when `repository` is set... except in
+rare cases where the source of the spec is not in the default branch of the
+repository.
 
 **Note:** The path is relative to the root of the repository, and only valid in
 the default branch of the repository. If needed, the source may be fetched from

--- a/test/index.js
+++ b/test/index.js
@@ -149,7 +149,8 @@ describe("List of specs", () => {
     // No repo for the Patent Policy document either
     const wrong = specs.filter(s => !s.nightly.sourcePath &&
       !s.nightly.url.match(/rfc-editor\.org/) &&
-      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/));
+      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
+      !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
The source of the spec is not in the default branch of the repository, and we don't have any easy way to point at another branch for now.

This update also adjusts the README (in practice, the Patent Policy document was already an exception)