### PR TITLE
Add https://www.w3.org/TR/test-methodology/

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -934,6 +934,7 @@
     }
   },
   "https://www.w3.org/TR/SVG2/ multipage",
+  "https://www.w3.org/TR/test-methodology/",
   "https://www.w3.org/TR/timing-entrytypes-registry/",
   "https://www.w3.org/TR/touch-events/",
   {


### PR DESCRIPTION
I believe that this document is eligible under criterion 4, specifically "*it contains informative content that other specs often need to refer to (e.g. guidelines from horizontal activities such as accessibility, internationalization, privacy and security)*." I discovered that it was missing by trying to reference the `dfn` for `testable assertion` which I believe to be a rather central concept.