### PR TITLE
Add rdf-canon and RDF specs it references

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -883,6 +883,15 @@
   "https://www.w3.org/TR/mixed-content/",
   "https://www.w3.org/TR/motion-1/",
   "https://www.w3.org/TR/mst-content-hint/",
+  {
+    "url": "https://www.w3.org/TR/n-quads/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/n-quads/"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://www.w3.org/TR/navigation-timing-2/",
   "https://www.w3.org/TR/network-error-logging-1/",
   "https://www.w3.org/TR/openscreenprotocol/",
@@ -902,6 +911,39 @@
   "https://www.w3.org/TR/presentation-api/",
   "https://www.w3.org/TR/proximity/",
   "https://www.w3.org/TR/push-api/",
+  {
+    "url": "https://www.w3.org/TR/rdf-canon/",
+    "nightly": {
+      "url": "https://w3c.github.io/rdf-canon/spec/"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/rdf11-concepts/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/rdf11-concepts/"
+    },
+    "series": {
+      "shortname": "rdf-concepts"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/rdf11-mt/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/rdf11-mt/"
+    },
+    "series": {
+      "shortname": "rdf-mt"
+    },
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://www.w3.org/TR/referrer-policy/",
   "https://www.w3.org/TR/remote-playback/",
   "https://www.w3.org/TR/reporting-1/",

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,15 @@ const addFormats = require("ajv-formats")
 const ajv = new Ajv();
 addFormats(ajv);
 
+// Some old specs that don't have a spec
+const noRepo = [
+  'SVG11',
+  'test-methodology',
+  'rdf11-concepts',
+  'rdf11-mt',
+  'n-quads'
+];
+
 
 describe("List of specs", () => {
   it("has a valid JSON schema", () => {
@@ -145,7 +154,7 @@ describe("List of specs", () => {
       !s.nightly.url.match(/\/Consortium\/Patent-Policy\/$/) &&
       !s.nightly.url.match(/\/sourcemaps\.info\//) &&
       !s.nightly.url.match(/fidoalliance\.org\//) &&
-      s.shortname !== 'SVG11');
+      !noRepo.includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -157,7 +166,7 @@ describe("List of specs", () => {
       !s.nightly.url.match(/tc39\.es\/proposal\-decorators\/$/) &&
       !s.nightly.url.match(/\/sourcemaps\.info\//) &&
       !s.nightly.url.match(/fidoalliance\.org\//) &&
-      s.shortname !== 'SVG11');
+      !noRepo.includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
Also adds these specs (and test-methodology) to the list of specs for which we should not expect to find any repository or source path, because they don't have any.

This would fix #776.