### PR TITLE
Fix Close Watcher title and flag spec as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -378,7 +378,11 @@
   },
   "https://wicg.github.io/capability-delegation/spec.html",
   "https://wicg.github.io/client-hints-infrastructure/",
-  "https://wicg.github.io/close-watcher/",
+  {
+    "url": "https://wicg.github.io/close-watcher/",
+    "title": "Close Watcher API",
+    "standing": "discontinued"
+  },
   "https://wicg.github.io/compression/",
   "https://wicg.github.io/content-index/spec/",
   "https://wicg.github.io/cookie-store/",


### PR DESCRIPTION
Spec about to be folded into the HTML spec.

Keeping the spec as "discontinued" for the interest of integration with Specref. Entry should get an `obsoletedBy` property that points to HTML once we have such a mechanism in place (see #1006).