### PR TITLE
Add WOFF 1.0

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -886,6 +886,12 @@
     "nightly": {
       "url": "https://w3c.github.io/woff/woff1/spec/Overview.html",
       "sourcePath": "woff1/spec/Overview.html"
+    },
+    "tests": {
+      "repository": "https://github.com/w3c/woff",
+      "testPaths": [
+        "woff1/tests"
+      ]
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -881,6 +881,14 @@
     }
   },
   {
+    "url": "https://www.w3.org/TR/WOFF/",
+    "shortTitle": "WOFF 1.0",
+    "nightly": {
+      "url": "https://w3c.github.io/woff/woff1/spec/Overview.html",
+      "sourcePath": "woff1/spec/Overview.html"
+    }
+  },
+  {
     "url": "https://www.w3.org/TR/WOFF2/",
     "shortTitle": "WOFF 2.0",
     "nightly": {


### PR DESCRIPTION
WOFF 2.0 does not replace WOFF 1.0. It just defines a second version of the file format. This adds WOFF 1.0 to the list.

WOFF 1.0 and WOFF 2.0 are part of the same series, which seems good. The shortname for WOFF 1.0 is `WOFF` because that is what the W3C API returns. Similarly, WOFF 1.0 is flagged as being the current specification for the series because that is the current specification returned by the W3C API for the specification series `WOFF` (and what people get when they browse https://www.w3.org/TR/WOFF/ ).

If that seems wrong, the info needs fixing in the W3C API.

Note that separating the specs entirely to create different spec series makes the build process fail because specs with TR URLs are supposedly managed by the W3C API, and there are no series named `WOFF1` and `WOFF2`.

Fixes #622.