### PR TITLE
Fix short title of css-ui-3

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -743,7 +743,10 @@
   "https://www.w3.org/TR/css-transforms-2/ delta",
   "https://www.w3.org/TR/css-transitions-1/",
   "https://www.w3.org/TR/css-typed-om-1/",
-  "https://www.w3.org/TR/css-ui-3/",
+  {
+    "url": "https://www.w3.org/TR/css-ui-3/",
+    "shortTitle": "CSS User Interface 3"
+  },
   {
     "url": "https://www.w3.org/TR/css-ui-4/",
     "shortTitle": "CSS User Interface 4"


### PR DESCRIPTION
The short title for Level 4 was explicitly set to drop "Basic". For consistency, we need to do the same thing with Level 3.