### PR TITLE
Add unofficial CSS proposals

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -55,6 +55,7 @@
     }
   },
   "https://dom.spec.whatwg.org/",
+  "https://drafts.css-houdini.org/box-tree-api-1/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
   {
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
@@ -67,9 +68,13 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Backgrounds 4"
   },
+  "https://drafts.csswg.org/css-color-6/",
+  "https://drafts.csswg.org/css-color-hdr/",
+  "https://drafts.csswg.org/css-conditional-values-1/",
   "https://drafts.csswg.org/css-easing-2/",
   "https://drafts.csswg.org/css-env-1/",
   "https://drafts.csswg.org/css-extensions-1/",
+  "https://drafts.csswg.org/css-forms-1/",
   {
     "url": "https://drafts.csswg.org/css-gcpm-4/",
     "seriesComposition": "delta",
@@ -84,6 +89,12 @@
     "shortTitle": "CSS Multicol 2"
   },
   "https://drafts.csswg.org/css-page-4/ delta",
+  {
+    "url": "https://drafts.csswg.org/css-page-template-1/",
+    "nightly": {
+      "status": "Unofficial Proposal Draft"
+    }
+  },
   "https://drafts.csswg.org/css-scroll-snap-2/ delta",
   "https://drafts.csswg.org/css-shapes-2/ delta",
   {
@@ -728,6 +739,10 @@
   },
   "https://www.w3.org/TR/css-syntax-3/",
   "https://www.w3.org/TR/css-tables-3/",
+  {
+    "url": "https://www.w3.org/TR/css-template-3/",
+    "standing": "pending"
+  },
   "https://www.w3.org/TR/css-text-3/",
   "https://www.w3.org/TR/css-text-4/ delta",
   "https://www.w3.org/TR/css-text-decor-3/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -352,9 +352,6 @@
     "https://drafts.csswg.org/css3-tables-algorithms/": {
       "comment": "marked as obsolete"
     },
-    "https://drafts.csswg.org/css-template-1/": {
-      "comment": "repository for ideas that may migrate to other modules of CSS"
-    },
     "https://drafts.csswg.org/selectors-nonelement-1/": {
       "comment": "retired spec"
     },

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -338,14 +338,6 @@
       "comment": "Still lots of todo",
       "lastreviewed": "2023-01-01"
     },
-    "https://drafts.csswg.org/css-color-hdr/": {
-      "comment": "Marked as unofficial proposal",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.csswg.org/css-color-6/": {
-      "comment": "Marked as not ready for implementation",
-      "lastreviewed": "2023-01-01"
-    },
     "https://drafts.csswg.org/css-block-3/": {
       "comment": "Placholder for an eventual CSS Block Layout Level 3 Module",
       "lastreviewed": "2023-01-01"
@@ -358,24 +350,8 @@
       "comment": "No spec yet",
       "lastreviewed": "2023-01-01"
     },
