### PR TITLE
Ignore Non-element Selectors, monitor TC39 RegExp v flag proposal

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -340,6 +340,9 @@
     "https://drafts.csswg.org/css-template-1/": {
       "comment": "repository for ideas that may migrate to other modules of CSS"
     },
+    "https://drafts.csswg.org/selectors-nonelement-1/": {
+      "comment": "retired spec"
+    },
     "https://drafts.css-houdini.org/scroll-customization-api/": {
       "comment": "No activity since 2015; marked as no longer pursuing in https://www.chromestatus.com/features/5616710262456320"
     },

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -272,6 +272,10 @@
       "lastreviewed": "2022-05-01",
       "comment": "no published content yet, actual content in a Google Doc"
     },
+    "tc39/proposal-regexp-v-flag": {
+      "lastreviewed": "2022-05-23",
+      "comment": "no published content yet, actual content in a Readme"
+    },
     "WICG/origin-policy": {
       "lastreviewed": "2022-05-01",
       "comment": "proposal put on hold"


### PR DESCRIPTION
The Non-element Selectors spec was dropped from the list last week as a retired spec. It should have been added to the ignore list.

The new v flag proposal for RegExp is currently only defined in a README.

Fixes #619