### PR TITLE
Add CSS 2023 snapshot to the list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -732,6 +732,7 @@
   "https://www.w3.org/TR/csp-embedded-enforcement/",
   "https://www.w3.org/TR/CSP3/",
   "https://www.w3.org/TR/css-2022/",
+  "https://www.w3.org/TR/css-2023/",
   "https://www.w3.org/TR/css-align-3/",
   "https://www.w3.org/TR/css-animation-worklet-1/",
   "https://www.w3.org/TR/css-animations-1/",


### PR DESCRIPTION
CSS 2023 snapshot just published to /TR. It replaces the 2022 version as the current snapshot. Older version kept in the list for now although we may want to drop it later on, e.g. next time we add a CSS snapshot.

Closes #877.