### PR TITLE
Add CHIPS IETF draft

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -7,6 +7,21 @@
   },
   "https://console.spec.whatwg.org/",
   {
+    "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
+    "shortname": "partitioned-cookies",
+    "organization": "IETF",
+    "groups": [
+      {
+        "name": "HTTP Working Group",
+        "url": "https://datatracker.ietf.org/wg/httpbis/"
+      }
+    ],
+    "nightly": {
+      "url": "https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html",
+      "repository": "https://github.com/DCtheTall/CHIPS-spec"
+    }
+  },
+  {
     "url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
     "shortname": "client-hint-reliability",
     "organization": "IETF",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -85,7 +85,7 @@ module.exports = async function (specs, options) {
     const paths = repoPathCache.get(cacheKey);
 
     // Extract filename from nightly URL when there is one
-    const match = spec.nightly.url.match(/\/(\w+)\.html$/);
+    const match = spec.nightly.url.match(/\/([\w\-]+)\.html$/);
     const nightlyFilename = match ? match[1] : "";
 
     const sourcePath = getFirstFoundInTree(paths,
@@ -100,6 +100,7 @@ module.exports = async function (specs, options) {
       `${nightlyFilename}.bs`,
       `${nightlyFilename}.html`,
       `${nightlyFilename}.src.html`,
+      `${nightlyFilename}.md`,
 
       // WebGL extensions
       `extensions/${spec.shortname}/extension.xml`,

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -225,8 +225,8 @@
       "comment": "no published content yet"
     },
     "WICG/CHIPS": {
-      "lastreviewed": "2023-01-01",
-      "comment": "no published content yet"
+      "lastreviewed": "2023-01-09",
+      "comment": "no published content yet, ongoing IETF draft at https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies"
     },
     "privacycg/nav-tracking-mitigations": {
       "lastreviewed": "2023-01-01",


### PR DESCRIPTION
As requested in #822.

I'm not entirely clear whether the IETF work supersedes the WICG work and repo. I kept the `WICG/CHIPS` entry in the monitor list for now.

Change:

```json
{
  "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
  "seriesComposition": "full",
  "shortname": "partitioned-cookies",
  "series": {
    "shortname": "partitioned-cookies",
    "currentSpecification": "partitioned-cookies",
    "title": "Cookies Having Independent Partitioned State specification",
    "shortTitle": "Cookies Having Independent Partitioned State specification",
    "nightlyUrl": "https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html"
  },
  "organization": "IETF",
  "groups": [
    {
      "name": "HTTP Working Group",
      "url": "https://datatracker.ietf.org/wg/httpbis/"
    }
  ],
  "nightly": {
    "url": "https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html",
    "status": "Editor's Draft",
    "repository": "https://github.com/DCtheTall/CHIPS-spec",
    "alternateUrls": [],
    "sourcePath": "draft-cutler-httpbis-partitioned-cookies.md",
    "filename": "draft-cutler-httpbis-partitioned-cookies.html"
  },
  "title": "Cookies Having Independent Partitioned State specification",
  "source": "spec",
  "shortTitle": "Cookies Having Independent Partitioned State specification",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```