### PR TITLE
Set --no-cone mode for git sparse-checkout of WPT

### DIFF
--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -60,6 +60,7 @@ function fetchWPT() {
     // Clone repo using sparse mode: the repo is huge and we're only interested
     // in META.yml files
     execSync("git clone https://github.com/web-platform-tests/wpt.git --depth 1 --sparse", { cwd: cacheFolder });
+    execSync("git sparse-checkout set --no-cone", { cwd: wptFolder });
     execSync("git sparse-checkout add **/META.yml", { cwd: wptFolder });
   }
 }


### PR DESCRIPTION
Behavior of sparse-checkout is not fully stable and changed in 2.37 version of Git. Command line now expects directories by default, and not patterns. Forcing the mode to `--no-cone` tells Git to parse the parameter as a pattern instead:
https://www.git-scm.com/docs/git-sparse-checkout#_internalsfull_pattern_set

That is what we need, although note use of the `--no-cone` feature is discouraged and may be remove in a future version of Git. Feature does what we need for now. In the absence of it, we'd have to build the list of directories and `META.yml` files ourselves. That's doable with the right Git command and parameters, just requires looking into what the right Git command and parameters are ;)