### PR TITLE
Add "discontinued" standing, add missing specs for Bikeshed

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,15 +202,20 @@ specs in the `browser-specs` package.
 A rough approximation of whether the spec is in good standing, meaning that,
 regardless of its current status, it should be regarded as a spec that gets some
 love from targeted implementers and as a spec that has some well-defined scope,
-or whether the spec has not yet matured enough or should only be viewed as a
-collection of interesting ideas for now.
+whether the spec has not yet matured enough or should only be viewed as a
+collection of interesting ideas for now, or whether development of the spec has
+been discontinued.
 
 Specs for which the status is "Unofficial Proposal Draft" or "A Collection of
 Interesting Ideas" typically have a standing set to `"pending"` (but there may
 be exceptions).
 
-The `standing` property is always set. Value may either be `"good"` or
-`"pending"`. Value is always `"good"` for specs in the `browser-specs` package.
+Specs whose status is "Discontinued Draft" typically have a standing set to
+`"discontinued"`.
+
+The `standing` property is always set. Value may either be `"good"`, `"pending"`
+or `"discontinued"`. Value is always `"good"` for specs in the `browser-specs`
+package.
 
 
 ### `series`

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -195,7 +195,7 @@
 
     "standing": {
       "type": "string",
-      "enum": ["good", "pending"]
+      "enum": ["good", "pending", "discontinued"]
     }
   }
 }

--- a/specs.json
+++ b/specs.json
@@ -67,9 +67,13 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Backgrounds 4"
   },
+  "https://drafts.csswg.org/css-color-6/ delta",
+  "https://drafts.csswg.org/css-color-hdr/",
+  "https://drafts.csswg.org/css-conditional-values-1/",
   "https://drafts.csswg.org/css-easing-2/",
   "https://drafts.csswg.org/css-env-1/",
   "https://drafts.csswg.org/css-extensions-1/",
+  "https://drafts.csswg.org/css-forms-1/",
   {
     "url": "https://drafts.csswg.org/css-gcpm-4/",
     "seriesComposition": "delta",
@@ -587,6 +591,7 @@
   "https://www.w3.org/TR/credential-management-1/",
   "https://www.w3.org/TR/csp-embedded-enforcement/",
   "https://www.w3.org/TR/CSP3/",
+  "https://www.w3.org/TR/css-2022/",
   "https://www.w3.org/TR/css-align-3/",
   "https://www.w3.org/TR/css-animation-worklet-1/",
   "https://www.w3.org/TR/css-animations-1/",
@@ -615,6 +620,7 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Cascading 6"
   },
+  "https://www.w3.org/TR/css-color-3/",
   {
     "url": "https://www.w3.org/TR/css-color-4/",
     "nightly": {
@@ -637,6 +643,7 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Conditional 5"
   },
+  "https://www.w3.org/TR/css-contain-1/",
   "https://www.w3.org/TR/css-contain-2/",
   "https://www.w3.org/TR/css-contain-3/ delta",
   "https://www.w3.org/TR/css-content-3/",
@@ -661,6 +668,7 @@
     "url": "https://www.w3.org/TR/css-gcpm-3/",
     "shortTitle": "CSS GCPM 3"
   },
