### PR TITLE
Stop using httpwg.org URL for newish RFCs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -636,31 +636,31 @@
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9110",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9110.html"
+      "repository": "https://github.com/httpwg/httpwg.github.io"
     }
   },
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9111",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9111.html"
+      "repository": "https://github.com/httpwg/httpwg.github.io"
     }
   },
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9112",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9112.html"
+      "repository": "https://github.com/httpwg/httpwg.github.io"
     }
   },
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9113",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9113.html"
+      "repository": "https://github.com/httpwg/httpwg.github.io"
     }
   },
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9114",
     "nightly": {
-      "url": "https://httpwg.org/specs/rfc9114.html"
+      "repository": "https://github.com/httpwg/httpwg.github.io"
     }
   },
   {


### PR DESCRIPTION
Entries for RFC9110, RFC9111, RFC9112, RFC9113 and RFC9114 were explicitly forcing the use of `httpwg.org` URLs. That's not really useful since the `rfc-editor.org` URLs are just as readable. That also introduces hiccups because fragment IDs are not the same in both versions, as in: https://github.com/w3c/IFT/issues/143

This update drops the explicit mention. In practice, that means that the info in browser-specs will align itself with whatever is in Specref, and Specref has the appropriate logic (`httpwg.org` for old RFCs, `rfc-editor.org` for newer ones).

Looking at Webref data, this switch will only impact the FedCM spec. Other specs that reference the afore-mentioned RFCs do not link to sections.

Example of update that this will introduce:

```json
{
  "url": "https://www.rfc-editor.org/rfc/rfc9114",
  "seriesComposition": "full",
  "shortname": "rfc9114",
  "series": {
    "shortname": "rfc9114",
    "currentSpecification": "rfc9114",
    "title": "HTTP/3",
    "shortTitle": "HTTP/3",
    "nightlyUrl": "https://www.rfc-editor.org/rfc/rfc9114"
  },
  "nightly": {
    "url": "https://www.rfc-editor.org/rfc/rfc9114",
    "status": "Proposed Standard",
    "repository": "https://github.com/httpwg/httpwg.github.io",
    "alternateUrls": [],
    "sourcePath": "specs/rfc9114.xml",
    "filename": "rfc9114.html"
  },
  "organization": "IETF",
  "groups": [
    {
      "name": "QUIC Working Group",
      "url": "https://datatracker.ietf.org/wg/quic/"
    }
  ],
  "title": "HTTP/3",
  "source": "specref",
  "shortTitle": "HTTP/3",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```