### PR TITLE
Build job: re-introduce dependencies installation step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
         # xxx-specs@latest branches
         fetch-depth: 0
 
+    - name: Setup environment
+      run: npm ci
+
     - name: Build new index file
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previous update to the job that dropped generation of `config.json` accidently dropped the installation of dependencies. Job could not run as a result.