### PR TITLE
Add RDF 1.2 and SPARQL 1.2 drafts

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -365,6 +365,139 @@
     }
   },
   "https://w3c.github.io/PNG-spec/",
+  {
+    "url": "https://w3c.github.io/rdf-concepts/spec/",
+    "shortname": "rdf12-concepts",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-n-quads/spec/",
+    "shortname": "rdf12-n-quads",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-n-triples/spec/",
+    "shortname": "rdf12-n-triples",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-schema/spec/",
+    "shortname": "rdf12-schema",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-semantics/spec/",
+    "shortname": "rdf12-semantics",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-trig/spec/",
+    "shortname": "rdf12-trig",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-turtle/spec/",
+    "shortname": "rdf12-turtle",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/rdf-xml/spec/",
+    "shortname": "rdf12-xml",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-concepts/spec/",
+    "shortname": "sparql12-concepts",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-entailment/spec/",
+    "shortname": "sparql12-entailment",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-federated-query/spec/",
+    "shortname": "sparql12-federated-query",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-graph-store-protocol/spec/",
+    "shortname": "sparql12-graph-store-protocol",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-protocol/spec/",
+    "shortname": "sparql12-protocol",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-query/spec/",
+    "shortname": "sparql12-query",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-results-csv-tsv/spec/",
+    "shortname": "sparql12-results-csv-tsv",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-results-json/spec/",
+    "shortname": "sparql12-results-json",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-results-xml/spec/",
+    "shortname": "sparql12-results-xml",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-service-description/spec/",
+    "shortname": "sparql12-service-description",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://w3c.github.io/sparql-update/spec/",
+    "shortname": "sparql12-update",
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://w3c.github.io/web-nfc/",
   "https://w3c.github.io/web-share-target/",
   "https://w3c.github.io/webdriver-bidi/",
@@ -986,30 +1119,6 @@
     "url": "https://www.w3.org/TR/rdf-canon/",
     "nightly": {
       "url": "https://w3c.github.io/rdf-canon/spec/"
-    },
-    "categories": [
-      "-browser"
-    ]
-  },
-  {
-    "url": "https://www.w3.org/TR/rdf11-concepts/",
-    "nightly": {
-      "url": "https://www.w3.org/TR/rdf11-concepts/"
-    },
-    "series": {
-      "shortname": "rdf-concepts"
-    },
-    "categories": [
-      "-browser"
-    ]
-  },
-  {
-    "url": "https://www.w3.org/TR/rdf11-mt/",
-    "nightly": {
-      "url": "https://www.w3.org/TR/rdf11-mt/"
-    },
-    "series": {
-      "shortname": "rdf-mt"
     },
     "categories": [
       "-browser"

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -183,9 +183,10 @@ async function generateIndex(specs, { previousIndex = null, log = console.log } 
     }
     else {
       res.series.title = res.title
-        .replace(/ \d+(\.\d+)?$/, '')         // Drop level number
-        .replace(/( -)? Level$/, '')          // Drop "Level"
-        .replace(/ Module$/, '');             // Drop "Module"
+        .replace(/ \d+(\.\d+)?$/, '')           // Drop level number
+        .replace(/( -)? Level$/, '')            // Drop "Level"
+        .replace(/ Module$/, '')                // Drop "Module"
+        .replace(/^(RDF|SPARQL) \d\.\d/, '$1'); // Handle RDF/SPARQL titles
     }
 
     // Update the current specification based on the info returned by the

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -183,6 +183,17 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
     };
   }
 
