### PR TITLE
Remove Priority Hints from spec list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -410,7 +410,6 @@
   "https://wicg.github.io/permissions-revoke/",
   "https://wicg.github.io/portals/",
   "https://wicg.github.io/prefer-current-tab/",
-  "https://wicg.github.io/priority-hints/",
   "https://wicg.github.io/private-network-access/",
   "https://wicg.github.io/responsive-image-client-hints/",
   "https://wicg.github.io/sanitizer-api/",


### PR DESCRIPTION
This is being integrated into Fetch and HTML.