### PR TITLE
Adjust reference to npm-publish package

### DIFF
--- a/src/release-package.js
+++ b/src/release-package.js
@@ -9,7 +9,7 @@ const path = require("path");
 const os = require("os");
 const { execSync } = require("child_process");
 const { rimraf } = require("rimraf");
-const npmPublish = require("@jsdevtools/npm-publish");
+const { npmPublish } = require("@jsdevtools/npm-publish");
 
 const owner = "w3c";
 const repo = "browser-specs";


### PR DESCRIPTION
Same as in:
https://github.com/w3c/webref/pull/954

Not advertized in the list of breaking changes made in v2 AFAICT, but main function is no longer exported as default.