### PR TITLE
Force nightly status of PNG spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -426,7 +426,12 @@
     }
   },
   "https://w3c.github.io/permissions-registry/",
-  "https://w3c.github.io/PNG-spec/",
+  {
+    "url": "https://w3c.github.io/PNG-spec/",
+    "nightly": {
+      "status": "Editor's Draft"
+    }
+  },
   {
     "url": "https://w3c.github.io/sparql-concepts/spec/",
     "shortname": "sparql12-concepts",


### PR DESCRIPTION
The ED currently reflects the /TR status and claims it is a CR Snapshot. Worth fixing in the ED perhaps but then that seems like a good candidate fight for another day...

(Note build will continue to fail due to unrelated broken links in the Network Error Logging entry, reported in https://github.com/w3c/network-error-logging/pull/163#issuecomment-1740365947)