### PR TITLE
Test unicity of sourcePath and fix duplication in SVG11 entry

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -893,8 +893,7 @@
     "url": "https://www.w3.org/TR/SVG11/",
     "multipage": true,
     "nightly": {
-      "url": "https://www.w3.org/TR/SVG11/",
-      "repository": "https://github.com/w3c/svgwg"
+      "url": "https://www.w3.org/TR/SVG11/"
     }
   },
   "https://www.w3.org/TR/SVG2/ multipage",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -146,6 +146,10 @@ module.exports = async function (specs, options) {
   }
 
   async function isRealRepo(repo) {
+    if (!options.githubToken) {
+      // Assume the repo exists if we can't check
+      return true;
+    }
     const cacheKey = `${repo.owner}/${repo.name}`;
     if (!repoCache.has(cacheKey)) {
       try {

--- a/test/index.js
+++ b/test/index.js
@@ -143,7 +143,8 @@ describe("List of specs", () => {
       !s.nightly.url.match(/rfc-editor\.org/) &&
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
       !s.nightly.url.match(/\/sourcemaps\.info\//) &&
-      !s.nightly.url.match(/fidoalliance\.org\//));
+      !s.nightly.url.match(/fidoalliance\.org\//) &&
+      s.shortname !== 'SVG11');
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -154,7 +155,8 @@ describe("List of specs", () => {
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
       !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/) &&
       !s.nightly.url.match(/\/sourcemaps\.info\//) &&
-      !s.nightly.url.match(/fidoalliance\.org\//));
+      !s.nightly.url.match(/fidoalliance\.org\//) &&
+      s.shortname !== 'SVG11');
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -197,5 +199,17 @@ describe("List of specs", () => {
       .filter(s => s.nightly.url.match(/\/drafts\.csswg\.org/))
       .filter(s => !s.nightly.alternateUrls.includes(`https://w3c.github.io/csswg-drafts/${s.shortname}/`));
     assert.deepStrictEqual(wrong, []);
+  });
+
+  it("has distinct source paths for all specs", () => {
+    // ... provided entries don't share the same nightly draft
+    // (typically the case for CSS 2.1 and CSS 2.2)
+    const wrong = specs.filter(s =>
+      s.nightly.repository && s.nightly.sourcePath &&
+      specs.find(spec => spec !== s &&
+        spec.nightly.url !== s.nightly.url &&
+        spec.nightly.repository === s.nightly.repository &&
+        spec.nightly.sourcePath === s.nightly.sourcePath));
+    assert.deepStrictEqual(wrong, [], JSON.stringify(wrong, null, 2));
   });
 });


### PR DESCRIPTION
This adds a test to ensure that we cannot have two different nightly versions of a spec that target the same repo and source path.

This typically happened with SVG11 and SVG2. The SVG11 entry incorrectly reported that its source is to be found in the w3c/svgwg repository. This update drops the association with that repository... and updates the underlying code in `compute-repository` not to take for granted that hypothetical repositories returned by `parseSpecUrl` actually exist.

This fixes #418.