### PR TITLE
Add RFC8288 support

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -434,6 +434,7 @@
   "https://www.rfc-editor.org/rfc/rfc7725",
   "https://www.rfc-editor.org/rfc/rfc7838",
   "https://www.rfc-editor.org/rfc/rfc8246",
+  "https://www.rfc-editor.org/rfc/rfc8288",
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
   {

--- a/specs.json
+++ b/specs.json
@@ -434,7 +434,15 @@
   "https://www.rfc-editor.org/rfc/rfc7725",
   "https://www.rfc-editor.org/rfc/rfc7838",
   "https://www.rfc-editor.org/rfc/rfc8246",
-  "https://www.rfc-editor.org/rfc/rfc8288",
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc8288",
+    "groups": [
+      {
+        "name": "Mark Nottingham (individual in art area)",
+        "url": "https://datatracker.ietf.org/person/mnot@mnot.net"
+      }
+    ]
+  },
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
   {


### PR DESCRIPTION
[RFC8288](https://www.rfc-editor.org/rfc/rfc8288) is now a proposed standard, would be nice to have it here. Contents of the RFC (Link header) already implemented in Chrome.