### PR TITLE
Force nightly status of CSS Animations 2 to ED

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -76,13 +76,7 @@
     "standing": "good"
   },
   "https://drafts.csswg.org/css-anchor-position-1/",
-  {
-    "url": "https://drafts.csswg.org/css-animations-2/",
-    "seriesComposition": "delta",
-    "nightly": {
-      "status": "Editor's Draft"
-    }
-  },
+  "https://www.w3.org/TR/css-animations-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
     "seriesComposition": "delta",

--- a/specs.json
+++ b/specs.json
@@ -76,7 +76,13 @@
     "standing": "good"
   },
   "https://drafts.csswg.org/css-anchor-position-1/",
-  "https://drafts.csswg.org/css-animations-2/ delta",
+  {
+    "url": "https://drafts.csswg.org/css-animations-2/",
+    "seriesComposition": "delta",
+    "nightly": {
+      "status": "Editor's Draft"
+    }
+  },
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
     "seriesComposition": "delta",

--- a/specs.json
+++ b/specs.json
@@ -76,7 +76,6 @@
     "standing": "good"
   },
   "https://drafts.csswg.org/css-anchor-position-1/",
-  "https://www.w3.org/TR/css-animations-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
     "seriesComposition": "delta",
@@ -738,6 +737,7 @@
   "https://www.w3.org/TR/css-align-3/",
   "https://www.w3.org/TR/css-animation-worklet-1/",
   "https://www.w3.org/TR/css-animations-1/",
+  "https://www.w3.org/TR/css-animations-2/ delta",
   {
     "url": "https://www.w3.org/TR/css-backgrounds-3/",
     "shortTitle": "CSS Backgrounds 3"


### PR DESCRIPTION
The status of the nightly version of CSS Animations 2 is currently set to "First Public Working Draft". Not such a big deal, but not one of the expected values per our JSON schema.

If this type of issues keeps re-appearing, we may want to do one of:
1. add logic to convert the status of nightly versions to "Editor's Draft" when needed
2. relax the JSON schema to also accept release statuses
3. keep on being strict and report issues to groups