### PR TITLE
Retrieve W3C API key from environment, drop config.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,21 +27,17 @@ jobs:
         # xxx-specs@latest branches
         fetch-depth: 0
 
-    - name: Setup environment
-      run: |
-        echo "${{ secrets.CONFIG_JSON }}" | base64 --decode > config.json
-        npm ci
-
     - name: Build new index file
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        W3C_API_KEY: ${{ secrets.W3C_API_KEY }}
       run: npm run build
 
     - name: Test new index file
       env:
-        CONFIG_JSON: ${{ secrets.CONFIG_JSON }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        W3C_API_KEY: ${{ secrets.W3C_API_KEY }}
       run: |
-        echo "${{ secrets.CONFIG_JSON }}" | base64 --decode > config.json
         npm run test
 
     - name: Bump minor version of packages if needed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,16 +26,17 @@ jobs:
 
       - name: Test (including W3C API tests)
         env:
-          CONFIG_JSON: ${{ secrets.CONFIG_JSON }}
-        if: ${{ env.CONFIG_JSON }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          W3C_API_KEY: ${{ secrets.W3C_API_KEY }}
+        if: ${{ env.W3C_API_KEY }}
         run: |
-          echo "${{ secrets.CONFIG_JSON }}" | base64 --decode > config.json
           npm run test
 
       - name: Test (without W3C API tests)
         env:
-          CONFIG_JSON: ${{ secrets.CONFIG_JSON }}
-        if: ${{ !env.CONFIG_JSON }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          W3C_API_KEY: ${{ secrets.W3C_API_KEY }}
+        if: ${{ !env.W3C_API_KEY }}
         run: npm run test-pr
 
       - name: Lint

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -22,15 +22,22 @@ const determineTestPath = require("./determine-testpath.js");
 const extractPages = require("./extract-pages.js");
 const fetchInfo = require("./fetch-info.js");
 const fetchGroups = require("./fetch-groups.js");
-const { w3cApiKey } = require("../config.json");
+const w3cApiKey = (_ => {
+  try {
+    return require("../config.json").w3cApiKey;
+  }
+  catch {
+    return null;
+  }
+})() ?? process.env.W3C_API_KEY;
 const githubToken = (_ => {
   try {
     return require("../config.json").GH_TOKEN;
   }
   catch {
-    return "";
+    return null;
   }
-})() || process.env.GH_TOKEN;;
+})() ?? process.env.GH_TOKEN;
 
 
 async function sleep(ms) {

--- a/test/fetch-groups-w3c.js
+++ b/test/fetch-groups-w3c.js
@@ -11,12 +11,12 @@ const fetchGroups = require("../src/fetch-groups.js");
 
 const githubToken = (function () {
   try {
-    return require("../config.json").githubToken;
+    return require("../config.json").GH_TOKEN;
   }
   catch (err) {
     return null;
   }
-})();
+})() ?? process.env.GH_TOKEN;
 
 const w3cApiKey = (function () {
   try {
@@ -25,7 +25,7 @@ const w3cApiKey = (function () {
   catch (err) {
     return null;
   }
-})();
+})() ?? process.env.W3C_API_KEY;
 
 
 describe("fetch-groups module (with API keys)", function () {

--- a/test/fetch-info-w3c.js
+++ b/test/fetch-info-w3c.js
@@ -16,7 +16,7 @@ const w3cApiKey = (function () {
   catch (err) {
     return null;
   }
-})();
+})() ?? process.env.W3C_API_KEY;
 
 
 describe("fetch-info module (with W3C API key)", function () {


### PR DESCRIPTION
There was a typo in the tests that checked groups: the code read the GitHub token in `config.json` under `githubToken` instead of under `GH_TOKEN` as done in `build-index.js` (we're not fantastically consistent with our naming conventions here, we use `w3cApiKey` for the API key, but `GH_TOKEN` for the GitHub token. Anyway)

This meant that the test request to the GitHub API was done without any authentication. Most of the time, that did not have any consequence, but CI tests now regularly fail at that step, probably because the GitHub API enforces limits more strongly.

In any case, it seems much much better to use the GitHub token that GitHub provides to actions rather than one we set by hand long time ago. I suspect that setting config.json as a secret was done at a time when we were not familiar with GitHub actions and secrets.

This update drops the `CONFIG_JSON` secret altogether and updates the code to rather rely on the `GH_TOKEN` and `W3C_API_KEY` environment variables to read the tokens it needs to build the index and run the tests.

The update also fixes the typo, of course.

I added a `W3C_API_KEY` secret to the repository accordingly and will effectively drop the `CONFIG_JSON` secret once that PR is merged.