### PR TITLE
Replace css-device-adapt-1 with css-viewport

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -120,6 +120,7 @@
     "url": "https://drafts.csswg.org/css-variables-2/",
     "shortTitle": "CSS Variables 2"
   },
+  "https://drafts.csswg.org/css-viewport/",
   {
     "url": "https://drafts.csswg.org/web-animations-2/",
     "seriesComposition": "delta",
@@ -663,13 +664,6 @@
   "https://www.w3.org/TR/css-contain-3/ delta",
   "https://www.w3.org/TR/css-content-3/",
   "https://www.w3.org/TR/css-counter-styles-3/",
-  {
-    "url": "https://www.w3.org/TR/css-device-adapt-1/",
-    "nightly": {
-      "url": "https://drafts.csswg.org/css-viewport-1/",
-      "sourcePath": "css-viewport/Overview.bs"
-    }
-  },
   "https://www.w3.org/TR/css-display-3/",
   "https://www.w3.org/TR/css-easing-1/",
   {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -384,9 +384,6 @@
     },
     "https://www.w3.org/TR/resource-timing-1/": {
       "comment": "Level-less spec is in the list, no need to track old Level 1 spec"
-    },
-    "https://www.w3.org/TR/css-device-adapt-1/": {
-      "comment": "spec should be retired in 2023, see https://github.com/w3c/browser-specs/issues/837, replaced by css-viewport"
     }
   }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -384,6 +384,9 @@
     },
     "https://www.w3.org/TR/resource-timing-1/": {
       "comment": "Level-less spec is in the list, no need to track old Level 1 spec"
+    },
+    "https://www.w3.org/TR/css-device-adapt-1/": {
+      "comment": "spec should be retired in 2023, see https://github.com/w3c/browser-specs/issues/837, replaced by css-viewport"
     }
   }
 }

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -381,6 +381,10 @@
     "https://www.w3.org/TR/wasm-core-2/": {
       "lastreviewed": "2023-01-01",
       "comment": "Weirdly formatted multipage spec with sub-sub-pages that would likely confuse extraction logic"
+    },
+    "https://www.w3.org/TR/css-device-adapt-1/": {
+      "lastreviewed": "2023-01-18",
+      "comment": "spec should be retired in 2023, see https://github.com/w3c/browser-specs/issues/837, replaced by css-viewport"
     }
   }
 }


### PR DESCRIPTION
The css-device-adapt-1 spec will be retired soon and replaced by css-viewport. We had already updated the entry to have css-viewport be the Editor's Draft of css-device-adapt-1 but that remains confusing. This update completely drops css-device-adapt-1.

See https://github.com/w3c/browser-specs/issues/837

New entry would be:

```json
{
  "url": "https://drafts.csswg.org/css-viewport/",
  "seriesComposition": "full",
  "shortname": "css-viewport",
  "series": {
    "shortname": "css-viewport",
    "currentSpecification": "css-viewport",
    "title": "CSS Viewport",
    "shortTitle": "CSS Viewport",
    "nightlyUrl": "https://drafts.csswg.org/css-viewport/"
  },
  "organization": "W3C",
  "groups": [
    {
      "name": "Cascading Style Sheets (CSS) Working Group",
      "url": "https://www.w3.org/Style/CSS/"
    }
  ],
  "nightly": {
    "url": "https://drafts.csswg.org/css-viewport/",
    "status": "Editor's Draft",
    "alternateUrls": [
      "https://w3c.github.io/csswg-drafts/css-viewport/"
    ],
    "repository": "https://github.com/w3c/csswg-drafts",
    "sourcePath": "css-viewport/Overview.bs",
    "filename": "Overview.html"
  },
  "title": "CSS Viewport Module Level 1",
  "source": "spec",
  "shortTitle": "CSS Viewport 1",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```