### PR TITLE
Force shortname of CSS21 to be CSS2

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -906,9 +906,11 @@
   "https://www.w3.org/TR/css-writing-modes-4/",
   {
     "url": "https://www.w3.org/TR/CSS21/",
+    "shortname": "CSS2",
+    "seriesVersion": "2.1",
     "multipage": true,
     "nightly": {
-      "sourcePath": "css2/Overview.bs"
+      "url": "https://www.w3.org/TR/CSS21/"
     }
   },
   {

--- a/test/index.js
+++ b/test/index.js
@@ -13,12 +13,11 @@ const addFormats = require("ajv-formats")
 const ajv = new Ajv();
 addFormats(ajv);
 
-// Some old specs that don't have a spec
+// Some old specs that don't have a repo
 const noRepo = [
+  'CSS2',
   'SVG11',
   'test-methodology',
-  'rdf11-concepts',
-  'rdf11-mt',
   'n-quads',
   'DOM-Level-2-Style'
 ];


### PR DESCRIPTION
This forces the shortname of the CSS 2.1 spec to be `CSS2` instead of `CSS21` as requested in #879. This is consistent with /TR and Specref.

Some notes:
- In theory, `CSS2` is more an alias of `CSS2.1` than a real shortname. However we don't record aliases in browser-specs, only a spec shortname and the series shortname. Having `CSS2` as the series shortname seems wrong. We will lose `CSS21` as a result. I don't think that is really problematic in practice.
- The base URL could perhaps be `https://www.w3.org/TR/CSS2/` instead of `https://www.w3.org/TR/CSS21/`. However, the W3C API would still return `https://www.w3.org/TR/CSS21/` as being the release URL for the spec, so we would end up with a slight inconsistency (and a failed test).
- The Latest Editor's Draft in CSS 2.1 points to the CSS 2.2 draft. That makes crawl produce extracts for CSS 2.1 that really are more CSS 2.2 extracts. It seems better to avoid that. This update also forces the nightly URL to be the published /TR spec, for lack of a better alternative. Tests updated accordingly not to expect a repository and sourcePath for `CSS2`.