### PR TITLE
Update URL for Media Capture Handle Identity

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -174,13 +174,6 @@
       "sourcePath": "actions/index.html"
     }
   },
-  {
-    "url": "https://w3c.github.io/mediacapture-handle/identity/",
-    "shortname": "mediacapture-handle-identity",
-    "nightly": {
-      "sourcePath": "identity/index.html"
-    }
-  },
   "https://w3c.github.io/mediacapture-viewport/",
   "https://w3c.github.io/PNG-spec/",
   "https://w3c.github.io/web-locks/",
@@ -431,6 +424,12 @@
   "https://www.w3.org/TR/autoplay-detection/",
   "https://www.w3.org/TR/battery-status/",
   "https://www.w3.org/TR/beacon/",
+  {
+    "url": "https://www.w3.org/TR/capture-handle-identity/",
+    "nightly": {
+      "sourcePath": "identity/index.html"
+    }
+  },
   "https://www.w3.org/TR/clear-site-data/",
   "https://www.w3.org/TR/clipboard-apis/",
   {


### PR DESCRIPTION
Spec was published as first public working draft last week.

Note the change of spec shortname from `mediacapture-handle-identity` to `capture-handle-identity` (and the inconsistency with other similar specs that had `mediacapture` as prefix, bouh).

Fixes #608.

Diff that this introduces:

```json
{
  "added": [
    {
      "url": "https://www.w3.org/TR/capture-handle-identity/",
      "seriesComposition": "full",
      "shortname": "capture-handle-identity",
      "series": {
        "shortname": "capture-handle-identity",
        "currentSpecification": "capture-handle-identity",
        "title": "Capture Handle - Bootstrapping Collaboration when Screensharing",
        "shortTitle": "Capture Handle - Bootstrapping Collaboration when Screensharing",
        "releaseUrl": "https://www.w3.org/TR/capture-handle-identity/",
        "nightlyUrl": "https://w3c.github.io/mediacapture-handle/"
      },
      "nightly": {
        "url": "https://w3c.github.io/mediacapture-handle/",
        "sourcePath": "identity/index.html",
        "repository": "https://github.com/w3c/mediacapture-handle",
        "filename": "index.html"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Real-Time Communications Working Group",
          "url": "https://www.w3.org/groups/wg/webrtc"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/capture-handle-identity/",
        "filename": "Overview.html"
      },
      "title": "Capture Handle - Bootstrapping Collaboration when Screensharing",
      "source": "w3c",
      "shortTitle": "Capture Handle - Bootstrapping Collaboration when Screensharing",
      "categories": [
        "browser"
      ]
    }
  ],
  "updated": [],
  "deleted": [
    {
      "url": "https://w3c.github.io/mediacapture-handle/identity/",
      "seriesComposition": "full",
      "shortname": "mediacapture-handle-identity",
      "series": {
        "shortname": "mediacapture-handle-identity",
        "currentSpecification": "mediacapture-handle-identity",
        "title": "Capture Handle - Bootstrapping Collaboration when Screensharing",
        "shortTitle": "Capture Handle - Bootstrapping Collaboration when Screensharing",
        "nightlyUrl": "https://w3c.github.io/mediacapture-handle/identity/"
      },
      "nightly": {
        "url": "https://w3c.github.io/mediacapture-handle/identity/",
        "sourcePath": "identity/index.html",
        "repository": "https://github.com/w3c/mediacapture-handle",
        "filename": "index.html"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Real-Time Communications Working Group",
          "url": "https://www.w3.org/groups/wg/webrtc"
        }
      ],
      "title": "Capture Handle - Bootstrapping Collaboration when Screensharing",
      "source": "spec",
      "shortTitle": "Capture Handle - Bootstrapping Collaboration when Screensharing",
      "categories": [
        "browser"
      ]
    }
  ]
}
```