### PR TITLE
Add TC39 ArrayBuffer transfer, look at "spec.emu" for sourcePath

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -284,15 +284,11 @@
   "https://tc39.es/proposal-array-find-from-last/",
   "https://tc39.es/proposal-array-from-async/",
   "https://tc39.es/proposal-array-grouping/",
+  "https://tc39.es/proposal-arraybuffer-transfer/",
   "https://tc39.es/proposal-atomics-wait-async/",
   "https://tc39.es/proposal-change-array-by-copy/",
   "https://tc39.es/proposal-decorators/",
-  {
-    "url": "https://tc39.es/proposal-explicit-resource-management/",
-    "nightly": {
-      "sourcePath": "spec.emu"
-    }
-  },
+  "https://tc39.es/proposal-explicit-resource-management/",
   "https://tc39.es/proposal-import-assertions/",
   "https://tc39.es/proposal-intl-duration-format/",
   "https://tc39.es/proposal-intl-enumeration/",
@@ -334,21 +330,11 @@
   "https://tc39.es/proposal-iterator-helpers/",
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-json-parse-with-source/",
-  {
-    "url": "https://tc39.es/proposal-regexp-modifiers/",
-    "nightly": {
-      "sourcePath": "spec.emu"
-    }
-  },
+  "https://tc39.es/proposal-regexp-modifiers/",
   "https://tc39.es/proposal-resizablearraybuffer/",
   "https://tc39.es/proposal-set-methods/",
   "https://tc39.es/proposal-shadowrealm/",
-  {
-    "url": "https://tc39.es/proposal-symbols-as-weakmap-keys/",
-    "nightly": {
-      "sourcePath": "spec.emu"
-    }
-  },
+  "https://tc39.es/proposal-symbols-as-weakmap-keys/",
   "https://tc39.es/proposal-temporal/",
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",


### PR DESCRIPTION
This adds the TC39 ArrayBuffer transfer proposal, which reached Stage 3.

Source of the spec is in a `spec.emu` file, like 3 other TC39 specs. That seemed a good occasion to turn the exception into a rule. The code now also looks for `spec.emu` when it searches the source of the spec.

Closes #870.

```json
{
  "url": "https://tc39.es/proposal-arraybuffer-transfer/",
  "seriesComposition": "full",
  "shortname": "tc39-arraybuffer-transfer",
  "series": {
    "shortname": "tc39-arraybuffer-transfer",
    "currentSpecification": "tc39-arraybuffer-transfer",
    "title": "ArrayBuffer transfer",
    "shortTitle": "ArrayBuffer transfer",
    "nightlyUrl": "https://tc39.es/proposal-arraybuffer-transfer/"
  },
  "organization": "Ecma International",
  "groups": [
    {
      "name": "TC39",
      "url": "https://tc39.es/"
    }
  ],
  "nightly": {
    "url": "https://tc39.es/proposal-arraybuffer-transfer/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/tc39/proposal-arraybuffer-transfer",
    "sourcePath": "spec.emu",
    "filename": "index.html"
  },
  "title": "ArrayBuffer transfer",
  "source": "spec",
  "shortTitle": "ArrayBuffer transfer",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```