### PR TITLE
Adjust URLs of specs that migrated or got published to TR

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -161,9 +161,7 @@
   "https://w3c.github.io/badging/",
   "https://w3c.github.io/contact-api/spec/",
   "https://w3c.github.io/contentEditable/",
-  "https://w3c.github.io/event-timing/",
   "https://w3c.github.io/gamepad/extensions.html",
-  "https://w3c.github.io/largest-contentful-paint/",
   "https://w3c.github.io/mathml-aam/",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/mediacapture-automation/",
@@ -174,7 +172,6 @@
       "sourcePath": "actions/index.html"
     }
   },
-  "https://w3c.github.io/mediacapture-viewport/",
   "https://w3c.github.io/PNG-spec/",
   "https://w3c.github.io/web-locks/",
   "https://w3c.github.io/web-nfc/",
@@ -191,6 +188,7 @@
   "https://webbluetoothcg.github.io/web-bluetooth/",
   "https://webidl.spec.whatwg.org/",
   "https://websockets.spec.whatwg.org/",
+  "https://wicg.github.io/attribution-reporting-api/",
   "https://wicg.github.io/background-fetch/",
   {
     "url": "https://wicg.github.io/background-sync/spec/",
@@ -202,7 +200,6 @@
   "https://wicg.github.io/compression/",
   "https://wicg.github.io/compute-pressure/",
   "https://wicg.github.io/content-index/spec/",
-  "https://wicg.github.io/conversion-measurement-api/",
   "https://wicg.github.io/cookie-store/",
   "https://wicg.github.io/crash-reporting/",
   "https://wicg.github.io/credentiallessness/",
@@ -650,6 +647,7 @@
       "-browser"
     ]
   },
+  "https://www.w3.org/TR/event-timing/",
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
     "shortTitle": "Fetch Metadata"
@@ -685,6 +683,7 @@
   },
   "https://www.w3.org/TR/input-events-2/",
   "https://www.w3.org/TR/intersection-observer/",
+  "https://www.w3.org/TR/largest-contentful-paint/",
   "https://www.w3.org/TR/longtasks-1/",
   "https://www.w3.org/TR/magnetometer/",
   "https://www.w3.org/TR/manifest-app-info/",
@@ -700,6 +699,7 @@
   "https://www.w3.org/TR/mediacapture-region/",
   "https://www.w3.org/TR/mediacapture-streams/",
   "https://www.w3.org/TR/mediacapture-transform/",
+  "https://www.w3.org/TR/mediacapture-viewport/",
   "https://www.w3.org/TR/mediaqueries-4/",
   "https://www.w3.org/TR/mediaqueries-5/ delta",
   "https://www.w3.org/TR/mediasession/",


### PR DESCRIPTION
Fixes #621

Note the Attribution Reporting API replaces the Conversion Measurement API
(same spec with different shortname and title)

Diff:

