### PR TITLE
Add Multi-Screen Window Placement spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -188,6 +188,7 @@
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
   "https://w3c.github.io/webdriver-bidi/",
   "https://w3c.github.io/webrtc-ice/",
+  "https://w3c.github.io/window-placement/",
   {
     "url": "https://webassembly.github.io/exception-handling/js-api/",
     "forkOf": "wasm-js-api-1"


### PR DESCRIPTION
Adopted by the Second Screen Working Group. Fixes #584.

```json
{
  "added": [
    {
      "url": "https://w3c.github.io/window-placement/",
      "seriesComposition": "full",
      "shortname": "window-placement",
      "series": {
        "shortname": "window-placement",
        "currentSpecification": "window-placement",
        "title": "Multi-Screen Window Placement",
        "shortTitle": "Multi-Screen Window Placement",
        "nightlyUrl": "https://w3c.github.io/window-placement/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Second Screen Working Group",
          "url": "https://www.w3.org/2014/secondscreen/"
        }
      ],
      "nightly": {
        "url": "https://w3c.github.io/window-placement/",
        "repository": "https://github.com/w3c/window-placement",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Multi-Screen Window Placement",
      "source": "spec",
      "shortTitle": "Multi-Screen Window Placement",
      "categories": [
        "browser"
      ]
    }
  ],
  "updated": [],
  "deleted": []
}
```