### PR TITLE
Add FIDO CTAP spec to the list

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -10,7 +10,7 @@
 
     "filename": {
       "type": "string",
-      "pattern": "^[\\w\\-]+\\.html$"
+      "pattern": "^[\\w\\-\\.]+\\.html$"
     },
 
     "relativePath": {
@@ -20,7 +20,7 @@
 
     "shortname": {
       "type": "string",
-      "pattern": "^[\\w\\-]+((?<=-\\d+)\\.\\d+)?$"
+      "pattern": "^[\\w\\-]+((?<=-v?\\d+)\\.\\d+)?$"
     },
 
     "series": {

--- a/specs.json
+++ b/specs.json
@@ -79,7 +79,7 @@
     "organization": "FIDO Alliance",
     "groups": [
       {
-        "name": "FIDO Alliance",
+        "name": "FIDO2 Technical Working Group",
         "url": "https://fidoalliance.org/"
       }
     ]

--- a/specs.json
+++ b/specs.json
@@ -73,6 +73,17 @@
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://fedidcg.github.io/FedCM/",
   "https://fetch.spec.whatwg.org/",
+  {
+    "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
+    "shortname": "fido-v2.1",
+    "organization": "FIDO Alliance",
+    "groups": [
+      {
+        "name": "FIDO Alliance",
+        "url": "https://fidoalliance.org/"
+      }
+    ]
+  },
   "https://fs.spec.whatwg.org/",
   "https://fullscreen.spec.whatwg.org/",
   {

--- a/specs.json
+++ b/specs.json
@@ -80,7 +80,7 @@
     "groups": [
       {
         "name": "FIDO2 Technical Working Group",
-        "url": "https://fidoalliance.org/"
+        "url": "https://fidoalliance.org/members/working-groups/#fido2-technical-working-group"
       }
     ]
   },

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -117,7 +117,7 @@ function computeShortname(url) {
   // Latin characters (a-z letters, digits, underscore and "-"), and that it
   // only contains a dot for fractional levels at the end of the name
   // (e.g. "blah-1.2" is good but "blah.blah" and "blah-3.1-blah" are not)
-  if (!name.match(/^[\w\-]+((?<=\-\d+)\.\d+)?$/)) {
+  if (!name.match(/^[\w\-]+((?<=\-v?\d+)\.\d+)?$/)) {
     throw `Specification name contains unexpected characters: ${name} (extracted from ${url})`;
   }
 
@@ -157,7 +157,7 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
 
   // Extract X and X.Y levels, with form "name-X" or "name-X.Y".
   // (e.g. 5 for "mediaqueries-5", 1.2 for "wai-aria-1.2")
-  let match = seriesBasename.match(/^(.*?)-(\d+)(.\d+)?$/);
+  let match = seriesBasename.match(/^(.*?)-v?(\d+)(.\d+)?$/);
   if (match) {
     return {
       shortname: specShortname,

--- a/test/index.js
+++ b/test/index.js
@@ -138,21 +138,23 @@ describe("List of specs", () => {
   });
 
   it("contains repository URLs for all non IETF specs", () => {
-    // No repo for the Patent Policy document either
+    // Some more exceptions to the rule
     const wrong = specs.filter(s => !s.nightly.repository &&
       !s.nightly.url.match(/rfc-editor\.org/) &&
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
-      !s.nightly.url.match(/\/sourcemaps\.info\//));
+      !s.nightly.url.match(/\/sourcemaps\.info\//) &&
+      !s.nightly.url.match(/fidoalliance\.org\//));
     assert.deepStrictEqual(wrong, []);
   });
 
   it("contains relative paths to source of nightly spec for all non IETF specs", () => {
-    // No repo for the Patent Policy document either
+    // Some more exceptions to the rule
     const wrong = specs.filter(s => !s.nightly.sourcePath &&
       !s.nightly.url.match(/rfc-editor\.org/) &&
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
       !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/) &&
-      !s.nightly.url.match(/\/sourcemaps\.info\//));
+      !s.nightly.url.match(/\/sourcemaps\.info\//) &&
+      !s.nightly.url.match(/fidoalliance\.org\//));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
This adds the FIDO Client to Authenticator Protocol spec to the list, following discussions in #708.

The latest revision of the spec seems to be the Proposed Standard, not the review draft mentioned in the issue. This adds the version that includes errata.

Organization and group info are explicitly provided in `specs.json`. We may consider custom logic when and if we add more FIDO specs.

The shortname used by the FIDO Alliance uses a slightly different convention than other shortnames, adding a `v` before the version number: `fido-v2.1`. The shortname schema had to be relaxed accordingly.

Similarly, the filename schema had to be relaxed to also accept `.` characters.

Conceptually, these schema changes are breaking. Practically speaking, should we still consider them as minor changes?

The spec links to a GitHub repository that does not exist, or more probably that isn't public, so no repository.

This would add the following entry:

```json
{
  "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
  "seriesComposition": "full",
  "shortname": "fido-v2.1",
  "series": {
    "shortname": "fido",
    "currentSpecification": "fido-v2.1",
    "title": "Client to Authenticator Protocol (CTAP)",
    "shortTitle": "CTAP",
    "nightlyUrl": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html"
  },
  "seriesVersion": "2.1",
  "organization": "FIDO Alliance",
  "groups": [
    {
      "name": "FIDO Alliance",
      "url": "https://fidoalliance.org/"
    }
  ],
  "nightly": {
    "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
    "alternateUrls": [],
    "filename": "fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html"
  },
  "title": "Client to Authenticator Protocol (CTAP)",
  "source": "spec",
  "shortTitle": "CTAP",
  "categories": [
    "browser"
  ]
}
```