### PR TITLE
Drop level from URL of Contact Picker API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -604,7 +604,7 @@
     "shortTitle": "Compositing 1"
   },
   "https://www.w3.org/TR/compute-pressure/",
-  "https://www.w3.org/TR/contact-picker-1/",
+  "https://www.w3.org/TR/contact-picker/",
   "https://www.w3.org/TR/core-aam-1.2/",
   "https://www.w3.org/TR/credential-management-1/",
   "https://www.w3.org/TR/csp-embedded-enforcement/",


### PR DESCRIPTION
The Contact Picker API no longer uses a versioned shortname. Adjusting the URL accordingly.