```json
{
  "added": [
    {
      "url": "https://wicg.github.io/attribution-reporting-api/",
      "seriesComposition": "full",
      "shortname": "attribution-reporting-api",
      "series": {
        "shortname": "attribution-reporting-api",
        "currentSpecification": "attribution-reporting-api",
        "title": "Attribution Reporting",
        "shortTitle": "Attribution Reporting",
        "nightlyUrl": "https://wicg.github.io/attribution-reporting-api/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Platform Incubator Community Group",
          "url": "https://www.w3.org/community/wicg/"
        }
      ],
      "nightly": {
        "url": "https://wicg.github.io/attribution-reporting-api/",
        "repository": "https://github.com/WICG/attribution-reporting-api",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Attribution Reporting",
      "source": "spec",
      "shortTitle": "Attribution Reporting",
      "categories": [
        "browser"
      ]
    },
    {
      "url": "https://www.w3.org/TR/event-timing/",
      "seriesComposition": "full",
      "shortname": "event-timing",
      "series": {
        "shortname": "event-timing",
        "currentSpecification": "event-timing",
        "title": "Event Timing API",
        "shortTitle": "Event Timing API",
        "releaseUrl": "https://www.w3.org/TR/event-timing/",
        "nightlyUrl": "https://w3c.github.io/event-timing"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Performance Working Group",
          "url": "https://www.w3.org/webperf/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/event-timing/",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://w3c.github.io/event-timing",
        "repository": "https://github.com/w3c/event-timing",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Event Timing API",
      "source": "w3c",
      "shortTitle": "Event Timing API",
      "categories": [
        "browser"
      ]
    },
    {
      "url": "https://www.w3.org/TR/largest-contentful-paint/",
      "seriesComposition": "full",
      "shortname": "largest-contentful-paint",
      "series": {
        "shortname": "largest-contentful-paint",
        "currentSpecification": "largest-contentful-paint",
        "title": "Largest Contentful Paint",
        "shortTitle": "Largest Contentful Paint",
        "releaseUrl": "https://www.w3.org/TR/largest-contentful-paint/",
        "nightlyUrl": "https://wicg.github.io/largest-contentful-paint"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Performance Working Group",
          "url": "https://www.w3.org/webperf/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/largest-contentful-paint/",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://wicg.github.io/largest-contentful-paint",
        "repository": "https://github.com/WICG/largest-contentful-paint",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Largest Contentful Paint",
      "source": "w3c",
      "shortTitle": "Largest Contentful Paint",
      "categories": [
        "browser"
      ],
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "largest-contentful-paint"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/mediacapture-viewport/",
      "seriesComposition": "full",
      "shortname": "mediacapture-viewport",
      "series": {
        "shortname": "mediacapture-viewport",
        "currentSpecification": "mediacapture-viewport",
        "title": "Viewport Capture",
        "shortTitle": "Viewport Capture",
        "releaseUrl": "https://www.w3.org/TR/mediacapture-viewport/",
        "nightlyUrl": "https://w3c.github.io/mediacapture-viewport/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Real-Time Communications Working Group",
          "url": "https://www.w3.org/groups/wg/webrtc"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/mediacapture-viewport/",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://w3c.github.io/mediacapture-viewport/",
        "repository": "https://github.com/w3c/mediacapture-viewport",
        "sourcePath": "index.html",
        "filename": "index.html"
      },
      "title": "Viewport Capture",
      "source": "w3c",
      "shortTitle": "Viewport Capture",
      "categories": [
        "browser"
      ]
    }
  ],
  "updated": [],
  "deleted": [
    {
      "url": "https://w3c.github.io/event-timing/",
      "seriesComposition": "full",
      "shortname": "event-timing",
      "series": {
        "shortname": "event-timing",
        "currentSpecification": "event-timing",
        "title": "Event Timing API",
        "shortTitle": "Event Timing API",
        "nightlyUrl": "https://w3c.github.io/event-timing/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Performance Working Group",
          "url": "https://www.w3.org/webperf/"
        }
      ],
      "nightly": {
        "url": "https://w3c.github.io/event-timing/",
        "repository": "https://github.com/w3c/event-timing",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Event Timing API",
      "source": "specref",
      "shortTitle": "Event Timing API",
      "categories": [
        "browser"
      ]
    },
    {
      "url": "https://w3c.github.io/largest-contentful-paint/",
      "seriesComposition": "full",
      "shortname": "largest-contentful-paint",
      "series": {
        "shortname": "largest-contentful-paint",
        "currentSpecification": "largest-contentful-paint",
        "title": "Largest Contentful Paint",
        "shortTitle": "Largest Contentful Paint",
        "nightlyUrl": "https://w3c.github.io/largest-contentful-paint/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Performance Working Group",
          "url": "https://www.w3.org/webperf/"
        }
      ],
      "nightly": {
        "url": "https://w3c.github.io/largest-contentful-paint/",
        "repository": "https://github.com/w3c/largest-contentful-paint",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Largest Contentful Paint",
      "source": "specref",
      "shortTitle": "Largest Contentful Paint",
      "categories": [
        "browser"
      ]
    },
    {
      "url": "https://w3c.github.io/mediacapture-viewport/",
      "seriesComposition": "full",
      "shortname": "mediacapture-viewport",
      "series": {
        "shortname": "mediacapture-viewport",
        "currentSpecification": "mediacapture-viewport",
        "title": "Viewport Capture",
        "shortTitle": "Viewport Capture",
        "nightlyUrl": "https://w3c.github.io/mediacapture-viewport/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Real-Time Communications Working Group",
          "url": "https://www.w3.org/groups/wg/webrtc"
        }
      ],
      "nightly": {
        "url": "https://w3c.github.io/mediacapture-viewport/",
        "repository": "https://github.com/w3c/mediacapture-viewport",
        "sourcePath": "index.html",
        "filename": "index.html"
      },
      "title": "Viewport Capture",
      "source": "spec",
      "shortTitle": "Viewport Capture",
      "categories": [
        "browser"
      ]
    },
    {
      "url": "https://wicg.github.io/conversion-measurement-api/",
      "seriesComposition": "full",
      "shortname": "conversion-measurement-api",
      "series": {
        "shortname": "conversion-measurement-api",
        "currentSpecification": "conversion-measurement-api",
        "title": "Attribution Reporting",
        "shortTitle": "Attribution Reporting",
        "nightlyUrl": "https://wicg.github.io/conversion-measurement-api/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Platform Incubator Community Group",
          "url": "https://www.w3.org/community/wicg/"
        }
      ],
      "nightly": {
        "url": "https://wicg.github.io/conversion-measurement-api/",
        "repository": "https://github.com/WICG/conversion-measurement-api",
        "sourcePath": "index.bs",
        "filename": "index.html"
      },
      "title": "Attribution Reporting",
      "source": "spec",
      "shortTitle": "Attribution Reporting",
      "categories": [
        "browser"
      ]
    }
  ]
}
```