### PR TITLE
Re-add Global Privacy Control spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -161,6 +161,7 @@
   "https://infra.spec.whatwg.org/",
   "https://mimesniff.spec.whatwg.org/",
   "https://notifications.spec.whatwg.org/",
+  "https://privacycg.github.io/gpc-spec/",
   "https://privacycg.github.io/private-click-measurement/",
   "https://privacycg.github.io/requestStorageAccessForOrigin/",
   "https://privacycg.github.io/storage-access/",


### PR DESCRIPTION
Merged previous PR #862 too fast, forgot to wait until a `w3c.json` file gets added to the repository, see pending PR:
https://github.com/privacycg/gpc-spec/pull/47