### PR TITLE
Target version 1.1 of Payment Handler spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -775,7 +775,7 @@
   },
   "https://www.w3.org/TR/payment-method-id/",
   "https://www.w3.org/TR/payment-method-manifest/",
-  "https://www.w3.org/TR/payment-request/",
+  "https://www.w3.org/TR/payment-request-1.1/",
   "https://www.w3.org/TR/performance-timeline/",
   "https://www.w3.org/TR/permissions-policy-1/",
   "https://www.w3.org/TR/permissions/",


### PR DESCRIPTION
Version 1.0 will soon be published as W3C Recommendation, the working group has started work on version 1.1. Fixes #674.

This will update the Payment Request entry with the following info:

```json
{
  "url": "https://www.w3.org/TR/payment-request-1.1/",
  "seriesComposition": "full",
  "shortname": "payment-request-1.1",
  "series": {
    "shortname": "payment-request",
    "currentSpecification": "payment-request-1.1",
    "title": "Payment Request API",
    "shortTitle": "Payment Request API",
    "releaseUrl": "https://www.w3.org/TR/payment-request/",
    "nightlyUrl": "https://w3c.github.io/payment-request/"
  },
  "seriesVersion": "1.1",
  "shortTitle": "Payment Request API",
  "organization": "W3C",
  "groups": [
    {
      "name": "Web Payments Working Group",
      "url": "https://www.w3.org/Payments/WG/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/payment-request-1.1/",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/payment-request/",
    "repository": "https://github.com/w3c/payment-request",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "Payment Request API 1.1",
  "source": "w3c",
  "categories": [
    "browser"
  ],
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "payment-request"
    ]
  }
}
```