### PR TITLE
Update URL of css-anchor-position-1

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -75,7 +75,6 @@
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
     "standing": "good"
   },
-  "https://drafts.csswg.org/css-anchor-position-1/",
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
     "seriesComposition": "delta",
@@ -619,6 +618,7 @@
   "https://www.w3.org/TR/css-2022/",
   "https://www.w3.org/TR/css-2023/",
   "https://www.w3.org/TR/css-align-3/",
+  "https://www.w3.org/TR/css-anchor-position-1/",
   "https://www.w3.org/TR/css-animation-worklet-1/",
   "https://www.w3.org/TR/css-animations-1/",
   "https://www.w3.org/TR/css-animations-2/ delta",

--- a/test/fetch-groups-w3c.js
+++ b/test/fetch-groups-w3c.js
@@ -52,7 +52,7 @@ describe("fetch-groups module (with API keys)", function () {
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
         name: "Web Applications Working Group",
-        url: "https://www.w3.org/groups/wg/webapps"
+        url: "https://www.w3.org/groups/wg/webapps/"
       }]);
     });
 
@@ -65,7 +65,7 @@ describe("fetch-groups module (with API keys)", function () {
       assert.equal(res[0].organization, "W3C");
       assert.deepStrictEqual(res[0].groups, [{
         name: "Web Applications Working Group",
-        url: "https://www.w3.org/groups/wg/webapps"
+        url: "https://www.w3.org/groups/wg/webapps/"
       }]);
       assert.equal(res[1].organization, "W3C");
       assert.deepStrictEqual(res[1].groups, [{


### PR DESCRIPTION
Published as First Public Working Draft this week.

The update also fixes the URL of the webapps WG's home page in tests (final slash added following website redesign).