### PR TITLE
Stop using w3c.github.io URL to fetch CSS specs

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -241,18 +241,12 @@ async function fetchInfoFromSpecref(specs, options) {
 async function fetchInfoFromSpecs(specs, options) {
   const info = await Promise.all(specs.map(async spec => {
     const url = spec.nightly?.url || spec.url;
-    // Force use of more stable w3c.github.io address for CSS drafts
-    let fetchUrl = url;
-    if (url.match(/\/drafts\.csswg\.org/)) {
-      const draft = computeShortname(url);
-      fetchUrl = `https://w3c.github.io/csswg-drafts/${draft.shortname}/`;
-    }
     let dom = null;
     try {
-      dom = await JSDOMFromURL(fetchUrl);
+      dom = await JSDOMFromURL(url);
     }
     catch (err) {
-      throw new Error(`Could not retrieve ${fetchUrl} with JSDOM: ${err.message}`);
+      throw new Error(`Could not retrieve ${url} with JSDOM: ${err.message}`);
     }
 
     if (spec.url.startsWith("https://tc39.es/")) {


### PR DESCRIPTION
The `https://w3c.github.io/csswg-drafts/` URLs now redirect to `https://drafts.csswg.org/css-viewport/`, following: https://github.com/w3c/csswg-drafts/issues/8798

Using `w3c.github.io` URLs no longer makes sense as a result. On top of adding a redirection, it prevents build because the w3c.github.io URL for `css-page-4` is currently broken.