### PR TITLE
Add Source Map spec to the list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -82,6 +82,18 @@
   "https://privacycg.github.io/private-click-measurement/",
   "https://privacycg.github.io/storage-access/",
   "https://quirks.spec.whatwg.org/",
+  {
+    "url": "https://sourcemaps.info/spec.html",
+    "shortname": "sourcemap",
+    "shortTitle": "Source Map",
+    "organization": "sourcemaps.info",
+    "groups": [
+      {
+        "name": "sourcemaps.info",
+        "url": "https://sourcemaps.info/"
+      }
+    ]
+  },
   "https://storage.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",
   "https://svgwg.org/specs/animations/",

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,8 @@ describe("List of specs", () => {
     // No repo for the Patent Policy document either
     const wrong = specs.filter(s => !s.nightly.repository &&
       !s.nightly.url.match(/rfc-editor\.org/) &&
-      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/));
+      !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
+      !s.nightly.url.match(/\/sourcemaps\.info\//));
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -150,7 +151,8 @@ describe("List of specs", () => {
     const wrong = specs.filter(s => !s.nightly.sourcePath &&
       !s.nightly.url.match(/rfc-editor\.org/) &&
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
-      !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/));
+      !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/) &&
+      !s.nightly.url.match(/\/sourcemaps\.info\//));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
Add the latest revision of the Source Map spec to the list, using the readable HTML version of the spec published by sourcemaps.info. The actual spec is in a Google Doc but there is no easy way to extract content automatically from a
canvas-based Google Doc:
https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k

Organization and group are set to "sourcemaps.info" for lack of better choice. Also note the need to relax a couple of tests as there is no real repository for the spec (there is one for sourcemaps.info, but that's for the site itself, not for raising issues against the spec).

Closes #618.

This will add the following entry to the list:

```json
{
  "url": "https://sourcemaps.info/spec.html",
  "seriesComposition": "full",
  "shortname": "sourcemap",
  "series": {
    "shortname": "sourcemap",
    "currentSpecification": "sourcemap",
    "title": "Source Map Revision 3 Proposal",
    "shortTitle": "Source Map",
    "nightlyUrl": "https://sourcemaps.info/spec.html"
  },
  "shortTitle": "Source Map",
  "organization": "sourcemaps.info",
  "groups": [
    {
      "name": "sourcemaps.info",
      "url": "https://sourcemaps.info/"
    }
  ],
  "nightly": {
    "url": "https://sourcemaps.info/spec.html",
    "filename": "spec.html"
  },
  "title": "Source Map Revision 3 Proposal",
  "source": "spec",
  "categories": [
    "browser"
  ]
}
```