### PR TITLE
Add a new alternateUrls property and use it for CSS drafts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ to specify the list of groups that develop or developed the spec.
     **and** when it cannot be fixed at the source.
   - The code cannot compute the right [`sourcePath`](README.md#nightlysourcepath)
     because the source file of the nightly spec does not follow a common pattern.
+  - One or more alternate URLs, used in external sources, need to be recorded in
+    an [`alternateUrls`](README.md#nightlyalternateurls) property (note the
+    `w3c.github.io` URL of CSS drafts is automatically added as an alternate
+    URL, no need to specify it in `specs.json`)
 - `tests`: same as the [`tests`](README.md#tests) property in `index.json`. The
 property must only be set when:
   - The test suite of the specification is not in a well-known repository.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cross-references, WebIDL, quality, etc.
     - [`release.pages`](#releasepages)
   - [`nightly`](#nightly)
     - [`nightly.url`](#nightlyurl)
+    - [`nightly.alternateUrls`](#nightlyalternateurls)
     - [`nightly.filename`](#nightlyfilename)
     - [`nightly.pages`](#nightlypages)
     - [`nightly.repository`](#nightlyrepository)
@@ -409,6 +410,28 @@ neither exist in the W3C API nor in Specref. The [`source`](#source) property
 details the actual provenance.
 
 The `url` property is always set.
+
+
+#### `nightly.alternateUrls`
+
+A list of alternate URLs for the Editor's Draft or the living standard.
+
+The list typically contains URLs that external sources may use to reference the
+spec, be it because the canonical URL evolved over time and sources still use
+old URLs (e.g. when the spec was incubated in a Community Group and transitioned
+to a Working Group), or because the canonical URL is unstable for some reason
+and external sources decided to use a workaround (e.g. CSS drafts).
+
+Alternate URLs should only be used to ease mapping between external sources and
+specs in `browser-specs`. The canonical URL in [`nightly.url`](#nightlyurl)
+should be preferred to reference a spec otherwise.
+
+Alternate URLs are only set when needed, meaning when an alternate URL is
+effectively in use in some external source and when the external source cannot
+easily be updated to use the canonical URL. In particular, the list is not meant
+to be exhaustive.
+
+The `alternateUrls` property is always set and is often an empty array.
 
 
 #### `nightly.filename`

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -81,6 +81,10 @@
       "type": "object",
       "properties": {
         "url": { "$ref": "#/$defs/url" },
+        "alternateUrls": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/url" }
+        },
         "filename": { "$ref": "#/$defs/filename" },
         "sourcePath": { "$ref": "#/$defs/relativePath" },
         "pages": {

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -167,6 +167,14 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
       res.nightly.url = res.nightly.url.replace(/\/$/, `-${res.seriesVersion}/`);
     }
 
+    // Add alternate w3c.github.io URLs for CSS specs
+    // (Note drafts of CSS Houdini and Visual effects task forces don't have a
+    // w3c.github.io version)
+    res.nightly.alternateUrls = res.nightly.alternateUrls || [];
+    if (res.nightly.url.match(/\/drafts\.csswg\.org/)) {
+      res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${res.shortname}/`);
+    }
+
     // Set the series title based on the info returned by the W3C API if
     // we have it, or compute the series title ourselves
     const seriesInfo = specInfo.__series[spec.series.shortname];

--- a/test/index.js
+++ b/test/index.js
@@ -189,4 +189,11 @@ describe("List of specs", () => {
         spec.forkOf === s.shortname)));
     assert.deepStrictEqual(wrong, []);
   });
+
+  it("has a w3c.github.io alternate URL for CSS drafts", () => {
+    const wrong = specs
+      .filter(s => s.nightly.url.match(/\/drafts\.csswg\.org/))
+      .filter(s => !s.nightly.alternateUrls.includes(`https://w3c.github.io/csswg-drafts/${s.shortname}/`));
+    assert.deepStrictEqual(wrong, []);
+  });
 });


### PR DESCRIPTION
This records the `w3c.github.io` URL for CSS drafts in a new `alternateUrls` property under `nightly`. See context in #704.

That property is an array as the mechanism could be used to record nightly URLs used by a spec throughout its development. The code automatically adds the w3c.github.io URL for CSS drafts.

One possible question: A spec already published in /TR could get a new shortname. Since the array is under `nightly`, this cannot really be used to record the previous /TR URL. Should this `alternateUrls` property rather be moved to the root (but then how to distinguish between alternate URLs for the nightly and release versions of the spec)? Or would we add an `alternateUrls` property under `release` as well if we ever want to track that?

Notes:
- creating the PR as draft as I couldn't test this thoroughly because... CSS drafts server is down.
- CI tests will fail in any case until a new index is generated because of the new test that checks the presence of the `alternateUrls` property