### PR TITLE
Drop Resource Hints from the list

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1115,7 +1115,6 @@
   "https://www.w3.org/TR/reporting-1/",
   "https://www.w3.org/TR/requestidlecallback/",
   "https://www.w3.org/TR/resize-observer-1/",
-  "https://www.w3.org/TR/resource-hints/",
   "https://www.w3.org/TR/resource-timing/",
   "https://www.w3.org/TR/screen-capture/",
   {

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -399,6 +399,9 @@
     },
     "https://www.w3.org/TR/resource-timing-1/": {
       "comment": "Level-less spec is in the list, no need to track old Level 1 spec"
+    },
+    "https://www.w3.org/TR/resource-hints/": {
+      "comment": "Integrated in HTML, ED redirects to HTML"
     }
   }
 }


### PR DESCRIPTION
Spec integrated in HTML. The ED now redirects to HTML, which makes Reffy think that Resource Hints is the HTML spec.

Via https://github.com/w3c/reffy/issues/1236