### PR TITLE
Add JSON-LD specs to (non-browser) list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -720,6 +720,33 @@
   },
   "https://www.w3.org/TR/input-events-2/",
   "https://www.w3.org/TR/intersection-observer/",
+  {
+    "url": "https://www.w3.org/TR/json-ld11-api/",
+    "series": {
+      "shortname": "json-ld-api"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/json-ld11-framing/",
+    "series": {
+      "shortname": "json-ld-framing"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/json-ld11/",
+    "series": {
+      "shortname": "json-ld"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://www.w3.org/TR/largest-contentful-paint/",
   "https://www.w3.org/TR/longtasks-1/",
   "https://www.w3.org/TR/magnetometer/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -30,9 +30,6 @@
     "EPUB 3 Working Group": {
       "comment": "specs not targeted at browsers"
     },
-    "JSON-LD Working Group": {
-      "comment": "specs not targeted at browsers"
-    },
     "MiniApps Working Group": {
       "comment": "specs not targeted at browsers"
     },

--- a/test/index.js
+++ b/test/index.js
@@ -118,12 +118,12 @@ describe("List of specs", () => {
   });
 
   it("has series titles that look consistent with spec titles", () => {
-    // Note the WebRTC spec follows a slightly different pattern
+    // Note the WebRTC and JSON-LD specs follow a slightly different pattern
     // TEMP (2022-01-05): temp exception to the rule: published version of CSS
     // Images Level 4 has an obscure title à la "CSS Image Values..."
     // (should get fixed next time the spec gets published to /TR)
     const wrong = specs.filter(s => !s.title.includes(s.series.title))
-      .filter(s => !["webrtc", "css-images-4"].includes(s.shortname));
+      .filter(s => !["webrtc", "json-ld11-api", "json-ld11-framing", "css-images-4"].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
Adds JSON-LD syntax, api and framing specs to the list of specs not targeted at browsers.

See related request in:
https://github.com/w3c/respec/issues/4243

Build code gets confused by the versioning scheme used in the specs: code expects version number to appear last whereas JSON-LD specs have version numbers within the title. Hence the explicit series shortnames in `specs.json` and the hardcoded test exception for the series title.

This will add the following info to the list:

```json
{
  "url": "https://www.w3.org/TR/json-ld11-api/",
  "seriesComposition": "full",
  "shortname": "json-ld11-api",
  "series": {
    "shortname": "json-ld-api",
    "currentSpecification": "json-ld11-api",
    "title": "JSON-LD Processing Algorithms and API",
    "shortTitle": "JSON-LD Processing Algorithms and API",
    "releaseUrl": "https://www.w3.org/TR/json-ld-api/",
    "nightlyUrl": "https://w3c.github.io/json-ld-api/"
  },
  "categories": [],
  "organization": "W3C",
  "groups": [
    {
      "name": "JSON-LD Working Group",
      "url": "https://www.w3.org/2018/json-ld-wg/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/json-ld11-api/",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/json-ld-api/",
    "repository": "https://github.com/w3c/json-ld-api",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "JSON-LD 1.1 Processing Algorithms and API",
  "source": "w3c",
  "shortTitle": "JSON-LD 1.1 Processing Algorithms and API"
},
{
  "url": "https://www.w3.org/TR/json-ld11-framing/",
  "seriesComposition": "full",
  "shortname": "json-ld11-framing",
  "series": {
    "shortname": "json-ld-framing",
    "currentSpecification": "json-ld11-framing",
    "title": "JSON-LD Framing",
    "shortTitle": "JSON-LD Framing",
    "releaseUrl": "https://www.w3.org/TR/json-ld-framing/",
    "nightlyUrl": "https://w3c.github.io/json-ld-framing/"
  },
  "categories": [],
  "organization": "W3C",
  "groups": [
    {
      "name": "JSON-LD Working Group",
      "url": "https://www.w3.org/2018/json-ld-wg/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/json-ld11-framing/",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/json-ld-framing/",
    "repository": "https://github.com/w3c/json-ld-framing",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "JSON-LD 1.1 Framing",
  "source": "w3c",
  "shortTitle": "JSON-LD 1.1 Framing"
},
{
  "url": "https://www.w3.org/TR/json-ld11/",
  "seriesComposition": "full",
  "shortname": "json-ld11",
  "series": {
    "shortname": "json-ld",
    "currentSpecification": "json-ld11",
    "title": "JSON-LD",
    "shortTitle": "JSON-LD",
    "releaseUrl": "https://www.w3.org/TR/json-ld/",
    "nightlyUrl": "https://w3c.github.io/json-ld-syntax/"
  },
  "seriesVersion": "1.1",
  "categories": [],
  "organization": "W3C",
  "groups": [
    {
      "name": "JSON-LD Working Group",
      "url": "https://www.w3.org/2018/json-ld-wg/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/json-ld11/",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/json-ld-syntax/",
    "repository": "https://github.com/w3c/json-ld-syntax",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "JSON-LD 1.1",
  "source": "w3c",
  "shortTitle": "JSON-LD 1.1"
}
```