### PR TITLE
Enable dependencies caching in jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,18 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-        cache: 'npm'
-
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
         # Need to checkout all history as job also needs to access the
         # xxx-specs@latest branches
         fetch-depth: 0
+
+    - name: Setup node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
 
     - name: Setup environment
       run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -10,14 +10,14 @@ jobs:
     name: Check base URL
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: 'npm'
-
-    - name: Checkout repo
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout latest version of release script
+        uses: actions/checkout@v3
+
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'npm'
-
-      - name: Checkout latest version of release script
-        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
 
       - name: Checkout latest version of release script
         uses: actions/checkout@v3

--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -10,14 +10,14 @@ jobs:
     name: Update the list of monitored specs and highlights those that have changed
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout latest version of release script
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: 'npm'
-
-    - name: Checkout latest version of release script
-      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v3

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v3
@@ -27,11 +28,7 @@ jobs:
         ref: main
 
     - name: Install dependencies
-      run: |
-        npm install --no-save @octokit/rest
-        npm install --no-save @octokit/plugin-throttling
-        npm install --no-save rimraf
-        npm install --no-save @jsdevtools/npm-publish
+      run: npm ci
 
     - name: Release package if needed
       run: node src/release-package.js ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,16 +16,16 @@ jobs:
     if: startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout latest version of release script
+      uses: actions/checkout@v3
+      with:
+        ref: main
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: 'npm'
-
-    - name: Checkout latest version of release script
-      uses: actions/checkout@v3
-      with:
-        ref: main
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v3

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -10,14 +10,14 @@ jobs:
     name: Find potential new specs
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout latest version of release script
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: 'npm'
-
-    - name: Checkout latest version of release script
-      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -13,14 +13,13 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
-    - name: Checkout webref
+    - name: Checkout latest version of release script
       uses: actions/checkout@v3
 
     - name: Install dependencies
-      run: |
-        npm install --no-save @octokit/rest
-        npm install --no-save @octokit/plugin-throttling
+      run: npm ci
 
     - name: Request review of pre-release PR
       run: node src/request-pr-review.js

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -9,14 +9,14 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout latest version of release script
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: 'npm'
-
-    - name: Checkout latest version of release script
-      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
This should speed up installation of dependencies (this usually only takes a few seconds for browser-specs so speedup will remain limited) and save a bit of energy.

This update also switches to using `npm ci` everywhere instead of installing only required dependencies, for consistency across jobs.