### PR TITLE
Ignore older version of Payment Request

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -381,9 +381,6 @@
     },
     "https://w3c.github.io/device-memory/": {
       "comment": "Already in the list. Code gets confused because TR spec links to itself as ED"
-    },
-    "https://www.w3.org/TR/payment-request/": {
-      "comment": "Older version of Payment Request 1.1"
     }
   }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -381,6 +381,9 @@
     },
     "https://w3c.github.io/device-memory/": {
       "comment": "Already in the list. Code gets confused because TR spec links to itself as ED"
+    },
+    "https://www.w3.org/TR/payment-request/": {
+      "comment": "Older version of Payment Request 1.1"
     }
   }
 }

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -57,7 +57,7 @@ const hasMoreRecentLevel = (s, url, loose) => {
   try {
     const shortnameData = computeShortname(url);
     return s.series.shortname === shortnameData.series.shortname
-      && (s.seriesVersion > shortnameData.seriesVersion
+      && (s.seriesVersion > (shortnameData.seriesVersion ?? '')
           || loose && (s.seriesVersion === shortnameData.seriesVersion
                        // case of CSS drafts whose known editors drafts are version-less, but the directories in the repo use versions
                        || !s.seriesVersion


### PR DESCRIPTION
Closes #680. False positive as list now contains v1.1 of the spec.