### PR TITLE
Temporarily force series title for scroll-animations

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1128,6 +1128,7 @@
   {
     "url": "https://www.w3.org/TR/scroll-animations-1/",
     "series": {
+      "shortname": "scroll-animations",
       "title": "Scroll-driven Animations"
     }
   },

--- a/specs.json
+++ b/specs.json
@@ -1125,7 +1125,12 @@
     }
   },
   "https://www.w3.org/TR/screen-wake-lock/",
-  "https://www.w3.org/TR/scroll-animations-1/",
+  {
+    "url": "https://www.w3.org/TR/scroll-animations-1/",
+    "series": {
+      "title": "Scroll-driven Animations"
+    }
+  },
   "https://www.w3.org/TR/secure-contexts/",
   "https://www.w3.org/TR/secure-payment-confirmation/",
   "https://www.w3.org/TR/selection-api/",


### PR DESCRIPTION
The title of the spec switched to "Scroll-driven Animations" but the series title in the W3C API is still the old one. Name will soon be fixed in the W3C API database. This temporary update is only meant to resume building so that a new package may be published.