### PR TITLE
Force series title for Screen Orientation

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -981,6 +981,7 @@
   {
     "url": "https://www.w3.org/TR/screen-orientation/",
     "series": {
+      "shortname": "screen-orientation",
       "title": "Screen Orientation"
     }
   },

--- a/specs.json
+++ b/specs.json
@@ -978,7 +978,12 @@
   "https://www.w3.org/TR/resource-hints/",
   "https://www.w3.org/TR/resource-timing/",
   "https://www.w3.org/TR/screen-capture/",
-  "https://www.w3.org/TR/screen-orientation/",
+  {
+    "url": "https://www.w3.org/TR/screen-orientation/",
+    "series": {
+      "title": "Screen Orientation"
+    }
+  },
   "https://www.w3.org/TR/screen-wake-lock/",
   "https://www.w3.org/TR/scroll-animations-1/",
   "https://www.w3.org/TR/secure-contexts/",


### PR DESCRIPTION
The title of the spec was recently changed from "The Screen Orientation API" to "Screen Orientation". The series' title has not yet been updated in the W3C API though. This update updates the series title in browser-specs while this gets fixed in the W3C API.