### PR TITLE
Update canonical URL of web-locks to /TR URL

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -345,7 +345,6 @@
     }
   },
   "https://w3c.github.io/PNG-spec/",
-  "https://w3c.github.io/web-locks/",
   "https://w3c.github.io/web-nfc/",
   "https://w3c.github.io/web-share-target/",
   "https://w3c.github.io/webdriver-bidi/",
@@ -1090,6 +1089,7 @@
   "https://www.w3.org/TR/wasm-js-api-2/",
   "https://www.w3.org/TR/wasm-web-api-2/",
   "https://www.w3.org/TR/web-animations-1/",
+  "https://www.w3.org/TR/web-locks/",
   "https://www.w3.org/TR/web-share/",
   "https://www.w3.org/TR/webaudio/",
   {


### PR DESCRIPTION
Spec was published as First Public Working Draft last week. Fixes #816.

Change:

```json
{
  "url": "https://www.w3.org/TR/web-locks/",
  "seriesComposition": "full",
  "shortname": "web-locks",
  "series": {
    "shortname": "web-locks",
    "currentSpecification": "web-locks",
    "title": "Web Locks API",
    "shortTitle": "Web Locks API",
    "releaseUrl": "https://www.w3.org/TR/web-locks/",
    "nightlyUrl": "https://w3c.github.io/web-locks/"
  },
  "organization": "W3C",
  "groups": [
    {
      "name": "Web Applications Working Group",
      "url": "https://www.w3.org/groups/wg/webapps"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/web-locks/",
    "status": "First Public Working Draft",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/web-locks/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/w3c/web-locks",
    "sourcePath": "index.bs",
    "filename": "index.html"
  },
  "title": "Web Locks API",
  "source": "w3c",
  "shortTitle": "Web Locks API",
  "categories": [
    "browser"
  ],
  "standing": "good",
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "web-locks"
    ]
  }
}
```