### PR TITLE
Filter out specs contributed to Specref

### DIFF
--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -56,6 +56,16 @@ describe("fetch-info module (without W3C API key)", function () {
       assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/hr-time/");
       assert.equal(info[other.shortname].title, "High Resolution Time Level 2");
     });
+
+    it("does not retrieve info from a spec that got contributed to Specref", async () => {
+      const spec = {
+        url: "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
+        shortname: "ANGLE_instanced_arrays"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+    });
   });
 
 


### PR DESCRIPTION
If [PR on Specref gets merged](https://github.com/tobie/specref/pull/750), browser-specs will start contributing specs to Specref. At the same time, it fetches info for bunch of other specs from Specref. For obvious reason, browser-specs must not use spec info from Specref for specs it actually contributes to Specref, otherwise we would not longer be able to track updates made to that spec.

Unfortunately, there is no way to know from Specref's API where a spec comes from (the API does not return the `source` property), so code needs to fetch the list of specs to discard directly from Specref's GitHub repository.