### PR TITLE
Jobs: Create PR without a "draft" status

### DIFF
--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -27,6 +27,5 @@ jobs:
           The following specs have been updated since the last review:
           ${{env.review_list}}
         assignees: tidoust, dontcallmedom, sideshowbarker
-        draft: true
         branch: monitor-update
         branch-suffix: timestamp

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -34,6 +34,5 @@ jobs:
           The following repos have been identified as possibly relevant:
           ${{env.monitor_list}}
         assignees: tidoust, dontcallmedom, sideshowbarker
-        draft: true
         branch: new-monitor
         branch-suffix: timestamp


### PR DESCRIPTION
A PR created as "draft" requires an extra manual step since it cannot be merged directly. The PRs created by the jobs need reviewing and may need to be amended, but they aren't drafts in the sense that the job is not going to update them later on with a more complete PR.