### PR TITLE
Add TC39 RegExp modifiers, monitor Pending Beacon

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -261,6 +261,12 @@
   },
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-json-parse-with-source/",
+  {
+    "url": "https://tc39.es/proposal-regexp-modifiers/",
+    "nightly": {
+      "sourcePath": "spec.emu"
+    }
+  },
   "https://tc39.es/proposal-resizablearraybuffer/",
   "https://tc39.es/proposal-shadowrealm/",
   {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -381,6 +381,9 @@
     },
     "https://w3c.github.io/device-memory/": {
       "comment": "Already in the list. Code gets confused because TR spec links to itself as ED"
+    },
+    "https://www.w3.org/TR/resource-timing-1/": {
+      "comment": "Level-less spec is in the list, no need to track old Level 1 spec"
     }
   }
 }

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -315,6 +315,10 @@
     "w3c/rch-rdh": {
       "lastreviewed": "2022-10-17",
       "comment": "empty spec for now"
+    },
+    "WICG/pending-beacon": {
+      "lastreviewed": "2022-10-24",
+      "comment": "Origin trial in Chrome but spec still flagged as unofficial proposal draft"
     }
   },
   "specs": {


### PR DESCRIPTION
This update also adds the `resource-timing-1` spec to the ignore list (we have `resource-timing` in the list, level version exists for historical reasons).
Fixes #751.