### PR TITLE
Update URL of Bikeshed spec in tests

### DIFF
--- a/test/fetch-info-w3c.js
+++ b/test/fetch-info-w3c.js
@@ -116,7 +116,7 @@ describe("fetch-info module (with W3C API key)", function () {
         shortname: "html"
       };
       const other = {
-        url: "https://tabatkins.github.io/bikeshed/",
+        url: "https://speced.github.io/bikeshed/",
         shortname: "bikeshed"
       };
       const info = await fetchInfo([w3c, whatwg, other], { w3cApiKey });

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -62,7 +62,7 @@ describe("fetch-info module (without W3C API key)", function () {
   describe("fetch from spec", () => {
     it("extracts spec info from a Bikeshed spec when needed", async () => {
       const spec = {
-        url: "https://tabatkins.github.io/bikeshed/",
+        url: "https://speced.github.io/bikeshed/",
         shortname: "bikeshed"
       };
       const info = await fetchInfo([spec]);


### PR DESCRIPTION
Bikeshed's documentation is used in tests as a canonical Bikeshed spec. The Bikeshed repo was moved last week and URL needs updating.