### PR TITLE
Rename css-anchor to css-anchor-position

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -75,7 +75,7 @@
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
     "standing": "good"
   },
-  "https://drafts.csswg.org/css-anchor-1/",
+  "https://drafts.csswg.org/css-anchor-position-1/",
   "https://drafts.csswg.org/css-animations-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",


### PR DESCRIPTION
CSS Working Group decided to rename the spec, see: https://github.com/w3c/csswg-drafts/commit/d76c8ca2072af5b7571f79c40ccfc92b90c15fc3