### PR TITLE
Fix nightly status of SPARQL 1.2 Concept

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -354,7 +354,10 @@
     "shortname": "sparql12-concepts",
     "categories": [
       "-browser"
-    ]
+    ],
+    "nightly": {
+      "status": "Editor's Draft"
+    }
   },
   "https://w3c.github.io/web-nfc/",
   "https://w3c.github.io/web-share-target/",


### PR DESCRIPTION
Group Draft Note is not a "nightly" status. The spec has not been published to /TR yet, the status should switch back to "Editor's Draft" once that happens, as done for other SPARQL specs.