### PR TITLE
Update all WebGL URLs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -98,6 +98,80 @@
       }
     ]
   },
+  "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
+  "https://registry.khronos.org/webgl/extensions/EXT_blend_minmax/",
+  "https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/",
+  "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/",
+  "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_half_float/",
+  "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
+  "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query/",
+  "https://registry.khronos.org/webgl/extensions/EXT_float_blend/",
+  "https://registry.khronos.org/webgl/extensions/EXT_frag_depth/",
+  "https://registry.khronos.org/webgl/extensions/EXT_shader_texture_lod/",
+  "https://registry.khronos.org/webgl/extensions/EXT_sRGB/",
+  "https://registry.khronos.org/webgl/extensions/EXT_texture_compression_bptc/",
+  "https://registry.khronos.org/webgl/extensions/EXT_texture_compression_rgtc/",
+  "https://registry.khronos.org/webgl/extensions/EXT_texture_filter_anisotropic/",
+  "https://registry.khronos.org/webgl/extensions/EXT_texture_norm16/",
+  "https://registry.khronos.org/webgl/extensions/KHR_parallel_shader_compile/",
+  "https://registry.khronos.org/webgl/extensions/OES_draw_buffers_indexed/",
+  "https://registry.khronos.org/webgl/extensions/OES_element_index_uint/",
+  "https://registry.khronos.org/webgl/extensions/OES_fbo_render_mipmap/",
+  "https://registry.khronos.org/webgl/extensions/OES_standard_derivatives/",
+  "https://registry.khronos.org/webgl/extensions/OES_texture_float_linear/",
+  "https://registry.khronos.org/webgl/extensions/OES_texture_float/",
+  "https://registry.khronos.org/webgl/extensions/OES_texture_half_float_linear/",
+  "https://registry.khronos.org/webgl/extensions/OES_texture_half_float/",
+  "https://registry.khronos.org/webgl/extensions/OES_vertex_array_object/",
+  "https://registry.khronos.org/webgl/extensions/OVR_multiview2/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_color_buffer_float/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_etc/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_etc1/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_s3tc/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_debug_renderer_info/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_debug_shaders/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_depth_texture/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_draw_buffers/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_lose_context/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw/",
+  {
+    "url": "https://registry.khronos.org/webgl/specs/latest/1.0/",
+    "shortname": "webgl1",
+    "series": {
+      "shortname": "webgl1"
+    },
+    "nightly": {
+      "sourcePath": "specs/latest/1.0/index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites/1.0.3"
+      ]
+    }
+  },
+  {
+    "url": "https://registry.khronos.org/webgl/specs/latest/2.0/",
+    "shortname": "webgl2",
+    "series": {
+      "shortname": "webgl2"
+    },
+    "nightly": {
+      "sourcePath": "specs/latest/2.0/index.html"
+    },
+    "tests": {
+      "repository": "https://github.com/KhronosGroup/WebGL",
+      "testPaths": [
+        "conformance-suites/2.0.0"
+      ]
+    }
+  },
   "https://storage.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",
   "https://svgwg.org/specs/animations/",
@@ -304,80 +378,6 @@
   "https://wicg.github.io/webpackage/loading.html",
   "https://wicg.github.io/webusb/",
   "https://wicg.github.io/window-controls-overlay/",
-  "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_clip_cull_distance/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/",
-  "https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/",
-  "https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_draw_buffers_indexed/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_texture_float/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/",
-  "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
-  "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
-  "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
-  {
-    "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
-    "shortname": "webgl1",
-    "series": {
-      "shortname": "webgl1"
-    },
-    "nightly": {
-      "sourcePath": "specs/latest/1.0/index.html"
-    },
-    "tests": {
-      "repository": "https://github.com/KhronosGroup/WebGL",
-      "testPaths": [
-        "conformance-suites/1.0.3"
-      ]
-    }
-  },
-  {
-    "url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/",
-    "shortname": "webgl2",
-    "series": {
-      "shortname": "webgl2"
-    },
-    "nightly": {
-      "sourcePath": "specs/latest/2.0/index.html"
-    },
-    "tests": {
-      "repository": "https://github.com/KhronosGroup/WebGL",
-      "testPaths": [
-        "conformance-suites/2.0.0"
-      ]
-    }
-  },
   {
     "url": "https://www.rfc-editor.org/rfc/rfc2397",
     "groups": [

--- a/specs.json
+++ b/specs.json
@@ -86,18 +86,6 @@
   "https://privacycg.github.io/private-click-measurement/",
   "https://privacycg.github.io/storage-access/",
   "https://quirks.spec.whatwg.org/",
-  {
-    "url": "https://sourcemaps.info/spec.html",
-    "shortname": "sourcemap",
-    "shortTitle": "Source Map",
-    "organization": "sourcemaps.info",
-    "groups": [
-      {
-        "name": "sourcemaps.info",
-        "url": "https://sourcemaps.info/"
-      }
-    ]
-  },
   "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
   "https://registry.khronos.org/webgl/extensions/EXT_blend_minmax/",
   "https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/",
@@ -171,6 +159,18 @@
         "conformance-suites/2.0.0"
       ]
     }
