### PR TITLE
More updates based on #1008

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -523,6 +523,10 @@
   "https://wicg.github.io/manifest-incubations/",
   "https://wicg.github.io/media-feeds/",
   {
+    "url": "https://wicg.github.io/nav-speculation/no-vary-search.html",
+    "shortname": "no-vary-search"
+  },
+  {
     "url": "https://wicg.github.io/nav-speculation/prefetch.html",
     "shortname": "prefetch"
   },
@@ -950,6 +954,18 @@
     }
   },
   "https://www.w3.org/TR/DOM-Parsing/",
+  {
+    "url": "https://www.w3.org/TR/dpub-aam-1.1/",
+    "categories": [
+      "-browser"
+    ]
+  },
+  {
+    "url": "https://www.w3.org/TR/dpub-aria-1.1/",
+    "categories": [
+      "-browser"
+    ]
+  },
   "https://www.w3.org/TR/edit-context/",
   {
     "url": "https://www.w3.org/TR/encrypted-media/",

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -422,7 +422,7 @@
       "comment": "Proposal in a personal repository, no adoption from community"
     },
     "https://w3c.github.io/math-aam/": {
-      "comment": "no longer worked on and community froup closed"
+      "comment": "no longer worked on and community group closed"
     }
   }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -24,9 +24,6 @@
     "Education and Outreach Working Group": {
       "comment": "specs not targeted at browsers"
     },
-    "EPUB 3 Working Group": {
-      "comment": "specs not targeted at browsers"
-    },
     "MiniApps Working Group": {
       "comment": "specs not targeted at browsers"
     },
@@ -151,15 +148,6 @@
     },
     "w3c/webappsec-uisecurity": {
       "comment": "no longer worked on"
-    },
-    "w3c/dpub-aam": {
-      "comment": "not targeting browsers but epub readers"
-    },
-    "w3c/dpub-aria": {
-      "comment": "not targeting browsers but epub readers"
-    },
-    "w3c/publ-epub-revision": {
-      "comment": "not targeting browsers but epub readers"
     },
     "WICG/audio-focus": {
       "comment": "moved to w3c/audio-session"
@@ -287,7 +275,7 @@
       "comment": "no longer worked on"
     },
     "https://www.w3.org/TR/webpayments-http-messages/": {
-      "comment": "not intended for browsers"
+      "comment": "no longer worked on"
     },
     "https://w3c.github.io/svgwg/": {
       "comment": "not a spec; draft URLs on svgwg.org"
@@ -432,6 +420,9 @@
     },
     "https://tabatkins.github.io/specs/css-stacking-context-1/": {
       "comment": "Proposal in a personal repository, no adoption from community"
+    },
+    "https://w3c.github.io/math-aam/": {
+      "comment": "no longer worked on and community froup closed"
     }
   }
 }

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -343,6 +343,14 @@
     "patcg-individual-drafts/private-aggregation-api": {
       "lastreviewed": "2023-10-10",
       "comment": "proposal has not been adopted by the Private Advertising Technology Community Group"
+    },
+    "screen-share/capture-all-screens": {
+      "lastreviewed": "2023-10-12",
+      "comment": "still early exploration phase; no clear implementation plan yet"
+    },
+    "w3c/p2p-webtransport": {
+      "lastreviewed": "2023-10-12",
+      "comment": "client to server should be overtaken by WebTransport, status of p2p unclear, see https://github.com/w3c/p2p-webtransport/issues/140"
     }
   },
   "specs": {
@@ -397,6 +405,10 @@
     "https://www.w3.org/TR/css-device-adapt-1/": {
       "lastreviewed": "2023-09-01",
       "comment": "spec should be retired in 2023, see https://github.com/w3c/browser-specs/issues/837, replaced by css-viewport"
+    },
+    "https://wicg.github.io/anonymous-iframe/": {
+      "lastreviewed": "2023-10-12",
+      "comment": "no real group name in w3c.json file"
     }
   }
 }


### PR DESCRIPTION
- Add No-Vary-Search proposal
- Add DPUB ARIA as non-browser spec
- Add DPUB AAM as non-browser spec
- Monitor iframe Credentialness, pending w3c.json fix
- Monitor p2p-webtransport, pending clarification of status
- Ignore Math AAM, no longer worked on
- Update ignore rationale for webpayments-http-messages
- Drop EPUB Working Group from ignore list