### PR TITLE
WebRTC Extensions spec

### DIFF
--- a/index.json
+++ b/index.json
@@ -17728,6 +17728,48 @@
     }
   },
   {
+    "url": "https://www.w3.org/TR/webrtc-extensions/",
+    "seriesComposition": "full",
+    "shortname": "webrtc",
+    "series": {
+      "shortname": "webrtc",
+      "currentSpecification": "webrtc",
+      "title": "WebRTC Extensions",
+      "shortTitle": "WebRTC Extensions",
+      "releaseUrl": "https://www.w3.org/TR/webrtc-extensions/",
+      "nightlyUrl": "https://w3c.github.io/webrtc-extensions/"
+    },
+    "shortTitle": "WebRTC Extensions",
+    "organization": "W3C",
+    "groups": [
+      {
+        "name": "Web Real-Time Communications Working Group",
+        "url": "https://www.w3.org/groups/wg/webrtc"
+      }
+    ],
+    "release": {
+      "url": "https://www.w3.org/TR/webrtc-extensions/",
+      "filename": "Overview.html"
+    },
+    "nightly": {
+      "url": "https://w3c.github.io/webrtc-extensions/",
+      "repository": "https://github.com/w3c/webrtc-extensions/",
+      "sourcePath": "webrtc-exensions.html",
+      "filename": "index.html"
+    },
+    "title": "WebRTC Extensions",
+    "source": "w3c",
+    "categories": [
+      "browser"
+    ],
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "webrtc"
+      ]
+    }
+  },
+  {
     "url": "https://www.w3.org/TR/webtransport/",
     "seriesComposition": "full",
     "shortname": "webtransport",


### PR DESCRIPTION
This attempts to add the WebRTC extensions spec https://w3c.github.io/webrtc-extensions/ which is needed to allow me to update some of the properties in browser compatibility data: https://github.com/mdn/browser-compat-data/pull/16200

All I did was copy the previous record (WebRTC: Real-Time Communication Between Browsers) and attempt to update values. However I have not done this before and there were many values that I wasn't clear on. Advice on how to make this right welcome.