### PR TITLE
Drop credentiallessness, now merged in HTML and Fetch

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -215,7 +215,6 @@
   "https://wicg.github.io/content-index/spec/",
   "https://wicg.github.io/cookie-store/",
   "https://wicg.github.io/crash-reporting/",
-  "https://wicg.github.io/credentiallessness/",
   {
     "url": "https://wicg.github.io/csp-next/scripting-policy.html",
     "nightly": {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -152,6 +152,9 @@
     "WICG/controls-list": {
       "comment": "aimed toward HTML LS  https://github.com/whatwg/html/pull/2426"
     },
+    "WICG/credentiallessness": {
+      "comment": "merged into the HTML and Fetch specifications"
+    },
     "WICG/cross-origin-embedder-policy": {
       "comment": "aimed toward integration in other specs - see https://github.com/whatwg/html/pull/5454"
     },


### PR DESCRIPTION
"COEP:credentialless merged into the HTML and Fetch specification."
https://github.com/WICG/credentiallessness/#obsoletion-notice