### PR TITLE
Drop retired Selectors Non Element spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -767,7 +767,6 @@
   "https://www.w3.org/TR/secure-payment-confirmation/",
   "https://www.w3.org/TR/selection-api/",
   "https://www.w3.org/TR/selectors-4/",
-  "https://www.w3.org/TR/selectors-nonelement-1/",
   "https://www.w3.org/TR/server-timing/",
   {
     "url": "https://www.w3.org/TR/service-workers-1/",


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/601

Spec was published in 2019 as a Retired Group Note.