### PR TITLE
Adjust URL of Service Workers

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -800,12 +800,7 @@
   "https://www.w3.org/TR/selection-api/",
   "https://www.w3.org/TR/selectors-4/",
   "https://www.w3.org/TR/server-timing/",
-  {
-    "url": "https://www.w3.org/TR/service-workers-1/",
-    "nightly": {
-      "url": "https://w3c.github.io/ServiceWorker/"
-    }
-  },
+  "https://www.w3.org/TR/service-workers/",
   {
     "url": "https://www.w3.org/TR/SRI/",
     "shortTitle": "SRI"


### PR DESCRIPTION
The spec dropped the level from its shortname and the link to the Editor's Draft no longer needs to be explicitly specified. This fixes #665.