### PR TITLE
Add TC39 Symbol as WeakMap Keys proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -167,6 +167,7 @@
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-resizablearraybuffer/",
   "https://tc39.es/proposal-shadowrealm/",
+  "https://tc39.es/proposal-symbols-as-weakmap-keys/",
   "https://tc39.es/proposal-temporal/",
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",


### PR DESCRIPTION
Fixes #633.

Diff:

```json
{
  "url": "https://tc39.es/proposal-symbols-as-weakmap-keys/",
  "seriesComposition": "full",
  "shortname": "tc39-symbols-as-weakmap-keys",
  "series": {
    "shortname": "tc39-symbols-as-weakmap-keys",
    "currentSpecification": "tc39-symbols-as-weakmap-keys",
    "title": "Symbol as WeakMap Keys Proposal",
    "shortTitle": "Symbol as WeakMap Keys",
    "nightlyUrl": "https://tc39.es/proposal-symbols-as-weakmap-keys/"
  },
  "organization": "Ecma International",
  "groups": [
    {
      "name": "TC39",
      "url": "https://tc39.es/"
    }
  ],
  "nightly": {
    "url": "https://tc39.es/proposal-symbols-as-weakmap-keys/",
    "repository": "https://github.com/tc39/proposal-symbols-as-weakmap-keys",
    "filename": "index.html"
  },
  "title": "Symbol as WeakMap Keys Proposal",
  "source": "spec",
  "shortTitle": "Symbol as WeakMap Keys",
  "categories": [
    "browser"
  ]
}
```