### PR TITLE
Add Client Hint Reliability IETF draft

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -7,6 +7,22 @@
   },
   "https://console.spec.whatwg.org/",
   {
+    "url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
+    "shortname": "client-hint-reliability",
+    "organization": "IETF",
+    "groups": [
+      {
+        "name": "HTTP Working Group",
+        "url": "https://datatracker.ietf.org/wg/httpbis/"
+      }
+    ],
+    "nightly": {
+      "url": "https://www.ietf.org/archive/id/draft-davidben-http-client-hint-reliability-03.html",
+      "repository": "https://github.com/davidben/http-client-hint-reliability",
+      "sourcePath": "draft-davidben-http-client-hint-reliability.md"
+    }
+  },
+  {
     "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
     "shortname": "digest-headers",
     "organization": "IETF",


### PR DESCRIPTION
Fixes #788.

It is not entirely clear whether the proposal will be officially adopted and eventually published as an RFC, but it seems still somewhat "active" in 2022 (a couple of discussions in the repository), and supported in Chrome.

Linking the proposal to the HTTP Working Group, since that's what the draft says, although the same comment applies here: it is not entirely clear whether the group will officially adopt the draft.

Note: the nightly URL is set to the better-looking HTML version. The URL contains the document's version and will need to be adjusted if a new draft gets published.

This would add the following entry:

```json
{
  "url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
  "seriesComposition": "full",
  "shortname": "client-hint-reliability",
  "series": {
    "shortname": "client-hint-reliability",
    "currentSpecification": "client-hint-reliability",
    "title": "Client Hint Reliability",
    "shortTitle": "Client Hint Reliability",
    "nightlyUrl": "https://www.ietf.org/archive/id/draft-davidben-http-client-hint-reliability-03.html"
  },
  "organization": "IETF",
  "groups": [
    {
      "name": "HTTP Working Group",
      "url": "https://datatracker.ietf.org/wg/httpbis/"
    }
  ],
  "nightly": {
    "url": "https://www.ietf.org/archive/id/draft-davidben-http-client-hint-reliability-03.html",
    "repository": "https://github.com/davidben/http-client-hint-reliability",
    "sourcePath": "draft-davidben-http-client-hint-reliability.md",
    "alternateUrls": [],
    "filename": "draft-davidben-http-client-hint-reliability-03.html"
  },
  "title": "Client Hint Reliability",
  "source": "spec",
  "shortTitle": "Client Hint Reliability",
  "categories": [
    "browser"
  ]
}
```