### PR TITLE
Drop TC39 resizablearray proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -340,7 +340,6 @@
   "https://tc39.es/proposal-json-modules/",
   "https://tc39.es/proposal-json-parse-with-source/",
   "https://tc39.es/proposal-regexp-modifiers/",
-  "https://tc39.es/proposal-resizablearraybuffer/",
   "https://tc39.es/proposal-set-methods/",
   "https://tc39.es/proposal-shadowrealm/",
   "https://tc39.es/proposal-symbols-as-weakmap-keys/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -376,6 +376,9 @@
     "https://tc39.es/proposal-regexp-legacy-features/": {
       "comment": "no proper spec, legacy"
     },
+    "https://tc39.es/proposal-resizablearraybuffer/": {
+      "comment": "Integrated in ECMAScript"
+    },
     "https://tc39.es/proposal-hashbang/": {
       "comment": "not meant for browsers environments"
     },


### PR DESCRIPTION
Proposal moved to stage 4 and is about to be integrated in ECMAScript. More importantly, the spec's content has been replaced by a message that redirects people to the pending pull request.