### PR TITLE
Switch to WHATWG URL for Encoding spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -103,6 +103,7 @@
     "shortTitle": "Compositing 2"
   },
   "https://drafts.fxtf.org/filter-effects-2/ delta",
+  "https://encoding.spec.whatwg.org/",
   "https://fedidcg.github.io/FedCM/",
   "https://fetch.spec.whatwg.org/",
   {
@@ -774,7 +775,6 @@
   "https://www.w3.org/TR/device-posture/",
   "https://www.w3.org/TR/DOM-Parsing/",
   "https://www.w3.org/TR/edit-context/",
-  "https://www.w3.org/TR/encoding/",
   {
     "url": "https://www.w3.org/TR/encrypted-media/",
     "nightly": {


### PR DESCRIPTION
The /TR version of the spec has been discontinued and redirects to the WHATWG version.

This will update the "encoding" entry to:

```json
{
  "url": "https://encoding.spec.whatwg.org/",
  "seriesComposition": "full",
  "shortname": "encoding",
  "series": {
    "shortname": "encoding",
    "currentSpecification": "encoding",
    "title": "Encoding Standard",
    "shortTitle": "Encoding",
    "nightlyUrl": "https://encoding.spec.whatwg.org/"
  },
  "organization": "WHATWG",
  "groups": [
    {
      "name": "Encoding Workstream",
      "url": "https://encoding.spec.whatwg.org/"
    }
  ],
  "nightly": {
    "url": "https://encoding.spec.whatwg.org/",
    "status": "Living Standard",
    "alternateUrls": [],
    "repository": "https://github.com/whatwg/encoding",
    "sourcePath": "encoding.bs",
    "filename": "index.html"
  },
  "title": "Encoding Standard",
  "source": "specref",
  "shortTitle": "Encoding",
  "categories": [
    "browser"
  ],
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "encoding"
    ]
  }
}
```