### PR TITLE
Add RFC 8297 (103 Early Hints)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -543,6 +543,7 @@
       }
     ]
   },
+  "https://www.rfc-editor.org/rfc/rfc8297",
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
   {


### PR DESCRIPTION
Fixes #1019 

Technically this spec has a Category of Experimental, which seemingly may go against the [Spec selection criteria](https://github.com/w3c/browser-specs/blob/main/README.md#spec-selection-criteria), but it's also in the [HTML standard](https://html.spec.whatwg.org/multipage/semantics.html#early-hints) and [implemented in Chrome](https://developer.chrome.com/blog/early-hints/), and coming soon in Safari 17 (it's already in Safari Tech Preview).