### PR TITLE
Add promises-guide, make code handle TAG findings

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -523,6 +523,7 @@
       "sourcePath": "archive/draft-ietf-httpbis-expect-ct.md"
     }
   },
+  "https://www.w3.org/2001/tag/doc/promises-guide",
   {
     "url": "https://www.w3.org/Consortium/Patent-Policy/",
     "shortname": "w3c-patent-policy",

--- a/src/compute-categories.js
+++ b/src/compute-categories.js
@@ -38,10 +38,7 @@ module.exports = function (spec) {
 
   // All specs target browsers by default unless the spec object says otherwise
   if (!requestedCategories.includes("reset")) {
-    // Note (2022-02-08): This assumes that a non browser group that co-owns a
-    // spec disqualifies the spec as a browser spec. This is true today but
-    // potentially wobbly.
-    const browserGroup = !spec.groups.find(group => nonbrowserGroups[group.name]);
+    const browserGroup = spec.groups.find(group => !nonbrowserGroups[group.name]);
     const browserRepo = !spec.nightly?.repository ||
         !nonbrowserRepos[spec.nightly.repository.replace(/^https:\/\/github\.com\//, "")];
     if (browserGroup && browserRepo) {

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -102,6 +102,12 @@ function computeShortname(url) {
       return rfcs[1];
     }
 
+    // Handle TAG findings
+    const tag = url.match(/^https?:\/\/(?:www\.)?w3\.org\/2001\/tag\/doc\/([^\/]+)\/?$/);
+    if (tag) {
+      return tag[1];
+    }
+
     // Return name when one was given
     if (!url.match(/\//)) {
       return url;

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -39,6 +39,9 @@
     "Spatial Data on the Web Working Group": {
       "comment": "specs not targeted at browsers"
     },
+    "Technical Architecture Group": {
+      "comment": "specs not targeted at browsers"
+    },
     "Verifiable Credentials Working Group": {
       "comment": "specs not targeted at browsers"
     },

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -110,6 +110,14 @@ module.exports = async function (specs, options) {
       continue;
     }
 
+    if (info && info.owner === "w3ctag") {
+      spec.groups = spec.groups ?? [{
+        name: "Technical Architecture Group",
+        url: "https://www.w3.org/2001/tag/"
+      }];
+      continue;
+    }
+
     // All specs that remain should be developed by some W3C group.
     spec.organization = spec.organization ?? "W3C";
 

--- a/src/parse-spec-url.js
+++ b/src/parse-spec-url.js
@@ -70,5 +70,10 @@ module.exports = function (url) {
     return { type: "tr", owner: "w3c", name: w3cTr[1] };
   }
 
+  const tag = url.match(/^https?:\/\/(?:www\.)?w3\.org\/2001\/tag\/doc\/([^\/]+)\/?$/);
+  if (tag) {
+    return { type: "custom", owner: "w3ctag", name: tag[1] };
+  }
+
   return null;
 }

--- a/test/compute-categories.js
+++ b/test/compute-categories.js
@@ -2,14 +2,19 @@ const assert = require("assert");
 const computeCategories = require("../src/compute-categories.js");
 
 describe("compute-categories module", () => {
-  it("sets `browser` category by default", function () {
-    const spec = { groups: [] };
-    assert.deepStrictEqual(computeCategories(spec), ["browser"]);
-  });
-
   it("sets `browser` category when group targets browsers", function () {
     const spec = {
       groups: [ { name: "Web Applications Working Group" } ]
+    };
+    assert.deepStrictEqual(computeCategories(spec), ["browser"]);
+  });
+
+  it("sets `browser` category when one of the groups targets browsers", function () {
+    const spec = {
+      groups: [
+        { name: "Accessible Platform Architectures Working Group" },
+        { name: "Web Applications Working Group" }
+      ]
     };
     assert.deepStrictEqual(computeCategories(spec), ["browser"]);
   });
@@ -21,10 +26,9 @@ describe("compute-categories module", () => {
     assert.deepStrictEqual(computeCategories(spec), []);
   });
 
-  it("does not set a `browser` category when repo does not target browsers", function () {
+  it("does not set a `browser` category when all groups does not target browsers", function () {
     const spec = {
-      groups: [ { name: "Web Applications Working Group" } ],
-      nightly: { repository: "https://github.com/w3c/dpub-aam" }
+      groups: [ { name: "Accessible Platform Architectures Working Group" } ]
     };
     assert.deepStrictEqual(computeCategories(spec), []);
   });

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -84,7 +84,7 @@ describe("compute-shortname module", () => {
 
     it("throws when URL that does not follow a known pattern", () => {
       assert.throws(
-        () => computeInfo("https://www.w3.org/2001/tag/doc/promises-guide/"),
+        () => computeInfo("https://www.w3.org/2022/12/webmediaapi.html"),
         /^Cannot extract meaningful name from /);
     });
 


### PR DESCRIPTION
This adds the "Writing Promise-Using Specifications" TAG finding to the (non-browser) list to reduce the gap between specs in Shepherd and specs in Webref, as discussed in https://github.com/tabatkins/bikeshed/issues/2431

The TAG was added to the list of non-browser groups to make sure TAG Findings get classified as non-browser specs.

This also adds the code needed to extract findings shortnames and repositories, so that we can be more systematic about these specs from now on.

The update also fixes the code that looked for a non-browser group in the list of groups that produced the spec. That code assumed that whenever there's a non-browser group in the list, the spec is not targeted at browsers. CSS Typed OM is a counter-example (jointy developed by the CSS WG and the TAG). The fix should not affect any other spec (all other specs jointly developed by more than one group are developed by working groups targeting browsers).

```json
   {
      "url": "https://www.w3.org/2001/tag/doc/promises-guide",
      "seriesComposition": "full",
      "shortname": "promises-guide",
      "series": {
        "shortname": "promises-guide",
        "currentSpecification": "promises-guide",
        "title": "Writing Promise-Using Specifications",
        "shortTitle": "Writing Promise-Using Specifications",
        "nightlyUrl": "https://www.w3.org/2001/tag/doc/promises-guide"
      },
      "groups": [
        {
          "name": "Technical Architecture Group",
          "url": "https://www.w3.org/2001/tag/"
        }
      ],
      "nightly": {
        "url": "https://www.w3.org/2001/tag/doc/promises-guide",
        "alternateUrls": [],
        "repository": "https://github.com/w3ctag/promises-guide",
        "sourcePath": "index.bs",
        "filename": "Overview.html"
      },
      "title": "Writing Promise-Using Specifications",
      "source": "specref",
      "shortTitle": "Writing Promise-Using Specifications",
      "categories": []
    }
```