### PR TITLE
Adjust URL of Resource Timing, ignore Image Maps

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -49,7 +49,6 @@
   "https://drafts.csswg.org/css-page-4/ delta",
   "https://drafts.csswg.org/css-scroll-snap-2/ delta",
   "https://drafts.csswg.org/css-shapes-2/ delta",
-  "https://drafts.csswg.org/css-view-transitions-1/",
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
     "shortTitle": "CSS Size Adjustment 1"
@@ -64,6 +63,7 @@
     "url": "https://drafts.csswg.org/css-variables-2/",
     "shortTitle": "CSS Variables 2"
   },
+  "https://drafts.csswg.org/css-view-transitions-1/",
   "https://drafts.csswg.org/scroll-animations-1/",
   "https://drafts.csswg.org/web-animations-2/ delta",
   {

--- a/specs.json
+++ b/specs.json
@@ -870,7 +870,7 @@
   "https://www.w3.org/TR/requestidlecallback/",
   "https://www.w3.org/TR/resize-observer-1/",
   "https://www.w3.org/TR/resource-hints/",
-  "https://www.w3.org/TR/resource-timing-2/",
+  "https://www.w3.org/TR/resource-timing/",
   "https://www.w3.org/TR/screen-capture/",
   "https://www.w3.org/TR/screen-orientation/",
   "https://www.w3.org/TR/screen-wake-lock/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -217,6 +217,9 @@
     },
     "WICG/floc": {
       "comment": "proposal replaced by the Topics API"
+    },
+    "WICG/import-maps": {
+      "comment": "folded into HTML (and redirects to it)"
     }
   },
   "specs": {


### PR DESCRIPTION
- Resource Timing no longer uses levels.
- Image Maps got folded into HTML and now redirects to it.

This fixes #736, #737.