### PR TITLE
Add "unofficial" category

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -167,22 +167,21 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["browser"]
+        "enum": ["browser", "unofficial"]
       }
+    },
+
+    "categories-delta": {
+      "type": "string",
+      "enum": ["reset", "+browser", "-browser", "+unofficial", "-unofficial"]
     },
 
     "categories-specs": {
       "oneOf": [
-        {
-          "type": "string",
-          "enum": ["reset", "+browser", "-browser"]
-        },
+        { "$ref": "#/$defs/categories-delta" },
         {
           "type": "array",
-          "items": {
-            "type": "string",
-            "enum": ["reset", "+browser", "-browser"]
-          },
+          "items": { "$ref": "#/$defs/categories-delta" },
           "minItems": 1
         }
       ]

--- a/specs.json
+++ b/specs.json
@@ -56,7 +56,12 @@
   },
   "https://dom.spec.whatwg.org/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
-  "https://drafts.css-houdini.org/font-metrics-api-1/",
+  {
+    "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
+    "categories": [
+      "-unofficial"
+    ]
+  },
   "https://drafts.csswg.org/css-anchor-1/",
   "https://drafts.csswg.org/css-animations-2/ delta",
   {
@@ -97,7 +102,13 @@
     "url": "https://drafts.csswg.org/css-variables-2/",
     "shortTitle": "CSS Variables 2"
   },
-  "https://drafts.csswg.org/web-animations-2/ delta",
+  {
+    "url": "https://drafts.csswg.org/web-animations-2/",
+    "seriesComposition": "delta",
+    "categories": [
+      "-unofficial"
+    ]
+  },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",
     "shortTitle": "Compositing 2"

--- a/src/prepare-packages.js
+++ b/src/prepare-packages.js
@@ -26,7 +26,9 @@ async function preparePackages() {
     },
     {
       name: 'browser-specs',
-      filter: spec => spec.categories?.includes('browser')
+      filter: spec =>
+        spec.categories?.includes('browser') &&
+        !spec.categories?.includes('unofficial')
     }
   ];
 

--- a/test/compute-categories.js
+++ b/test/compute-categories.js
@@ -4,7 +4,8 @@ const computeCategories = require("../src/compute-categories.js");
 describe("compute-categories module", () => {
   it("sets `browser` category when group targets browsers", function () {
     const spec = {
-      groups: [ { name: "Web Applications Working Group" } ]
+      groups: [ { name: "Web Applications Working Group" } ],
+      nightly: { status: "Working Draft" }
     };
     assert.deepStrictEqual(computeCategories(spec), ["browser"]);
   });
@@ -14,21 +15,24 @@ describe("compute-categories module", () => {
       groups: [
         { name: "Accessible Platform Architectures Working Group" },
         { name: "Web Applications Working Group" }
-      ]
+      ],
+      nightly: { status: "Working Draft" }
     };
     assert.deepStrictEqual(computeCategories(spec), ["browser"]);
   });
 
   it("does not set a `browser` category when group does not target browsers", function () {
     const spec = {
-      groups: [ { name: "Accessible Platform Architectures Working Group" } ]
+      groups: [ { name: "Accessible Platform Architectures Working Group" } ],
+      nightly: { status: "Working Draft" }
     };
     assert.deepStrictEqual(computeCategories(spec), []);
   });
 
   it("does not set a `browser` category when all groups does not target browsers", function () {
     const spec = {
-      groups: [ { name: "Accessible Platform Architectures Working Group" } ]
+      groups: [ { name: "Accessible Platform Architectures Working Group" } ],
+      nightly: { status: "Working Draft" }
     };
     assert.deepStrictEqual(computeCategories(spec), []);
   });
