### PR TITLE
Update URL of Private Network Access spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -412,6 +412,7 @@
   "https://wicg.github.io/keyboard-map/",
   "https://wicg.github.io/layout-instability/",
   "https://wicg.github.io/local-font-access/",
+  "https://wicg.github.io/local-network-access/",
   "https://wicg.github.io/manifest-incubations/",
   "https://wicg.github.io/media-feeds/",
   {
@@ -437,7 +438,6 @@
   "https://wicg.github.io/portals/",
   "https://wicg.github.io/prefer-current-tab/",
   "https://wicg.github.io/priority-hints/",
-  "https://wicg.github.io/private-network-access/",
   "https://wicg.github.io/responsive-image-client-hints/",
   "https://wicg.github.io/sanitizer-api/",
   "https://wicg.github.io/savedata/",


### PR DESCRIPTION
Underlying repository was renamed to local-network-access, previous URL redirects to the new one (and confuses browser-specs)

```json
{
  "url": "https://wicg.github.io/local-network-access/",
  "seriesComposition": "full",
  "shortname": "local-network-access",
  "series": {
    "shortname": "local-network-access",
    "currentSpecification": "local-network-access",
    "title": "Private Network Access",
    "shortTitle": "Private Network Access",
    "nightlyUrl": "https://wicg.github.io/local-network-access/"
  },
  "organization": "W3C",
  "groups": [
    {
      "name": "Web Platform Incubator Community Group",
      "url": "https://www.w3.org/community/wicg/"
    }
  ],
  "nightly": {
    "url": "https://wicg.github.io/local-network-access/",
    "status": "Draft Community Group Report",
    "alternateUrls": [],
    "repository": "https://github.com/WICG/local-network-access",
    "sourcePath": "index.src.html",
    "filename": "index.html"
  },
  "title": "Private Network Access",
  "source": "spec",
  "shortTitle": "Private Network Access",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```