### PR TITLE
Force level in nightly URLs of CSS specs

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -156,6 +156,17 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
       }
     });
 
+    // Latest ED link in TR versions of CSS specs sometimes target the spec series
+    // entry point on the CSS drafts server. To make sure that the nightly URL
+    // targets the same level as the TR level we're looking at, we'll add the
+    // level to the nightly URL when it's not already there (note the resulting
+    // URL should always exist given the way the CSS drafts server is setup)
+    if (res.seriesVersion &&
+        res.nightly.url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org/) &&
+        !res.nightly.url.match(/\d+\/$/)) {
+      res.nightly.url = res.nightly.url.replace(/\/$/, `-${res.seriesVersion}/`);
+    }
+
     // Set the series title based on the info returned by the W3C API if
     // we have it, or compute the series title ourselves
     const seriesInfo = specInfo.__series[spec.series.shortname];


### PR DESCRIPTION
This makes sure that `nightly.url` contains the level (i.e. `seriesVersion`) of the specs for CSS specs, to avoid running into issues where we think we're crawling a specific level but actually get redirected to another level.

Closes #675.

This will typically add the level to the nightly URL of the following specs:

- css-align-3
- css-animations-1
- css-backgrounds-3
- css-break-3
- css-color-4
- css-counter-styles-3
- css-device-adapt-1
- css-display-3
- css-easing-1
- css-font-loading-3
- css-gcpm-3
- css-line-grid-1
- css-multicol-1
- css-namespaces-3
- css-nesting-1
- css-page-floats-3
- css-position-3
- css-regions-1
- css-rhythm-1
- css-round-display-1
- css-scoping-1
- css-scroll-anchoring-1
- css-scrollbars-1
- css-shadow-parts-1
- css-shapes-2
- css-syntax-3
- css-transforms-1
- css-transitions-1
- css-variables-1
- css-will-change-1
- cssom-1
- cssom-view-1
- fill-stroke-3
- geometry-1
- resize-observer-1
- selectors-4