### PR TITLE
Drop Priority Hints from spec list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -562,7 +562,6 @@
   "https://wicg.github.io/permissions-revoke/",
   "https://wicg.github.io/portals/",
   "https://wicg.github.io/prefer-current-tab/",
-  "https://wicg.github.io/priority-hints/",
   "https://wicg.github.io/responsive-image-client-hints/",
   "https://wicg.github.io/sanitizer-api/",
   "https://wicg.github.io/savedata/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -89,6 +89,9 @@
     "w3c/sparql-new": {
       "comment": "group note and not targeted at browsers"
     },
+    "WICG/priority-hints": {
+      "comment": "merged into HTML"
+    },
     "WICG/open-ui": {
       "comment": "not targeted at browsers"
     },


### PR DESCRIPTION
Spec has now been fully integrated in HTML and Fetch.

(supersedes #791)