### PR TITLE
Force status of Web Animations 2

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -124,7 +124,10 @@
   {
     "url": "https://drafts.csswg.org/web-animations-2/",
     "seriesComposition": "delta",
-    "standing": "good"
+    "standing": "good",
+    "nightly": {
+      "status": "Unofficial Proposal Draft"
+    }
   },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",


### PR DESCRIPTION
The spec is being staged for publication to /TR and the status of the nightly version is currently "First Public Working Draft". I suspect the nightly draft will become an "Editor's Draft" after publication.

In the meantime, to unlock build, this update forces the status to what it used to be, meaning "Unofficial Proposal Draft".