### PR TITLE
Prefer index.html over Overview.html when detecting filenames

### DIFF
--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -27,8 +27,8 @@ module.exports = async function (url) {
 
   // Check common candidates
   const candidates = [
-    "Overview.html",
-    "index.html"
+    "index.html",
+    "Overview.html"
   ];
 
   for (const candidate of candidates) {


### PR DESCRIPTION
This update switches the order by which the code looks for spec filenames.

This follows from discussions about CSS drafts, which currently exist both as `Overview.html` and `index.html`, the latter being the most recent: https://github.com/w3c/csswg-drafts/issues/8899

This will de facto update the `filename` of all CSS drafts to `index.html`. Note that this will also update the `filename` of WebCrypto, which is a good thing because `Overview.html` actually redirects to `index.html` there.