### PR TITLE
Ignore current spec from W3C API if series is different

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -193,11 +193,14 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
     // Note: the current specification returned by the W3C API may not be in the
     // list, since we tend not to include previous levels for IDL specs (even
     // if they are still "current"), in which case we'll just ignore the info
-    // returned from the W3C API.
+    // returned from the W3C API. Also, for CSS specs, the current specification
+    // returned by the W3C API is actually the latest CSS snapshot which is in a
+    // different specification series for us.
     if (seriesInfo?.currentSpecification &&
         !res.series.forceCurrent &&
         (seriesInfo.currentSpecification !== res.series.currentSpecification) &&
-        specs.find(s => s.shortname === seriesInfo.currentSpecification)) {
+        specs.find(s => s.shortname === seriesInfo.currentSpecification &&
+                        s.series.shortname === res.series.shortname)) {
       res.series.currentSpecification = seriesInfo.currentSpecification;
     }
     delete res.series.forceCurrent;


### PR DESCRIPTION
The currently list asserts that `css-2022` is the current specification of the `CSS` series, even though, for us, the `CSS` series is different from the `css` series (the former contains the CSS 2.x specs, the latter contains the CSS snapshots).

This is because the W3C API considers that these series are just one series and returns `css-2022` as the current specification. This update makes sure that the code ignores the current specification returned by the W3C API when it does not belong to the same specification series for us.

This will make the code get back to `CSS22` as the current specification for the `CSS` series.