### PR TITLE
Update HTTP Core spec URLs (RFCs 9110, 9111, 9112, 9113, 9114)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -432,9 +432,7 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9112",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9112.html",
-      "repository": "https://github.com/httpwg/httpwg.github.io",
-      "sourcePath": "specs/rfc9112.xml"
+      "url": "https://httpwg.org/specs/rfc9112.html"
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -420,9 +420,7 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9110",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9110.html",
-      "repository": "https://github.com/httpwg/httpwg.github.io",
-      "sourcePath": "specs/rfc9110.xml"
+      "url": "https://httpwg.org/specs/rfc9110.html"
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -438,9 +438,7 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9113",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9113.html",
-      "repository": "https://github.com/httpwg/httpwg.github.io",
-      "sourcePath": "specs/rfc9113.xml"
+      "url": "https://httpwg.org/specs/rfc9113.html"
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -426,9 +426,7 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9111",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9111.html",
-      "repository": "https://github.com/httpwg/httpwg.github.io",
-      "sourcePath": "specs/rfc9111.xml"
+      "url": "https://httpwg.org/specs/rfc9111.html"
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -444,9 +444,7 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9114",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9114.html",
-      "repository": "https://github.com/httpwg/httpwg.github.io",
-      "sourcePath": "specs/rfc9114.xml"
+      "url": "https://httpwg.org/specs/rfc9114.html"
     }
   },
   {

--- a/specs.json
+++ b/specs.json
@@ -418,6 +418,46 @@
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
   {
+    "url": "https://www.rfc-editor.org/rfc/rfc9110",
+    "nightly": {
+      "url": "https://httpwg.org/specs/rfc9110.html",
+      "repository": "https://github.com/httpwg/httpwg.github.io",
+      "sourcePath": "specs/rfc9110.xml"
+    }
+  },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc9111",
+    "nightly": {
+      "url": "https://httpwg.org/specs/rfc9111.html",
+      "repository": "https://github.com/httpwg/httpwg.github.io",
+      "sourcePath": "specs/rfc9111.xml"
+    }
+  },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc9112",
+    "nightly": {
+      "url": "https://httpwg.org/specs/rfc9112.html",
+      "repository": "https://github.com/httpwg/httpwg.github.io",
+      "sourcePath": "specs/rfc9112.xml"
+    }
+  },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc9113",
+    "nightly": {
+      "url": "https://httpwg.org/specs/rfc9113.html",
+      "repository": "https://github.com/httpwg/httpwg.github.io",
+      "sourcePath": "specs/rfc9113.xml"
+    }
+  },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc9114",
+    "nightly": {
+      "url": "https://httpwg.org/specs/rfc9114.html",
+      "repository": "https://github.com/httpwg/httpwg.github.io",
+      "sourcePath": "specs/rfc9114.xml"
+    }
+  },
+  {
     "url": "https://www.w3.org/Consortium/Patent-Policy/",
     "shortname": "w3c-patent-policy",
     "organization": "W3C",


### PR DESCRIPTION
I first tried just adding only the https://www.rfc-editor.org/rfc URLs for these — without also explicitly specifying the “nightly” URLs — but after running “npm run build”, I found that the build script doesn’t automatically pick up the https://httpwg.org/specs URLs as the nightly URLs.