### PR TITLE
Drop Visual Viewport API (merged in CSSOM View)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -294,7 +294,6 @@
   "https://wicg.github.io/urlpattern/",
   "https://wicg.github.io/user-preference-media-features-headers/",
   "https://wicg.github.io/video-rvfc/",
-  "https://wicg.github.io/visual-viewport/",
   "https://wicg.github.io/web-otp/",
   "https://wicg.github.io/webcrypto-secure-curves/",
   "https://wicg.github.io/webhid/",


### PR DESCRIPTION
The proposed Visual Viewport API has been merged into CSSOM View:
https://github.com/w3c/csswg-drafts/issues/6339