### PR TITLE
Add css-borders-4 (as "full" spec for now)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -80,6 +80,7 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Backgrounds 4"
   },
+  "https://drafts.csswg.org/css-borders-4/",
   "https://drafts.csswg.org/css-color-6/ delta",
   "https://drafts.csswg.org/css-color-hdr/",
   "https://drafts.csswg.org/css-conditional-values-1/",


### PR DESCRIPTION
Spec is a "delta" spec that creates its own series, which we cannot easily capture without changing the data model or (implicit) guarantees enforced by tests.

Such breaking changes could be introduced later if we realize that we really need to capture the "delta" composition status of the spec.

See discussion in https://github.com/w3c/browser-specs/issues/1025

This will add the following entry to the list:

```json
{
  "url": "https://drafts.csswg.org/css-borders-4/",
  "seriesComposition": "full",
  "shortname": "css-borders-4",
  "series": {
    "shortname": "css-borders",
    "currentSpecification": "css-borders-4",
    "title": "CSS Borders and Box Decorations",
    "shortTitle": "CSS Borders and Box Decorations",
    "nightlyUrl": "https://drafts.csswg.org/css-borders/"
  },
  "seriesVersion": "4",
  "organization": "W3C",
  "groups": [
    {
      "name": "Cascading Style Sheets (CSS) Working Group",
      "url": "https://www.w3.org/Style/CSS/"
    }
  ],
  "nightly": {
    "url": "https://drafts.csswg.org/css-borders-4/",
    "status": "Editor's Draft",
    "alternateUrls": [
      "https://w3c.github.io/csswg-drafts/css-borders-4/",
      "https://w3c.github.io/csswg-drafts/css-borders/"
    ],
    "repository": "https://github.com/w3c/csswg-drafts",
    "sourcePath": "css-borders-4/Overview.bs",
    "filename": "index.html"
  },
  "title": "CSS Borders and Box Decorations Module Level 4",
  "source": "spec",
  "shortTitle": "CSS Borders and Box Decorations 4",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```