### PR TITLE
Use uppercase HEAD in diff script

### DIFF
--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -89,7 +89,7 @@ async function compareIndex(newRef, baseRef, { diffType = "diff", log = console.
 Main loop
 *******************************************************************************/
 const newRef = process.argv[2] ?? "working";
-const baseRef = process.argv[3] ?? "head";
+const baseRef = process.argv[3] ?? "HEAD";
 const diffType = process.argv[4] ?? "diff";
 
 compareIndex(newRef, baseRef, { diffType, log: console.warn })


### PR DESCRIPTION
branch names are case sensitive (in linux at least)