### PR TITLE
Add CSS Shared Elements Transitions

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -48,6 +48,7 @@
   "https://drafts.csswg.org/css-page-4/ delta",
   "https://drafts.csswg.org/css-scroll-snap-2/ delta",
   "https://drafts.csswg.org/css-shapes-2/ delta",
+  "https://drafts.csswg.org/css-shared-element-transitions-1/",
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
     "shortTitle": "CSS Size Adjustment 1"


### PR DESCRIPTION
Spec adopted by the CSS WG. Fixes #699.

This will add:

```json
{
  "url": "https://drafts.csswg.org/css-shared-element-transitions-1/",
  "seriesComposition": "full",
  "shortname": "css-shared-element-transitions-1",
  "series": {
    "shortname": "css-shared-element-transitions",
    "currentSpecification": "css-shared-element-transitions-1",
    "title": "CSS Shared Element Transitions",
    "shortTitle": "CSS Shared Element Transitions",
    "nightlyUrl": "https://drafts.csswg.org/css-shared-element-transitions/"
  },
  "seriesVersion": "1",
  "organization": "W3C",
  "groups": [
    {
      "name": "Cascading Style Sheets (CSS) Working Group",
      "url": "https://www.w3.org/Style/CSS/"
    }
  ],
  "nightly": {
    "url": "https://drafts.csswg.org/css-shared-element-transitions-1/",
    "repository": "https://github.com/w3c/csswg-drafts",
    "sourcePath": "css-shared-element-transitions-1/Overview.bs",
    "filename": "Overview.html"
  },
  "title": "CSS Shared Element Transitions Module Level 1",
  "source": "spec",
  "shortTitle": "CSS Shared Element Transitions 1",
  "categories": [
    "browser"
  ]
}
```