### PR TITLE
Add Permissions Registry, consider registries in find-specs

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -102,6 +102,7 @@
             "A Collection of Interesting Ideas",
             "Draft Community Group Report",
             "Draft Finding",
+            "Draft Registry",
             "Editor's Draft",
             "Experimental",
             "Informational",

--- a/specs.json
+++ b/specs.json
@@ -432,6 +432,7 @@
       "sourcePath": "actions/index.html"
     }
   },
+  "https://w3c.github.io/permissions-registry/",
   "https://w3c.github.io/PNG-spec/",
   {
     "url": "https://w3c.github.io/sparql-concepts/spec/",

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -77,7 +77,7 @@ const hasUntrackedURL = ({spec: url}) => !specs.find(s => s.nightly.url.startsWi
                                             ));
 const hasUnknownTrSpec = ({spec: url}) => !specs.find(s => s.release && trimSlash(s.release.url) === trimSlash(url)) && !specs.find(s => hasMoreRecentLevel(s,url));
 
-const composeFilters = (f1, f2) => value => f1(value) || f2(value);
+const eitherFilter = (f1, f2) => value => f1(value) || f2(value);
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
       && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));
 const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}) => {
@@ -124,7 +124,7 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
   // * check repos with w3c.json/repo-type including rec-track
   const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
         .map(fullName => repos.find(matchRepoName(fullName)));
-  const recTrackRepos = wgRepos.filter(composeFilters(hasRepoType('rec-track'), hasRepoType('registry')));
+  const recTrackRepos = wgRepos.filter(eitherFilter(hasRepoType('rec-track'), hasRepoType('registry')));
 
   // * look if those with homepage URLs have a match in the list of specs
   candidates = recTrackRepos.filter(r => r.homepageUrl)

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -77,6 +77,7 @@ const hasUntrackedURL = ({spec: url}) => !specs.find(s => s.nightly.url.startsWi
                                             ));
 const hasUnknownTrSpec = ({spec: url}) => !specs.find(s => s.release && trimSlash(s.release.url) === trimSlash(url)) && !specs.find(s => hasMoreRecentLevel(s,url));
 
+const composeFilters = (f1, f2) => value => f1(value) || f2(value);
 const hasRepoType = type => r => r.w3c && r.w3c["repo-type"]
       && (r.w3c["repo-type"] === type || r.w3c["repo-type"].includes(type));
 const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}) => {
@@ -123,7 +124,7 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
   // * check repos with w3c.json/repo-type including rec-track
   const wgRepos = wgs.map(g => g.repos.map(r => r.fullName)).flat()
         .map(fullName => repos.find(matchRepoName(fullName)));
-  const recTrackRepos = wgRepos.filter(hasRepoType('rec-track'));
+  const recTrackRepos = wgRepos.filter(composeFilters(hasRepoType('rec-track'), hasRepoType('registry')));
 
   // * look if those with homepage URLs have a match in the list of specs
   candidates = recTrackRepos.filter(r => r.homepageUrl)


### PR DESCRIPTION
This update also relaxes the rule on the nightly status to also accept "Draft Registry". Technically speaking, that's sort of wrong because the nightly version should rather be an "Editor's Draf of a Draft Registry", but that seems uselessly picky.