+  "https://www.w3.org/TR/css-grid-1/",
   "https://www.w3.org/TR/css-grid-2/",
   "https://www.w3.org/TR/css-highlight-api-1/",
   {
@@ -736,6 +744,7 @@
   "https://www.w3.org/TR/css-transforms-2/ delta",
   "https://www.w3.org/TR/css-transitions-1/",
   "https://www.w3.org/TR/css-typed-om-1/",
+  "https://www.w3.org/TR/css-ui-3/",
   {
     "url": "https://www.w3.org/TR/css-ui-4/",
     "shortTitle": "CSS User Interface 4"
@@ -754,6 +763,7 @@
   },
   "https://www.w3.org/TR/css-view-transitions-1/",
   "https://www.w3.org/TR/css-will-change-1/",
+  "https://www.w3.org/TR/css-writing-modes-3/",
   "https://www.w3.org/TR/css-writing-modes-4/",
   {
     "url": "https://www.w3.org/TR/CSS21/",
@@ -780,6 +790,15 @@
   "https://www.w3.org/TR/cssom-view-1/",
   "https://www.w3.org/TR/device-memory-1/",
   "https://www.w3.org/TR/device-posture/",
+  {
+    "url": "https://www.w3.org/TR/DOM-Level-2-Style/",
+    "series": {
+      "shortname": "DOM-Style"
+    },
+    "nightly": {
+      "url": "https://www.w3.org/TR/DOM-Level-2-Style/"
+    }
+  },
   "https://www.w3.org/TR/DOM-Parsing/",
   "https://www.w3.org/TR/edit-context/",
   {
@@ -888,6 +907,7 @@
   "https://www.w3.org/TR/mediacapture-streams/",
   "https://www.w3.org/TR/mediacapture-transform/",
   "https://www.w3.org/TR/mediacapture-viewport/",
+  "https://www.w3.org/TR/mediaqueries-3/",
   "https://www.w3.org/TR/mediaqueries-4/",
   "https://www.w3.org/TR/mediaqueries-5/ delta",
   "https://www.w3.org/TR/mediasession/",
@@ -999,7 +1019,9 @@
   "https://www.w3.org/TR/secure-contexts/",
   "https://www.w3.org/TR/secure-payment-confirmation/",
   "https://www.w3.org/TR/selection-api/",
+  "https://www.w3.org/TR/selectors-3/",
   "https://www.w3.org/TR/selectors-4/",
+  "https://www.w3.org/TR/selectors-nonelement-1/",
   "https://www.w3.org/TR/server-timing/",
   "https://www.w3.org/TR/service-workers/",
   {

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -121,6 +121,7 @@ module.exports = async function (specs, options) {
       "spec/Overview.html", // Only WebCrypto
       "docs/index.bs",      // Only ServiceWorker
       "spec.html",          // Most TC39 specs
+      `${spec.shortname}/Overview.html`,  // css-color-3, mediaqueries-3
 
       // Most common patterns, checking on "index.html" last as some repos
       // include such a file to store the generated spec from the source.

--- a/src/compute-standing.js
+++ b/src/compute-standing.js
@@ -30,5 +30,10 @@ module.exports = function (spec) {
   }
 
   const status = spec.release?.status ?? spec.nightly.status;
-  return unofficialStatuses.includes(status) ? "pending" : "good";
+  if (status === "Discontinued Draft") {
+    return "discontinued";
+  }
+  else {
+    return unofficialStatuses.includes(status) ? "pending" : "good";
+  }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -331,9 +331,6 @@
     "https://drafts.csswg.org/css-2021/": {
       "comment": "not a spec, but a collection"
     },
-    "https://drafts.csswg.org/css-2022/": {
-      "comment": "not a spec, but a collection"
-    },
     "https://drafts.csswg.org/css-egg-1/": {
       "comment": "excentric gadgetry"
     },
@@ -354,9 +351,6 @@
     },
     "https://drafts.csswg.org/css-template-1/": {
       "comment": "repository for ideas that may migrate to other modules of CSS"
-    },
-    "https://drafts.csswg.org/selectors-nonelement-1/": {
-      "comment": "retired spec"
     },
     "https://drafts.css-houdini.org/scroll-customization-api/": {
       "comment": "No activity since 2015; marked as no longer pursuing in https://www.chromestatus.com/features/5616710262456320"

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -338,14 +338,6 @@
       "comment": "Still lots of todo",
       "lastreviewed": "2023-01-01"
     },
-    "https://drafts.csswg.org/css-color-hdr/": {
-      "comment": "Marked as unofficial proposal",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.csswg.org/css-color-6/": {
-      "comment": "Marked as not ready for implementation",
-      "lastreviewed": "2023-01-01"
-    },
     "https://drafts.csswg.org/css-block-3/": {
       "comment": "Placholder for an eventual CSS Block Layout Level 3 Module",
       "lastreviewed": "2023-01-01"
@@ -358,10 +350,6 @@
       "comment": "No spec yet",
       "lastreviewed": "2023-01-01"
     },
-    "https://drafts.csswg.org/css-forms-1/": {
-      "comment": "Marked as not ready for implementation",
-      "lastreviewed": "2023-01-01"
-    },
     "https://drafts.csswg.org/css-page-template-1/": {
       "comment": "Marked as not ready for implementation",
       "lastreviewed": "2023-01-01"
@@ -372,10 +360,6 @@
     },
     "https://drafts.css-houdini.org/box-tree-api/": {
       "comment": "Marked as collection of ideas, no clear implementation plans yet",
-      "lastreviewed": "2023-01-01"
-    },
-    "https://drafts.csswg.org/css-conditional-values-1/": {
-      "comment": "Marked as not ready for implementation",
       "lastreviewed": "2023-01-01"
     },
     "https://svgwg.org/specs/markers/": {

--- a/test/compute-standing.js
+++ b/test/compute-standing.js
@@ -38,6 +38,11 @@ describe("compute-standing module", () => {
     assert.strictEqual(computeStanding(spec), "pending");
   });
 
+  it("returns `discontinued` for an Discontinued Draft", function () {
+    const spec = { nightly: { status: "Discontinued Draft" } };
+    assert.strictEqual(computeStanding(spec), "discontinued");
+  });
+
   it("returns the standing that the spec says it has", function () {
     const spec = {
       standing: "good",

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,8 @@ const noRepo = [
   'test-methodology',
   'rdf11-concepts',
   'rdf11-mt',
-  'n-quads'
+  'n-quads',
+  'DOM-Level-2-Style'
 ];
 
 
@@ -135,7 +136,8 @@ describe("List of specs", () => {
     const wrong = specs.filter(s => !s.title.includes(s.series.title))
       .filter(s => ![
           "webrtc", "json-ld11-api", "json-ld11-framing",
-          "css-images-4", "n-quads", "rdf11-concepts", "rdf11-mt"
+          "css-images-4", "n-quads", "rdf11-concepts", "rdf11-mt",
+          "DOM-Level-2-Style"
         ].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
This update adds a new `discontinued` value to the `standing` property for specs that are still in the list for some reason (typically because other specs still reference terms and sections they define in informative prose), but whose development has been discontinued. Specs whose status is "Discontinued Draft" end up with a `discontinued` standing.

This affects DNT in the current (before this update) list. The spec will be filtered out of the `browser-specs` package as a result. That seems a good thing.

This update also adds CSS specs that are needed for cross-referencing purpose in Bikeshed, as requested in:
https://github.com/tabatkins/bikeshed/issues/2431#issuecomment-1373992354

New specs are either:
- discontinued specs such as selectors-nonelement-1, DOM-Level-2-Style
- older versions of some specs such as css-color-3, css-contain-1, css-ui-3
- unofficial drafts that have not yet been completely adopted by the CSS WG such as css-color-6, css-color-hdr, css-conditional-values-1
- the latest CSS snapshot css-2022.

Two comments on "status, categories or standing?":
- Another approach for "Discontinued Draft" specs would be to say that they are in good standing and exclude them from the browser-specs package simply because they are discontinued.
- This will add css-2022 to the browser-specs package. I think that's fine. If we do not want that, we could perhaps remove the spec from the `browser` category.

<details>
  <summary>Changes to index.json</summary>

  Note series info for css-color is wrong simply because other levels were not taken into account when generating these changes.

  ```json
  [
    {
      "url": "https://drafts.csswg.org/css-color-6/",
      "seriesComposition": "delta",
      "shortname": "css-color-6",
      "series": {
        "shortname": "css-color",
        "currentSpecification": "css-color-3",
        "title": "CSS Color",
        "shortTitle": "CSS Color",
        "releaseUrl": "https://www.w3.org/TR/css-color/",
        "nightlyUrl": "https://drafts.csswg.org/css-color/"
      },
      "seriesVersion": "6",
      "seriesPrevious": "css-color-3",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "nightly": {
        "url": "https://drafts.csswg.org/css-color-6/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-color-6/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-color-6/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Color Module Level 6",
      "source": "spec",
      "shortTitle": "CSS Color 6",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-color"
        ]
      }
    },
    {
      "url": "https://drafts.csswg.org/css-color-hdr/",
      "seriesComposition": "full",
      "shortname": "css-color-hdr",
      "series": {
        "shortname": "css-color-hdr",
        "currentSpecification": "css-color-hdr",
        "title": "CSS Color HDR",
        "shortTitle": "CSS Color HDR",
        "nightlyUrl": "https://drafts.csswg.org/css-color-hdr/"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "nightly": {
        "url": "https://drafts.csswg.org/css-color-hdr/",
        "status": "Unofficial Proposal Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-color-hdr/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-color-hdr/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Color HDR Module Level 1",
      "source": "spec",
      "shortTitle": "CSS Color HDR 1",
      "categories": [
        "browser"
      ],
      "standing": "pending"
    },
    {
      "url": "https://drafts.csswg.org/css-conditional-values-1/",
      "seriesComposition": "full",
      "shortname": "css-conditional-values-1",
      "series": {
        "shortname": "css-conditional-values",
        "currentSpecification": "css-conditional-values-1",
        "title": "CSS Conditional Values",
        "shortTitle": "CSS Conditional Values",
        "nightlyUrl": "https://drafts.csswg.org/css-conditional-values/"
      },
      "seriesVersion": "1",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "nightly": {
        "url": "https://drafts.csswg.org/css-conditional-values-1/",
        "status": "Unofficial Proposal Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-conditional-values-1/",
          "https://w3c.github.io/csswg-drafts/css-conditional-values/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-conditional-values-1/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Conditional Values Module Level 1",
      "source": "spec",
      "shortTitle": "CSS Conditional Values 1",
      "categories": [
        "browser"
      ],
      "standing": "pending"
    },
    {
      "url": "https://drafts.csswg.org/css-forms-1/",
      "seriesComposition": "full",
      "shortname": "css-forms-1",
      "series": {
        "shortname": "css-forms",
        "currentSpecification": "css-forms-1",
        "title": "CSS Form Styling",
        "shortTitle": "CSS Form Styling",
        "nightlyUrl": "https://drafts.csswg.org/css-forms/"
      },
      "seriesVersion": "1",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "nightly": {
        "url": "https://drafts.csswg.org/css-forms-1/",
        "status": "A Collection of Interesting Ideas",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-forms-1/",
          "https://w3c.github.io/csswg-drafts/css-forms/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-forms-1/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Form Styling Module Level 1",
      "source": "spec",
      "shortTitle": "CSS Form Styling 1",
      "categories": [
        "browser"
      ],
      "standing": "pending"
    },
    {
      "url": "https://www.w3.org/TR/css-2022/",
      "seriesComposition": "full",
      "shortname": "css-2022",
      "series": {
        "shortname": "css",
        "currentSpecification": "css-2022",
        "title": "CSS Snapshot",
        "shortTitle": "CSS Snapshot",
        "releaseUrl": "https://www.w3.org/TR/css/",
        "nightlyUrl": "https://drafts.csswg.org/css/"
      },
      "seriesVersion": "2022",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-2022/",
        "status": "Draft Note",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-2022/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-2022/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-2022/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Snapshot 2022",
      "source": "w3c",
      "shortTitle": "CSS Snapshot 2022",
      "categories": [
        "browser"
      ],
      "standing": "good"
    },
    {
      "url": "https://www.w3.org/TR/css-color-3/",
      "seriesComposition": "full",
      "shortname": "css-color-3",
      "series": {
        "shortname": "css-color",
        "currentSpecification": "css-color-3",
        "title": "CSS Color",
        "shortTitle": "CSS Color",
        "releaseUrl": "https://www.w3.org/TR/css-color/",
        "nightlyUrl": "https://drafts.csswg.org/css-color/"
      },
      "seriesVersion": "3",
      "seriesNext": "css-color-6",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-color-3/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-color-3/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-color-3/",
          "https://w3c.github.io/csswg-drafts/css-color/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-color-3/Overview.html",
        "filename": "Overview.html"
      },
      "title": "CSS Color Module Level 3",
      "source": "w3c",
      "shortTitle": "CSS Color 3",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-color"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/css-contain-1/",
      "seriesComposition": "full",
      "shortname": "css-contain-1",
      "series": {
        "shortname": "css-contain",
        "currentSpecification": "css-contain-1",
        "title": "CSS Containment",
        "shortTitle": "CSS Containment",
        "releaseUrl": "https://www.w3.org/TR/css-contain/",
        "nightlyUrl": "https://drafts.csswg.org/css-contain/"
      },
      "seriesVersion": "1",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-contain-1/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-contain-1/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-contain-1/",
          "https://w3c.github.io/csswg-drafts/css-contain/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-contain-1/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Containment Module Level 1",
      "source": "w3c",
      "shortTitle": "CSS Containment 1",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-contain"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/css-grid-1/",
      "seriesComposition": "full",
      "shortname": "css-grid-1",
      "series": {
        "shortname": "css-grid",
        "currentSpecification": "css-grid-1",
        "title": "CSS Grid Layout",
        "shortTitle": "CSS Grid Layout",
        "releaseUrl": "https://www.w3.org/TR/css-grid/",
        "nightlyUrl": "https://drafts.csswg.org/css-grid/"
      },
      "seriesVersion": "1",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-grid-1/",
        "status": "Candidate Recommendation Draft",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-grid-1/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-grid-1/",
          "https://w3c.github.io/csswg-drafts/css-grid/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-grid-1/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Grid Layout Module Level 1",
      "source": "w3c",
      "shortTitle": "CSS Grid Layout 1",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-grid"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/css-ui-3/",
      "seriesComposition": "full",
      "shortname": "css-ui-3",
      "series": {
        "shortname": "css-ui",
        "currentSpecification": "css-ui-3",
        "title": "CSS Basic User Interface",
        "shortTitle": "CSS Basic User Interface",
        "releaseUrl": "https://www.w3.org/TR/css-ui/",
        "nightlyUrl": "https://drafts.csswg.org/css-ui/"
      },
      "seriesVersion": "3",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-ui-3/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-ui-3/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-ui-3/",
          "https://w3c.github.io/csswg-drafts/css-ui/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-ui-3/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Basic User Interface Module Level 3 (CSS3 UI)",
      "source": "w3c",
      "shortTitle": "CSS3 UI",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-ui"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/css-writing-modes-3/",
      "seriesComposition": "full",
      "shortname": "css-writing-modes-3",
      "series": {
        "shortname": "css-writing-modes",
        "currentSpecification": "css-writing-modes-3",
        "title": "CSS Writing Modes",
        "shortTitle": "CSS Writing Modes",
        "releaseUrl": "https://www.w3.org/TR/css-writing-modes/",
        "nightlyUrl": "https://drafts.csswg.org/css-writing-modes/"
      },
      "seriesVersion": "3",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/css-writing-modes-3/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/css-writing-modes-3/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/css-writing-modes-3/",
          "https://w3c.github.io/csswg-drafts/css-writing-modes/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "css-writing-modes-3/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "CSS Writing Modes Level 3",
      "source": "w3c",
      "shortTitle": "CSS Writing Modes 3",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/css-writing-modes"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/DOM-Level-2-Style/",
      "seriesComposition": "full",
      "shortname": "DOM-Level-2-Style",
      "series": {
        "shortname": "DOM-Style",
        "currentSpecification": "DOM-Level-2-Style",
        "title": "Document Object Model (DOM) Style",
        "shortTitle": "DOM",
        "releaseUrl": "https://www.w3.org/TR/DOM-Style/",
        "nightlyUrl": "https://www.w3.org/TR/DOM-Style/"
      },
      "nightly": {
        "url": "https://www.w3.org/TR/DOM-Level-2-Style/",
        "status": "Editor's Draft",
        "alternateUrls": [],
        "filename": "Overview.html"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "DOM Working Group",
          "url": "https://www.w3.org/DOM/Group/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/DOM-Level-2-Style/",
        "status": "Discontinued Draft",
        "filename": "Overview.html"
      },
      "title": "Document Object Model (DOM) Level 2 Style Specification",
      "source": "w3c",
      "shortTitle": "DOM",
      "categories": [
        "browser"
      ],
      "standing": "discontinued"
    },
    {
      "url": "https://www.w3.org/TR/mediaqueries-3/",
      "seriesComposition": "full",
      "shortname": "mediaqueries-3",
      "series": {
        "shortname": "mediaqueries",
        "currentSpecification": "mediaqueries-3",
        "title": "Media Queries",
        "shortTitle": "Media Queries",
        "releaseUrl": "https://www.w3.org/TR/mediaqueries/",
        "nightlyUrl": "https://drafts.csswg.org/mediaqueries/"
      },
      "seriesVersion": "3",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/mediaqueries-3/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/mediaqueries-3/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/mediaqueries-3/",
          "https://w3c.github.io/csswg-drafts/mediaqueries/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "mediaqueries-3/Overview.html",
        "filename": "Overview.html"
      },
      "title": "Media Queries Level 3",
      "source": "w3c",
      "shortTitle": "Media Queries 3",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/mediaqueries"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/selectors-3/",
      "seriesComposition": "full",
      "shortname": "selectors-3",
      "series": {
        "shortname": "selectors",
        "currentSpecification": "selectors-3",
        "title": "Selectors",
        "shortTitle": "Selectors",
        "releaseUrl": "https://www.w3.org/TR/selectors/",
        "nightlyUrl": "https://drafts.csswg.org/selectors/"
      },
      "seriesVersion": "3",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/selectors-3/",
        "status": "Recommendation",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/selectors-3/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/selectors-3/",
          "https://w3c.github.io/csswg-drafts/selectors/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "selectors-3/Overview.src.html",
        "filename": "Overview.html"
      },
      "title": "Selectors Level 3",
      "source": "w3c",
      "shortTitle": "Selectors 3",
      "categories": [
        "browser"
      ],
      "standing": "good",
      "tests": {
        "repository": "https://github.com/web-platform-tests/wpt",
        "testPaths": [
          "css/selectors"
        ]
      }
    },
    {
      "url": "https://www.w3.org/TR/selectors-nonelement-1/",
      "seriesComposition": "full",
      "shortname": "selectors-nonelement-1",
      "series": {
        "shortname": "selectors-nonelement",
        "currentSpecification": "selectors-nonelement-1",
        "title": "Non-element Selectors",
        "shortTitle": "Non-element Selectors",
        "releaseUrl": "https://www.w3.org/TR/selectors-nonelement/",
        "nightlyUrl": "https://drafts.csswg.org/selectors-nonelement/"
      },
      "seriesVersion": "1",
      "organization": "W3C",
      "groups": [
        {
          "name": "Cascading Style Sheets (CSS) Working Group",
          "url": "https://www.w3.org/Style/CSS/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/selectors-nonelement-1/",
        "status": "Discontinued Draft",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://drafts.csswg.org/selectors-nonelement-1/",
        "status": "Editor's Draft",
        "alternateUrls": [
          "https://w3c.github.io/csswg-drafts/selectors-nonelement-1/",
          "https://w3c.github.io/csswg-drafts/selectors-nonelement/"
        ],
        "repository": "https://github.com/w3c/csswg-drafts",
        "sourcePath": "selectors-nonelement-1/Overview.bs",
        "filename": "Overview.html"
      },
      "title": "Non-element Selectors Module Level 1",
      "source": "w3c",
      "shortTitle": "Non-element Selectors 1",
      "categories": [
        "browser"
      ],
      "standing": "discontinued"
    }
  ]
  ```json
</details>