+  },
+  {
+    "url": "https://sourcemaps.info/spec.html",
+    "shortname": "sourcemap",
+    "shortTitle": "Source Map",
+    "organization": "sourcemaps.info",
+    "groups": [
+      {
+        "name": "sourcemaps.info",
+        "url": "https://sourcemaps.info/"
+      }
+    ]
   },
   "https://storage.spec.whatwg.org/",
   "https://streams.spec.whatwg.org/",

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -64,7 +64,7 @@ function computeShortname(url) {
 
 
     // Handle Khronos extensions
-    const khronos = url.match(/https:\/\/www\.khronos\.org\/registry\/webgl\/extensions\/([^\/]+)\/$/);
+    const khronos = url.match(/https:\/\/registry\.khronos\.org\/webgl\/extensions\/([^\/]+)\/$/);
     if (khronos) {
         return khronos[1];
     }
@@ -148,7 +148,7 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
   // Shortnames of WebGL extensions sometimes end up with digits which are *not*
   // to be interpreted as level numbers. Similarly, shortnames of ECMA specs
   // typically have the form "ecma-ddd", and "ddd" is *not* a level number.
-  if (seriesBasename.match(/^ecma-/) || url.match(/^https:\/\/www\.khronos\.org\/registry\/webgl\/extensions\//)) {
+  if (seriesBasename.match(/^ecma-/) || url.match(/^https:\/\/registry\.khronos\.org\/webgl\/extensions\//)) {
     return {
       shortname: specShortname,
       series: { shortname: seriesBasename }

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -141,7 +141,7 @@ module.exports = async function (specs, options) {
       return Object.assign(info, spec.tests);
     }
 
-    if (spec.url.startsWith("https://www.khronos.org/")) {
+    if (spec.url.startsWith("https://registry.khronos.org/")) {
       info.repository = "https://github.com/KhronosGroup/WebGL";
       info.testPaths = ["conformance-suites"];
       // TODO: Be more specific, tests for extensions should one of the files in:

--- a/src/parse-spec-url.js
+++ b/src/parse-spec-url.js
@@ -55,7 +55,7 @@ module.exports = function (url) {
     return { type: "custom", owner: "w3c", name: "svgwg" };
   }
 
-  const webgl = url.match(/^https:\/\/www\.khronos\.org\/registry\/webgl\//);
+  const webgl = url.match(/^https:\/\/registry\.khronos\.org\/webgl\//);
   if (webgl) {
     return { type: "custom", owner: "khronosgroup", name: "WebGL" };
   }

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -70,7 +70,7 @@ describe("compute-repository module", async () => {
 
   it("handles WebGL URLs", async () => {
     assert.equal(
-      await computeSingleRepo("https://www.khronos.org/registry/webgl/specs/latest/1.0/"),
+      await computeSingleRepo("https://registry.khronos.org/webgl/specs/latest/1.0/"),
       "https://github.com/khronosgroup/WebGL");
   });
 

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -21,7 +21,7 @@ describe("compute-shortname module", () => {
     });
 
     it("handles Khronos Group WebGL extensions", () => {
-      assertName("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/", "EXT_wow32");
+      assertName("https://registry.khronos.org/webgl/extensions/EXT_wow32/", "EXT_wow32");
     });
 
     it("handles URLs of drafts on GitHub", () => {
@@ -155,7 +155,7 @@ describe("compute-shortname module", () => {
     });
 
     it("preserves digits at the end of WebGL extension names", () => {
-      assertSeries("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/", "EXT_wow32");
+      assertSeries("https://registry.khronos.org/webgl/extensions/EXT_wow32/", "EXT_wow32");
     });
 
     it("handles forks", () => {
@@ -211,7 +211,7 @@ describe("compute-shortname module", () => {
     });
 
     it("does not confuse digits at the end of a WebGL extension spec with a series version", () => {
-      assertNoSeriesVersion("https://www.khronos.org/registry/webgl/extensions/EXT_wow32/");
+      assertNoSeriesVersion("https://registry.khronos.org/webgl/extensions/EXT_wow32/");
     });
 
     it("handles forks", () => {

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -31,7 +31,7 @@ describe("fetch-groups module (without API keys)", function () {
   });
 
   it("handles WebGL URLs", async () => {
-    const res = await fetchGroupsFor("https://www.khronos.org/registry/webgl/extensions/EXT_clip_cull_distance/");
+    const res = await fetchGroupsFor("https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/");
     assert.equal(res.organization, "Khronos Group");
     assert.deepStrictEqual(res.groups, [{
       name: "WebGL Working Group",


### PR DESCRIPTION
All https://www.khronos.org/registry/ URLs now redirect to https://registry.khronos.org/ equivalents.