### PR TITLE
Adjust test on base URL for new IETF spec

### DIFF
--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -17,7 +17,8 @@ const problems = specs
   // A subset of the IETF RFCs are crawled from their httpwg.org rendering
   // see https://github.com/tobie/specref/issues/672 and
   // https://github.com/w3c/browser-specs/issues/280
-  .filter(s => !s.nightly || !s.nightly.url.startsWith('https://httpwg.org'))
+  .filter(s => !s.nightly.url.startsWith('https://httpwg.org') &&
+               !s.nightly.url.startsWith('https://www.ietf.org/'))
   .filter(s => (s.release && s.url !== s.release.url) || (!s.release && s.url !== s.nightly.url))
   .map(s => {
     const expected = s.release ? "release" : "nightly";


### PR DESCRIPTION
The job that checks base URLs already had an exception-to-the-rule for IETF specs but the latest one uses a slightly different pattern.

This fixes #793 (by making the tool not report the spec anymore)