+  // Extract X and X.Y levels with form "rdfXY-something" or "sparqlXY-something"
+  // (e.g. 1.2 for "rdf12-concepts")
+  match = seriesBasename.match(/^(rdf|sparql)(\d)(\d)-(.+)$/);
+  if (match) {
+    return {
+      shortname: specShortname,
+      series: { shortname: modernizeShortname(match[1] + "-" + match[4]) },
+      seriesVersion: match[2] + "." + match[3]
+    };
+  }
+
   // No level found
   return {
     shortname: specShortname,

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -138,6 +138,14 @@ describe("compute-shortname module", () => {
       assertSeries("answer42", "answer");
     });
 
+    it("parses form 'rdfXY-something'", () => {
+      assertSeries("rdf12-something", "rdf-something");
+    });
+
+    it("parses form 'sparqlXY-something'", () => {
+      assertSeries("sparql12-something", "sparql-something");
+    });
+
     it("includes final digits when they do not seem to be a level", () => {
       assertSeries("cors-rfc1918", "cors-rfc1918");
     });
@@ -192,6 +200,14 @@ describe("compute-shortname module", () => {
 
     it("finds the right series version for form 'shortnameXY'", () => {
       assertSeriesVersion("answer42", "4.2");
+    });
+
+    it("finds the right series version for form 'rdfXY-something'", () => {
+      assertSeriesVersion("rdf12-something", "1.2");
+    });
+
+    it("finds the right series version for form 'sparqlXY-something'", () => {
+      assertSeriesVersion("sparql12-something", "1.2");
     });
 
     it("does not report any series version when there are none", () => {


### PR DESCRIPTION
This update adds 19 RDF/SPARQL 1.2 drafts to the list, as non-browser specs. It also makes the code cognizant of the RDF/SPARQL numbering and titling scheme.

Note that the shortnames are "invented" for now. They match those used within the specs themselves, so hopefully the working group will just continue to use that same pattern when it starts publishing specs to /TR: https://w3c.github.io/rdf-primer/spec/#related

Previous RDF 1.1 entries (concepts and semantics) were dropped in favor of the new ones. This means that the list does not contain any /TR document for RDF and SPARQL, but that seems fine to me. Previous ones did not respect the definitions data model and are thus "less interesting" in any case.

This update does not add the "What's new" and "Primer" specs (two for RDF, one for SPARQL) that will be published as Notes. Perhaps it could or should?

Via #855.

<details>
  <summary>New entries that this update could create</summary>

```json
[
  {
    "url": "https://w3c.github.io/rdf-concepts/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-concepts",
    "series": {
      "shortname": "rdf-concepts",
      "currentSpecification": "rdf12-concepts",
      "title": "RDF Concepts and Abstract Syntax",
      "shortTitle": "RDF Concepts and Abstract Syntax",
      "nightlyUrl": "https://w3c.github.io/rdf-concepts/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-concepts/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-concepts",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 Concepts and Abstract Syntax",
    "source": "spec",
    "shortTitle": "RDF 1.2 Concepts and Abstract Syntax",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-n-quads/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-n-quads",
    "series": {
      "shortname": "rdf-n-quads",
      "currentSpecification": "rdf12-n-quads",
      "title": "RDF N-Quads",
      "shortTitle": "RDF N-Quads",
      "nightlyUrl": "https://w3c.github.io/rdf-n-quads/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-n-quads/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-n-quads",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 N-Quads",
    "source": "spec",
    "shortTitle": "RDF 1.2 N-Quads",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-n-triples/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-n-triples",
    "series": {
      "shortname": "rdf-n-triples",
      "currentSpecification": "rdf12-n-triples",
      "title": "RDF N-Triples",
      "shortTitle": "RDF N-Triples",
      "nightlyUrl": "https://w3c.github.io/rdf-n-triples/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-n-triples/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-n-triples",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 N-Triples",
    "source": "spec",
    "shortTitle": "RDF 1.2 N-Triples",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-schema/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-schema",
    "series": {
      "shortname": "rdf-schema",
      "currentSpecification": "rdf12-schema",
      "title": "RDF Schema",
      "shortTitle": "RDF Schema",
      "nightlyUrl": "https://w3c.github.io/rdf-schema/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-schema/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-schema",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 Schema",
    "source": "spec",
    "shortTitle": "RDF 1.2 Schema",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-semantics/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-semantics",
    "series": {
      "shortname": "rdf-semantics",
      "currentSpecification": "rdf12-semantics",
      "title": "RDF Semantics",
      "shortTitle": "RDF Semantics",
      "nightlyUrl": "https://w3c.github.io/rdf-semantics/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-semantics/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-semantics",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 Semantics",
    "source": "spec",
    "shortTitle": "RDF 1.2 Semantics",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-trig/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-trig",
    "series": {
      "shortname": "rdf-trig",
      "currentSpecification": "rdf12-trig",
      "title": "RDF TriG",
      "shortTitle": "RDF TriG",
      "nightlyUrl": "https://w3c.github.io/rdf-trig/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-trig/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-trig",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 TriG",
    "source": "spec",
    "shortTitle": "RDF 1.2 TriG",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-turtle/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-turtle",
    "series": {
      "shortname": "rdf-turtle",
      "currentSpecification": "rdf12-turtle",
      "title": "RDF Turtle",
      "shortTitle": "RDF Turtle",
      "nightlyUrl": "https://w3c.github.io/rdf-turtle/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-turtle/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-turtle",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 Turtle",
    "source": "spec",
    "shortTitle": "RDF 1.2 Turtle",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/rdf-xml/spec/",
    "seriesComposition": "full",
    "shortname": "rdf12-xml",
    "series": {
      "shortname": "rdf-xml",
      "currentSpecification": "rdf12-xml",
      "title": "RDF XML Syntax",
      "shortTitle": "RDF XML Syntax",
      "nightlyUrl": "https://w3c.github.io/rdf-xml/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/rdf-xml/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/rdf-xml",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "RDF 1.2 XML Syntax",
    "source": "spec",
    "shortTitle": "RDF 1.2 XML Syntax",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-concepts/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-concepts",
    "series": {
      "shortname": "sparql-concepts",
      "currentSpecification": "sparql12-concepts",
      "title": "SPARQL Overview",
      "shortTitle": "SPARQL Overview",
      "nightlyUrl": "https://w3c.github.io/sparql-concepts/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-concepts/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-concepts",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Overview",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Overview",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-entailment/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-entailment",
    "series": {
      "shortname": "sparql-entailment",
      "currentSpecification": "sparql12-entailment",
      "title": "SPARQL Entailment Regimes",
      "shortTitle": "SPARQL Entailment Regimes",
      "nightlyUrl": "https://w3c.github.io/sparql-entailment/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-entailment/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-entailment",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Entailment Regimes",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Entailment Regimes",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-federated-query/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-federated-query",
    "series": {
      "shortname": "sparql-federated-query",
      "currentSpecification": "sparql12-federated-query",
      "title": "SPARQL Federated Query",
      "shortTitle": "SPARQL Federated Query",
      "nightlyUrl": "https://w3c.github.io/sparql-federated-query/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-federated-query/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-federated-query",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Federated Query",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Federated Query",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-graph-store-protocol/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-graph-store-protocol",
    "series": {
      "shortname": "sparql-graph-store-protocol",
      "currentSpecification": "sparql12-graph-store-protocol",
      "title": "SPARQL Graph Store Protocol",
      "shortTitle": "SPARQL Graph Store Protocol",
      "nightlyUrl": "https://w3c.github.io/sparql-graph-store-protocol/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-graph-store-protocol/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-graph-store-protocol",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Graph Store Protocol",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Graph Store Protocol",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-protocol/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-protocol",
    "series": {
      "shortname": "sparql-protocol",
      "currentSpecification": "sparql12-protocol",
      "title": "SPARQL Protocol",
      "shortTitle": "SPARQL Protocol",
      "nightlyUrl": "https://w3c.github.io/sparql-protocol/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-protocol/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-protocol",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Protocol",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Protocol",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-query/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-query",
    "series": {
      "shortname": "sparql-query",
      "currentSpecification": "sparql12-query",
      "title": "SPARQL Query Language",
      "shortTitle": "SPARQL Query Language",
      "nightlyUrl": "https://w3c.github.io/sparql-query/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-query/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-query",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Query Language",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Query Language",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-results-csv-tsv/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-results-csv-tsv",
    "series": {
      "shortname": "sparql-results-csv-tsv",
      "currentSpecification": "sparql12-results-csv-tsv",
      "title": "SPARQL Query Results CSV and TSV Formats",
      "shortTitle": "SPARQL Query Results CSV and TSV Formats",
      "nightlyUrl": "https://w3c.github.io/sparql-results-csv-tsv/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-results-csv-tsv/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-results-csv-tsv",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Query Results CSV and TSV Formats",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Query Results CSV and TSV Formats",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-results-json/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-results-json",
    "series": {
      "shortname": "sparql-results-json",
      "currentSpecification": "sparql12-results-json",
      "title": "SPARQL Query Results JSON Format",
      "shortTitle": "SPARQL Query Results JSON Format",
      "nightlyUrl": "https://w3c.github.io/sparql-results-json/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-results-json/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-results-json",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Query Results JSON Format",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Query Results JSON Format",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-results-xml/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-results-xml",
    "series": {
      "shortname": "sparql-results-xml",
      "currentSpecification": "sparql12-results-xml",
      "title": "SPARQL Query Results XML Format",
      "shortTitle": "SPARQL Query Results XML Format",
      "nightlyUrl": "https://w3c.github.io/sparql-results-xml/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-results-xml/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-results-xml",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Query Results XML Format",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Query Results XML Format",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-service-description/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-service-description",
    "series": {
      "shortname": "sparql-service-description",
      "currentSpecification": "sparql12-service-description",
      "title": "SPARQL Service Description",
      "shortTitle": "SPARQL Service Description",
      "nightlyUrl": "https://w3c.github.io/sparql-service-description/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-service-description/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-service-description",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Service Description",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Service Description",
    "standing": "good"
  },
  {
    "url": "https://w3c.github.io/sparql-update/spec/",
    "seriesComposition": "full",
    "shortname": "sparql12-update",
    "series": {
      "shortname": "sparql-update",
      "currentSpecification": "sparql12-update",
      "title": "SPARQL Update",
      "shortTitle": "SPARQL Update",
      "nightlyUrl": "https://w3c.github.io/sparql-update/spec/"
    },
    "seriesVersion": "1.2",
    "categories": [],
    "organization": "W3C",
    "groups": [
      {
        "name": "RDF-star Working Group",
        "url": "https://www.w3.org/groups/wg/rdf-star"
      }
    ],
    "nightly": {
      "url": "https://w3c.github.io/sparql-update/spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/w3c/sparql-update",
      "sourcePath": "spec/index.html",
      "filename": "index.html"
    },
    "title": "SPARQL 1.2 Update",
    "source": "spec",
    "shortTitle": "SPARQL 1.2 Update",
    "standing": "good"
  }
]
```

</details>