### PR TITLE
Adjust alternate urls

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -49,7 +49,7 @@
   "https://drafts.csswg.org/css-page-4/ delta",
   "https://drafts.csswg.org/css-scroll-snap-2/ delta",
   "https://drafts.csswg.org/css-shapes-2/ delta",
-  "https://drafts.csswg.org/css-shared-element-transitions-1/",
+  "https://drafts.csswg.org/css-view-transitions-1/",
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
     "shortTitle": "CSS Size Adjustment 1"

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -198,11 +198,16 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
     // Add alternate w3c.github.io URLs for CSS specs
     // (Note drafts of CSS Houdini and Visual effects task forces don't have a
     // w3c.github.io version)
+    // (Also note the CSS WG uses the "css" series shortname for CSS snapshots
+    // and not for the CSS 2.x series)
     res.nightly.alternateUrls = res.nightly.alternateUrls || [];
     if (res.nightly.url.match(/\/drafts\.csswg\.org/)) {
-      res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${res.shortname}/`);
-      if ((res.series.currentSpecification === res.shortname) && (res.shortname !== res.series.shortname)) {
-        res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${res.series.shortname}/`);
+      const draft = computeShortname(res.nightly.url);
+      res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
+      if ((res.series.currentSpecification === res.shortname) &&
+          (draft.shortname !== draft.series.shortname) &&
+          (draft.series.shortname !== 'css')) {
+        res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ const assert = require("assert");
 const specs = require("../index.json");
 const schema = require("../schema/index.json");
 const dfnsSchema = require("../schema/definitions.json");
+const computeShortname = require("../src/compute-shortname");
 const Ajv = require("ajv");
 const addFormats = require("ajv-formats")
 const ajv = new Ajv();
@@ -197,7 +198,11 @@ describe("List of specs", () => {
   it("has a w3c.github.io alternate URL for CSS drafts", () => {
     const wrong = specs
       .filter(s => s.nightly.url.match(/\/drafts\.csswg\.org/))
-      .filter(s => !s.nightly.alternateUrls.includes(`https://w3c.github.io/csswg-drafts/${s.shortname}/`));
+      .filter(s => {
+        const draft = computeShortname(s.nightly.url);
+        return !s.nightly.alternateUrls.includes(
+          `https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
+      });
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
3 updates in 1:
- [Rename css-shared-element-transitions-1 to css-view-transitions-1](https://github.com/w3c/browser-specs/commit/3faf1fc7000ff9eefa76ba9a75781366ce2e2399)
- [Fetch alternate URL for CSS drafts](https://github.com/w3c/browser-specs/commit/37d1020c11b33529745abaea33c0dae25fe3d086)
- [Use draft shortname for alternateUrls of CSS specs](https://github.com/w3c/browser-specs/commit/a659bcb19e504ecb65d63d57a5748e74d5735d53). This fixes #730
