### PR TITLE
Use new window-management shortname for window-placement

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1265,7 +1265,7 @@
       "sourcePath": "wgsl/index.bs"
     }
   },
-  "https://www.w3.org/TR/window-placement/",
+  "https://www.w3.org/TR/window-management/",
   {
     "url": "https://www.w3.org/TR/WOFF/",
     "shortTitle": "WOFF 1.0",


### PR DESCRIPTION
The spec was re-published with a new title and shortname: https://www.w3.org/TR/window-management/