### PR TITLE
Add TC39 float16array proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -287,6 +287,7 @@
   "https://tc39.es/proposal-change-array-by-copy/",
   "https://tc39.es/proposal-decorators/",
   "https://tc39.es/proposal-explicit-resource-management/",
+  "https://tc39.es/proposal-float16array/",
   "https://tc39.es/proposal-intl-duration-format/",
   "https://tc39.es/proposal-intl-enumeration/",
   "https://tc39.es/proposal-intl-extend-timezonename/",

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -240,6 +240,10 @@
       "lastreviewed": "2023-05-01",
       "comment": "no published content yet, actual content in PR https://github.com/tc39/ecma262/pull/2721"
     },
+    "tc39/proposal-decorator-metadata": {
+      "lastreviewed": "2023-05-22",
+      "comment": "template spec, no actual content yet"
+    },
     "WICG/origin-policy": {
       "lastreviewed": "2023-05-01",
       "comment": "proposal put on hold"


### PR DESCRIPTION
Spec reached stage 3.

This update also adds the decorator metadata proposal to the monitor list because, even though the proposal reached stage 3, the actual spec just contains placeholder text for now.