### PR TITLE
Adjust short title for Protected Audience

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -573,7 +573,10 @@
   },
   "https://wicg.github.io/speech-api/",
   "https://wicg.github.io/trust-token-api/",
-  "https://wicg.github.io/turtledove/",
+  {
+    "url": "https://wicg.github.io/turtledove/",
+    "shortTitle": "Protected Audience"
+  },
   "https://wicg.github.io/ua-client-hints/",
   "https://wicg.github.io/urlpattern/",
   "https://wicg.github.io/user-preference-media-features-headers/",


### PR DESCRIPTION
Title of the `turtledove` proposal changed to:

  "Protected Audience (formerly FLEDGE)"

The code thinks that the text between parentheses is the short title since that's the usual convention. This update hardcodes the short title to "Protected Audience".