### PR TITLE
Consider spec.emu for sourcePath

### DIFF
--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -122,6 +122,7 @@ module.exports = async function (specs, options) {
       "spec/Overview.html", // Only WebCrypto
       "docs/index.bs",      // Only ServiceWorker
       "spec.html",          // Most TC39 specs
+      "spec.emu",           // Some TC39 specs
       `${spec.shortname}/Overview.html`,  // css-color-3, mediaqueries-3
 
       // Most common patterns, checking on "index.html" last as some repos


### PR DESCRIPTION
File update should have been part of previous commit. Needed to put `spec.emu` in the list of well-known source files for specs.