### PR TITLE
Stop re-building the index on pushes to the main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,6 @@ name: Update spec info
 on:
   schedule:
     - cron: '10 */6 * * *'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'packages/*/package.json'
-      - 'test/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Building the index when we push a change to the main branch is a nice idea in theory, but the build process consumes a lot of GitHub API requests and, due to GitHub API rate limits, can essentially only run once per hour. That does not work well when there is more than one pull request to merge.

The job can still be triggered manually through GitHub's admin interface.