### PR TITLE
Update EXT_clip_cull_distance and add WEBGL_provoking_vertex extensions

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -165,7 +165,6 @@
   "https://quirks.spec.whatwg.org/",
   "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
   "https://registry.khronos.org/webgl/extensions/EXT_blend_minmax/",
-  "https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/",
   "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/",
   "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_half_float/",
   "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
@@ -190,6 +189,7 @@
   "https://registry.khronos.org/webgl/extensions/OES_vertex_array_object/",
   "https://registry.khronos.org/webgl/extensions/OVR_multiview2/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_color_buffer_float/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_etc/",
@@ -205,6 +205,7 @@
   "https://registry.khronos.org/webgl/extensions/WEBGL_lose_context/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
   "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw/",
+  "https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/",
   {
     "url": "https://registry.khronos.org/webgl/specs/latest/1.0/",
     "shortname": "webgl1",


### PR DESCRIPTION
The EXT_clip_cull_distance extension is moving forward, dropping the `EXT` prefix in favor of a `WEBGL` prefix, as discussed in: https://github.com/KhronosGroup/WebGL/issues/3109

This update also adds the provoking_vertex extension, which was added to the WebGL repository 6 months ago, and moved to a `WEBGL` prefix a couple of months ago.

New entries:

```json
[
  {
    "url": "https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/",
    "seriesComposition": "full",
    "shortname": "WEBGL_clip_cull_distance",
    "series": {
      "shortname": "WEBGL_clip_cull_distance",
      "currentSpecification": "WEBGL_clip_cull_distance",
      "title": "WebGL WEBGL_clip_cull_distance Extension Draft Specification",
      "shortTitle": "WebGL WEBGL_clip_cull_distance Extension Draft",
      "nightlyUrl": "https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/"
    },
    "organization": "Khronos Group",
    "groups": [
      {
        "name": "WebGL Working Group",
        "url": "https://www.khronos.org/webgl/"
      }
    ],
    "nightly": {
      "url": "https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/KhronosGroup/WebGL",
      "sourcePath": "extensions/WEBGL_clip_cull_distance/extension.xml",
      "filename": "index.html"
    },
    "title": "WebGL WEBGL_clip_cull_distance Extension Draft Specification",
    "source": "spec",
    "shortTitle": "WebGL WEBGL_clip_cull_distance Extension Draft",
    "categories": [
      "browser"
    ],
    "standing": "good",
    "tests": {
      "repository": "https://github.com/KhronosGroup/WebGL",
      "testPaths": [
        "conformance-suites"
      ]
    }
  },
  {
    "url": "https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/",
    "seriesComposition": "full",
    "shortname": "WEBGL_provoking_vertex",
    "series": {
      "shortname": "WEBGL_provoking_vertex",
      "currentSpecification": "WEBGL_provoking_vertex",
      "title": "WebGL WEBGL_provoking_vertex Extension Draft Specification",
      "shortTitle": "WebGL WEBGL_provoking_vertex Extension Draft",
      "nightlyUrl": "https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/"
    },
    "organization": "Khronos Group",
    "groups": [
      {
        "name": "WebGL Working Group",
        "url": "https://www.khronos.org/webgl/"
      }
    ],
    "nightly": {
      "url": "https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/KhronosGroup/WebGL",
      "sourcePath": "extensions/WEBGL_provoking_vertex/extension.xml",
      "filename": "index.html"
    },
    "title": "WebGL WEBGL_provoking_vertex Extension Draft Specification",
    "source": "spec",
    "shortTitle": "WebGL WEBGL_provoking_vertex Extension Draft",
    "categories": [
      "browser"
    ],
    "standing": "good",
    "tests": {
      "repository": "https://github.com/KhronosGroup/WebGL",
      "testPaths": [
        "conformance-suites"
      ]
    }
  }
]
```