### PR TITLE
Add CSS Link Parameters spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -74,6 +74,7 @@
   },
   "https://drafts.csswg.org/css-grid-3/ delta",
   "https://drafts.csswg.org/css-images-5/ delta",
+  "https://drafts.csswg.org/css-link-params-1/",
   {
     "url": "https://drafts.csswg.org/css-multicol-2/",
     "seriesComposition": "delta",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -358,10 +358,6 @@
       "comment": "Marked as not ready for implementation",
       "lastreviewed": "2022-11-01"
     },
-    "https://drafts.csswg.org/css-link-params/": {
-      "comment": "Draft not rendered by CSS server yet",
-      "lastreviewed": "2022-11-01"
-    },
     "https://drafts.csswg.org/css-page-template-1/": {
       "comment": "Marked as not ready for implementation",
       "lastreviewed": "2022-11-01"


### PR DESCRIPTION
Draft spec is now correctly rendered by CSS server. Fixes #792.