### PR TITLE
currentSpecification value

### DIFF
--- a/index.json
+++ b/index.json
@@ -1410,7 +1410,7 @@
     "shortname": "compositing-2",
     "series": {
       "shortname": "compositing",
-      "currentSpecification": "compositing-1",
+      "currentSpecification": "compositing-2",
       "title": "Compositing and Blending",
       "shortTitle": "Compositing",
       "releaseUrl": "https://www.w3.org/TR/compositing/",


### PR DESCRIPTION
Updated  `currentSpecification` value to `compositing-2`.

I am not 100% sure my edit corrects the issues, but there is an issue that needs to be corrected.

There are 2 compositing specifications. 
  - https://drafts.fxtf.org/compositing/ (also at https://drafts.fxtf.org/compositing-2/)
  - https://www.w3.org/TR/compositing-1/ (also at https://drafts.fxtf.org/compositing-1/)

But both render the same (as "Compositing and Blending Level 1") when the JSON is parsed with tools such as Yari on MDN. 