### PR TITLE
Update URL of network-error-logging

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1114,7 +1114,7 @@
     ]
   },
   "https://www.w3.org/TR/navigation-timing-2/",
-  "https://www.w3.org/TR/network-error-logging-1/",
+  "https://www.w3.org/TR/network-error-logging/",
   "https://www.w3.org/TR/openscreenprotocol/",
   "https://www.w3.org/TR/orientation-event/",
   "https://www.w3.org/TR/orientation-sensor/",


### PR DESCRIPTION
Spec no longer comes as Level 1. Should fix #1078.