### PR TITLE
Add css-variables-2, TR url of window-placement

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -57,6 +57,10 @@
     "shortTitle": "CSS Values 5",
     "seriesComposition": "delta"
   },
+  {
+    "url": "https://drafts.csswg.org/css-variables-2/",
+    "shortTitle": "CSS Variables 2"
+  },
   "https://drafts.csswg.org/scroll-animations-1/",
   "https://drafts.csswg.org/web-animations-2/ delta",
   {
@@ -198,7 +202,6 @@
   "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
   "https://w3c.github.io/webdriver-bidi/",
   "https://w3c.github.io/webrtc-ice/",
-  "https://w3c.github.io/window-placement/",
   {
     "url": "https://webassembly.github.io/exception-handling/js-api/",
     "forkOf": "wasm-js-api-2"
@@ -908,6 +911,7 @@
       "sourcePath": "wgsl/index.bs"
     }
   },
+  "https://www.w3.org/TR/window-placement/",
   {
     "url": "https://www.w3.org/TR/WOFF/",
     "shortTitle": "WOFF 1.0",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -83,6 +83,9 @@
     "WICG/open-ui": {
       "comment": "not targeted at browsers"
     },
+    "WICG/visual-viewport": {
+      "comment": "merged into CSSOM View"
+    },
     "privacycg/template": {
       "comment": "not for spec"
     },


### PR DESCRIPTION
Fixes #653

Also ignores WICG/visual-viewport (spec dropped from browser-specs last week
after it was merged into CSSOM View)

New specs:

```json
{
  "url": "https://drafts.csswg.org/css-variables-2/",
  "seriesComposition": "full",
  "shortname": "css-variables-2",
  "series": {
    "shortname": "css-variables",
    "currentSpecification": "css-variables-2",
    "title": "CSS Custom Properties for Cascading Variables",
    "shortTitle": "CSS Variables",
    "nightlyUrl": "https://drafts.csswg.org/css-variables/"
  },
  "seriesVersion": "2",
  "shortTitle": "CSS Variables 2",
  "organization": "W3C",
  "groups": [
    {
      "name": "Cascading Style Sheets (CSS) Working Group",
      "url": "https://www.w3.org/Style/CSS/"
    }
  ],
  "nightly": {
    "url": "https://drafts.csswg.org/css-variables-2/",
    "repository": "https://github.com/w3c/csswg-drafts",
    "sourcePath": "css-variables-2/Overview.bs",
    "filename": "Overview.html"
  },
  "title": "CSS Custom Properties for Cascading Variables Module Level 2",
  "source": "spec",
  "categories": [
    "browser"
  ],
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "css/css-variables"
    ]
  }
},
{
  "url": "https://www.w3.org/TR/window-placement/",
  "seriesComposition": "full",
  "shortname": "window-placement",
  "series": {
    "shortname": "window-placement",
    "currentSpecification": "window-placement",
    "title": "Multi-Screen Window Placement",
    "shortTitle": "Multi-Screen Window Placement",
    "releaseUrl": "https://www.w3.org/TR/window-placement/",
    "nightlyUrl": "https://w3c.github.io/window-placement/"
  },
  "organization": "W3C",
  "groups": [
    {
      "name": "Second Screen Working Group",
      "url": "https://www.w3.org/2014/secondscreen/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/window-placement/",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/window-placement/",
    "repository": "https://github.com/w3c/window-placement",
    "sourcePath": "index.bs",
    "filename": "index.html"
  },
  "title": "Multi-Screen Window Placement",
  "source": "w3c",
  "shortTitle": "Multi-Screen Window Placement",
  "categories": [
    "browser"
  ],
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "window-placement"
    ]
  }
}
```