### PR TITLE
Make compositing-2 current, fix series.releaseUrl logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,11 @@ title, the property is set to the actual (possibly long) series title.
 #### `series.releaseUrl`
 
 The URL of the latest published snapshot for the spec series. For leveled specs
-(those that create a series), this matches the unversioned URL. That
-unversioned URL should return the specification identified by the
-[`currentSpecification`](#seriescurrentspecification) property.
+(those that create a series), this matches the unversioned URL. In most cases,
+that unversioned URL will return the specification identified by the
+[`currentSpecification`](#seriescurrentspecification) property. It may return
+an earlier level though, e.g. when the current specification has not yet been
+published as a TR document.
 
 For instance, this property will be set to `https://www.w3.org/TR/css-fonts/`
 for all specifications in the CSS Fonts series.
@@ -295,7 +297,8 @@ The `releaseUrl` property is only set for W3C specs published as TR documents.
 
 For leveled specs (those that create a series), this matches the unversioned URL
 that allows to access the latest Editor's Draft of the current specification in
-the series.
+the series. That unversioned URL should return the specification identified by
+the [`currentSpecification`](#seriescurrentspecification) property.
 
 For instance, this property will be set to `https://drafts.csswg.org/css-fonts/`
 for all specifications in the CSS Fonts series.

--- a/specs.json
+++ b/specs.json
@@ -128,7 +128,8 @@
   },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",
-    "shortTitle": "Compositing 2"
+    "shortTitle": "Compositing 2",
+    "forceCurrent": true
   },
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://encoding.spec.whatwg.org/",

--- a/src/compute-series-urls.js
+++ b/src/compute-series-urls.js
@@ -62,16 +62,16 @@ module.exports = function (spec, list) {
   const currentSpec = list.find(s => s.shortname === spec.series?.currentSpecification);
   const res = computeSeriesUrls(currentSpec ?? spec);
 
-  // Look for a release URL in previous versions of the spec if one exists
+  // Look for a release URL in given spec and previous versions
   if (!res.releaseUrl) {
-    while (spec.seriesPrevious) {
-      spec = list.find(s => s.shortname === spec.seriesPrevious);
-      if (!spec) {
-        break;
-      }
+    while (spec) {
       const prev = computeSeriesUrls(spec);
       if (prev.releaseUrl) {
         res.releaseUrl = prev.releaseUrl;
+        break;
+      }
+      spec = list.find(s => s.shortname === spec.seriesPrevious);
+      if (!spec) {
         break;
       }
     }

--- a/src/lint.js
+++ b/src/lint.js
@@ -68,20 +68,8 @@ function lintStr(specsStr) {
     .map(s => Object.assign({}, s, computeShortname(s.shortname || s.url)))
     .map((s, _, list) => Object.assign({}, s, computePrevNext(s, list)));
 
-  // Drop useless forceCurrent flag and shorten definition when possible
+  // Shorten definition when possible
   const fixed = sorted
-    .map(spec => {
-      const linked = linkedList.find(p => p.url === spec.url);
-      const next = linked.seriesNext ?
-        linkedList.find(p => p.shortname === linked.seriesNext) :
-        null;
-      const isLast = !next || next.seriesComposition === "delta" ||
-        next.seriesComposition === "fork";
-      if (spec.forceCurrent && isLast) {
-        spec.forceCurrent = false;
-      }
-      return spec;
-    })
     .map(shortenDefinition);
 
   const linted = JSON.stringify(fixed, null, 2) + "\n";

--- a/test/compute-series-urls.js
+++ b/test/compute-series-urls.js
@@ -127,6 +127,32 @@ describe("compute-series-urls module", () => {
   });
 
 
+  it("looks for a release URL in the provided spec if not the current one", () => {
+    const spec = {
+      url: "https://drafts.fxtf.org/compositing-1/",
+      shortname: "compositing-1",
+      series: { shortname: "compositing", currentSpecification: "compositing-2" },
+      nightly: { url: "https://drafts.fxtf.org/compositing-1/" },
+      release: { url: "https://www.w3.org/TR/compositing-1/" }
+    };
+
+    const list = [
+      spec,
+      {
+        url: "https://drafts.fxtf.org/compositing-2/",
+        shortname: "compositing-2",
+        series: { shortname: "compositing", currentSpecification: "compositing-2" },
+        seriesPrevious: "compositing-1",
+        nightly: { url: "https://drafts.fxtf.org/compositing-2/" }
+      }
+    ];
+
+    assert.deepStrictEqual(computeSeriesUrls(spec, list),
+      { releaseUrl: "https://www.w3.org/TR/compositing/",
+        nightlyUrl: "https://drafts.fxtf.org/compositing/" });
+  });
+
+
   it("computes info based on current specification", () => {
     const spec = {
       url: "https://www.w3.org/TR/SVG11/",

--- a/test/lint.js
+++ b/test/lint.js
@@ -105,26 +105,6 @@ describe("Linter", () => {
       ]));
     });
 
-    it("lints an object with a useless current flag", () => {
-      const specs = [
-        "https://www.w3.org/TR/spec/ current"
-      ];
-      assert.equal(lintStr(toStr(specs)), toStr([
-        "https://www.w3.org/TR/spec/"
-      ]));
-    });
-
-    it("lints an object with a useless current flag (delta version)", () => {
-      const specs = [
-        "https://www.w3.org/TR/spec-1/ current",
-        "https://www.w3.org/TR/spec-2/ delta"
-      ];
-      assert.equal(lintStr(toStr(specs)), toStr([
-        "https://www.w3.org/TR/spec-1/",
-        "https://www.w3.org/TR/spec-2/ delta",
-      ]));
-    });
-
     it("lints an object with a 'full' flag", () => {
       const specs = [
         { "url": "https://www.w3.org/TR/spec/", "seriesComposition": "full" }


### PR DESCRIPTION
This makes `compositing-2` the current specification for `compositing`, as discussed in https://github.com/w3c/browser-specs/pull/848#issuecomment-1403172297

This will make the data report the following series info:

```json
{
  "shortname": "compositing",
  "currentSpecification": "compositing-2",
  "title": "Compositing and Blending",
  "shortTitle": "Compositing",
  "nightlyUrl": "https://drafts.fxtf.org/compositing/",
  "releaseUrl": "https://www.w3.org/TR/compositing/"
}
```

The `nightlyUrl` is good and returns Level 2. The `releaseUrl` returns the latest published version of the spec, which is Level 1. That's not the level that is deemed current, but then it is the latest published version.

README amended accordingly to clarify that `releaseUrl` is not always the current spec, and that `nightlyUrl` should always be the current spec (unless there's a hiccup somewhere because /TR disagrees with the working group).