### PR TITLE
Drop TC39 Import Assertions proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -283,7 +283,6 @@
   "https://tc39.es/proposal-change-array-by-copy/",
   "https://tc39.es/proposal-decorators/",
   "https://tc39.es/proposal-explicit-resource-management/",
-  "https://tc39.es/proposal-import-assertions/",
   "https://tc39.es/proposal-intl-duration-format/",
   "https://tc39.es/proposal-intl-enumeration/",
   "https://tc39.es/proposal-intl-extend-timezonename/",


### PR DESCRIPTION
The proposal was renamed to Import Attributes, its URL updated, and more importantly the proposal was demoted to Stage 2 last month: https://github.com/tc39/proposals/commit/faa00dc13c48463a02dfe3aa6387b7082b41ce27

... which provides a practical example for:
https://github.com/w3c/browser-specs/issues/307#issuecomment-856606328