### PR TITLE
Force ED URL of css-color-4

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -497,7 +497,12 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Cascading 6"
   },
-  "https://www.w3.org/TR/css-color-4/",
+  {
+    "url": "https://www.w3.org/TR/css-color-4/",
+    "nightly": {
+      "url": "https://drafts.csswg.org/css-color-4/"
+    }
+  },
   "https://www.w3.org/TR/css-color-5/ delta",
   "https://www.w3.org/TR/css-color-adjust-1/",
   {


### PR DESCRIPTION
Temporary fix to be able to resume data curation in webref, pending proper fix on CSS WG side and possible hardcoded handling (see #675).