-    "https://drafts.csswg.org/css-forms-1/": {
-      "comment": "Marked as not ready for implementation",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.csswg.org/css-page-template-1/": {
-      "comment": "Marked as not ready for implementation",
-      "lastreviewed": "2023-01-01"
-    },
     "https://drafts.csswg.org/web-animations-css-integration/": {
       "comment": "Seems dormant",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.css-houdini.org/box-tree-api/": {
-      "comment": "Marked as collection of ideas, no clear implementation plans yet",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.csswg.org/css-conditional-values-1/": {
-      "comment": "Marked as not ready for implementation",
       "lastreviewed": "2023-01-01"
     },
     "https://svgwg.org/specs/markers/": {


### PR DESCRIPTION
This adds unofficial CSS proposals that are in Shepherd but not in web-specs:
- box-tree-api-1
- css-color-6
- css-color-hdr-1
- css-conditional-values-1
- css-forms-1
- css-page-template-1
- css-template-3

All specs will come with a `pending` standing, except css-color-6 which seems good enough to add even though it's still flagged as "not ready for implementation".

The css-page-template-1 spec is old. It does have an "Unofficial" banner but status is still "Editor's Draft". Status gets forced to "Unofficial Proposal Draft" as a result.

This will add the following entries:

```json
[
  {
    "url": "https://drafts.css-houdini.org/box-tree-api-1/",
    "seriesComposition": "full",
    "shortname": "box-tree-api-1",
    "series": {
      "shortname": "box-tree-api",
      "currentSpecification": "box-tree-api-1",
      "title": "Box Tree API",
      "shortTitle": "Box Tree API",
      "nightlyUrl": "https://drafts.css-houdini.org/box-tree-api/"
    },
    "seriesVersion": "1",
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "nightly": {
      "url": "https://drafts.css-houdini.org/box-tree-api-1/",
      "status": "A Collection of Interesting Ideas",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/css-houdini-drafts",
      "sourcePath": "box-tree-api/Overview.bs",
      "filename": "Overview.html"
    },
    "title": "Box Tree API Level 1",
    "source": "spec",
    "shortTitle": "Box Tree API 1",
    "categories": [
      "browser"
    ],
    "standing": "pending"
  },
  {
    "url": "https://drafts.csswg.org/css-color-6/",
    "seriesComposition": "full",
    "shortname": "css-color-6",
    "series": {
      "shortname": "css-color",
      "currentSpecification": "css-color-6",
      "title": "CSS Color",
      "shortTitle": "CSS Color",
      "nightlyUrl": "https://drafts.csswg.org/css-color/"
    },
    "seriesVersion": "6",
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "nightly": {
      "url": "https://drafts.csswg.org/css-color-6/",
      "status": "Editor's Draft",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-color-6/",
        "https://w3c.github.io/csswg-drafts/css-color/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "sourcePath": "css-color-6/Overview.bs",
      "filename": "Overview.html"
    },
    "title": "CSS Color Module Level 6",
    "source": "spec",
    "shortTitle": "CSS Color 6",
    "categories": [
      "browser"
    ],
    "standing": "good",
    "tests": {
      "repository": "https://github.com/web-platform-tests/wpt",
      "testPaths": [
        "css/css-color"
      ]
    }
  },
  {
    "url": "https://drafts.csswg.org/css-color-hdr/",
    "seriesComposition": "full",
    "shortname": "css-color-hdr",
    "series": {
      "shortname": "css-color-hdr",
      "currentSpecification": "css-color-hdr",
      "title": "CSS Color HDR",
      "shortTitle": "CSS Color HDR",
      "nightlyUrl": "https://drafts.csswg.org/css-color-hdr/"
    },
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "nightly": {
      "url": "https://drafts.csswg.org/css-color-hdr/",
      "status": "Unofficial Proposal Draft",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-color-hdr/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "sourcePath": "css-color-hdr/Overview.bs",
      "filename": "Overview.html"
    },
    "title": "CSS Color HDR Module Level 1",
    "source": "spec",
    "shortTitle": "CSS Color HDR 1",
    "categories": [
      "browser"
    ],
    "standing": "pending"
  },
  {
    "url": "https://drafts.csswg.org/css-conditional-values-1/",
    "seriesComposition": "full",
    "shortname": "css-conditional-values-1",
    "series": {
      "shortname": "css-conditional-values",
      "currentSpecification": "css-conditional-values-1",
      "title": "CSS Conditional Values",
      "shortTitle": "CSS Conditional Values",
      "nightlyUrl": "https://drafts.csswg.org/css-conditional-values/"
    },
    "seriesVersion": "1",
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "nightly": {
      "url": "https://drafts.csswg.org/css-conditional-values-1/",
      "status": "Unofficial Proposal Draft",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-conditional-values-1/",
        "https://w3c.github.io/csswg-drafts/css-conditional-values/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "sourcePath": "css-conditional-values-1/Overview.bs",
      "filename": "Overview.html"
    },
    "title": "CSS Conditional Values Module Level 1",
    "source": "spec",
    "shortTitle": "CSS Conditional Values 1",
    "categories": [
      "browser"
    ],
    "standing": "pending"
  },
  {
    "url": "https://drafts.csswg.org/css-forms-1/",
    "seriesComposition": "full",
    "shortname": "css-forms-1",
    "series": {
      "shortname": "css-forms",
      "currentSpecification": "css-forms-1",
      "title": "CSS Form Styling",
      "shortTitle": "CSS Form Styling",
      "nightlyUrl": "https://drafts.csswg.org/css-forms/"
    },
    "seriesVersion": "1",
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "nightly": {
      "url": "https://drafts.csswg.org/css-forms-1/",
      "status": "A Collection of Interesting Ideas",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-forms-1/",
        "https://w3c.github.io/csswg-drafts/css-forms/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "sourcePath": "css-forms-1/Overview.bs",
      "filename": "Overview.html"
    },
    "title": "CSS Form Styling Module Level 1",
    "source": "spec",
    "shortTitle": "CSS Form Styling 1",
    "categories": [
      "browser"
    ],
    "standing": "pending"
  },
  {
    "url": "https://drafts.csswg.org/css-page-template-1/",
    "seriesComposition": "full",
    "shortname": "css-page-template-1",
    "series": {
      "shortname": "css-page-template",
      "currentSpecification": "css-page-template-1",
      "title": "CSS Pagination Templates",
      "shortTitle": "CSS Pagination Templates",
      "nightlyUrl": "https://drafts.csswg.org/css-page-template/"
    },
    "seriesVersion": "1",
    "nightly": {
      "url": "https://drafts.csswg.org/css-page-template-1/",
      "status": "Unofficial Proposal Draft",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-page-template-1/",
        "https://w3c.github.io/csswg-drafts/css-page-template/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "sourcePath": "css-page-template-1/Overview.src.html",
      "filename": "Overview.html"
    },
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "title": "CSS Pagination Templates Module Level 3",
    "source": "specref",
    "shortTitle": "CSS Pagination Templates 3",
    "categories": [
      "browser"
    ],
    "standing": "pending"
  },
  {
    "url": "https://www.w3.org/TR/css-template-3/",
    "seriesComposition": "full",
    "shortname": "css-template-3",
    "series": {
      "shortname": "css-template",
      "currentSpecification": "css-template-3",
      "title": "CSS Template Layout",
      "shortTitle": "CSS Template Layout",
      "releaseUrl": "https://www.w3.org/TR/css-template/",
      "nightlyUrl": "https://drafts.csswg.org/css-template/"
    },
    "seriesVersion": "3",
    "standing": "pending",
    "organization": "W3C",
    "groups": [
      {
        "name": "Cascading Style Sheets (CSS) Working Group",
        "url": "https://www.w3.org/Style/CSS/"
      }
    ],
    "release": {
      "url": "https://www.w3.org/TR/css-template-3/",
      "status": "Note",
      "filename": "Overview.html"
    },
    "nightly": {
      "url": "https://drafts.csswg.org/css-template-3/",
      "status": "Editor's Draft",
      "alternateUrls": [
        "https://w3c.github.io/csswg-drafts/css-template-3/",
        "https://w3c.github.io/csswg-drafts/css-template/"
      ],
      "repository": "https://github.com/w3c/csswg-drafts",
      "filename": null
    },
    "title": "CSS Template Layout Module",
    "source": "w3c",
    "shortTitle": "CSS Template Layout",
    "categories": [
      "browser"
    ]
  }
]
```