@@ -36,22 +40,25 @@ describe("compute-categories module", () => {
   it("resets categories when asked to", function () {
     const spec = {
       groups: [ { name: "Web Applications Working Group" } ],
+      nightly: { status: "Unofficial Proposal Draft" },
       categories: "reset"
     };
     assert.deepStrictEqual(computeCategories(spec), []);
   });
 
-  it("drops browser when asked to", function () {
+  it("drops `browser` when asked to", function () {
     const spec = {
       groups: [ { name: "Web Applications Working Group" } ],
+      nightly: { status: "Working Draft" },
       categories: "-browser"
     };
     assert.deepStrictEqual(computeCategories(spec), []);
   });
 
-  it("adds browser when asked to", function () {
+  it("adds `browser` when asked to", function () {
     const spec = {
       groups: [ { name: "Accessible Platform Architectures Working Group" } ],
+      nightly: { status: "Working Draft" },
       categories: "+browser"
     };
     assert.deepStrictEqual(computeCategories(spec), ["browser"]);
@@ -60,9 +67,52 @@ describe("compute-categories module", () => {
   it("accepts an array of categories", function () {
     const spec = {
       groups: [ { name: "Accessible Platform Architectures Working Group" } ],
+      nightly: { status: "Working Draft" },
       categories: ["reset", "+browser"]
     };
     assert.deepStrictEqual(computeCategories(spec), ["browser"]);
+  });
+
+  it("sets `unofficial` category for a collection of interesting ideas", function () {
+    const spec = {
+      groups: [ { name: "Advisory Board" } ],
+      nightly: { status: "A Collection of Interesting Ideas" }
+    };
+    assert.deepStrictEqual(computeCategories(spec), ["unofficial"]);
+  });
+
+  it("sets `unofficial` category for an unofficial proposal draft", function () {
+    const spec = {
+      groups: [ { name: "Advisory Board" } ],
+      nightly: { status: "Unofficial Proposal Draft" }
+    };
+    assert.deepStrictEqual(computeCategories(spec), ["unofficial"]);
+  });
+
+  it("drops `unofficial` when asked to", function () {
+    const spec = {
+      groups: [ { name: "Advisory Board" } ],
+      nightly: { status: "Unofficial Proposal Draft" },
+      categories: "-unofficial"
+    };
+    assert.deepStrictEqual(computeCategories(spec), []);
+  });
+
+  it("adds `unofficial` when asked to", function () {
+    const spec = {
+      groups: [ { name: "Advisory Board" } ],
+      nightly: { status: "Working Draft" },
+      categories: "+unofficial"
+    };
+    assert.deepStrictEqual(computeCategories(spec), ["unofficial"]);
+  });
+
+  it("sets both `browser` and `unofficial` when needed", function () {
+    const spec = {
+      groups: [ { name: "CSS Working Group" } ],
+      nightly: { status: "A Collection of Interesting Ideas" }
+    };
+    assert.deepStrictEqual(computeCategories(spec), ["browser", "unofficial"]);
   });
 
   it("throws if spec object is empty", () => {
@@ -73,7 +123,19 @@ describe("compute-categories module", () => {
 
   it("throws if spec object does not have a groups property", () => {
     assert.throws(
-      () => computeCategories({ url: "https://example.org/" }),
+      () => computeCategories({
+        url: "https://example.org/",
+        nightly: { status: "Working Draft" }
+      }),
+      /^Invalid spec object passed as parameter$/);
+  });
+
+  it("throws if spec object does not have a nightly.status property", () => {
+    assert.throws(
+      () => computeCategories({
+        url: "https://example.org/",
+        groups: [ { name: "Web Applications Working Group" } ],
+      }),
       /^Invalid spec object passed as parameter$/);
   });
 });


### PR DESCRIPTION
This update creates a new `unofficial` category for specs whose status is "A Collection of Interesting Ideas" or "Unofficial Proposal Draft".

As usual, default rule can be overridden in `specs.json`. Done for font-metrics-api-1 and web-animations-2 because they define IDL that has already been included in Web Platform Tests.

The css-typed-om-2 spec will be the only one to get an `unofficial` flag for now. It deserves it, the spec is mostly empty for now (we could just as well drop the spec, but since it's been in the list since the start, let's keep it there).

Unofficial specs appear in the web-specs package but get filtered out of the browser-specs package.

The new status will make it possible to add a few additional unofficial CSS specs. To be done in a separate commit.