### PR TITLE
Make sure organization is set for TAG findings

### DIFF
--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -115,7 +115,6 @@ module.exports = async function (specs, options) {
         name: "Technical Architecture Group",
         url: "https://www.w3.org/2001/tag/"
       }];
-      continue;
     }
 
     // All specs that remain should be developed by some W3C group.

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -30,6 +30,15 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
+  it("handles W3C TAG URLs", async () => {
+    const res = await fetchGroupsFor("https://www.w3.org/2001/tag/doc/promises-guide");
+    assert.equal(res.organization, "W3C");
+    assert.deepStrictEqual(res.groups, [{
+      name: "Technical Architecture Group",
+      url: "https://www.w3.org/2001/tag/"
+    }]);
+  });
+
   it("handles WebGL URLs", async () => {
     const res = await fetchGroupsFor("https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/");
     assert.equal(res.organization, "Khronos Group");


### PR DESCRIPTION
The call to `continue` was the result of a ill-inspired copy-and-paste. This update also creates a dedicated test.