### PR TITLE
Explicitly ignore execCommand and sourcing in-band track

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -423,12 +423,6 @@
     },
     "https://w3c.github.io/math-aam/": {
       "comment": "no longer worked on and community group closed"
-    },
-    "https://w3c.github.io/editing/docs/execCommand/": {
-      "comment": "no longer worked on and not implemented consistently or fully by user agents"
-    },
-    "https://dev.w3.org/html5/html-sourcing-inband-tracks/": {
-      "comment": "no longer worked on and implementation status is unclear"
     }
   }
 }

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -423,6 +423,12 @@
     },
     "https://w3c.github.io/math-aam/": {
       "comment": "no longer worked on and community group closed"
+    },
+    "https://w3c.github.io/editing/docs/execCommand/": {
+      "comment": "no longer worked on and not implemented consistently or fully by user agents"
+    },
+    "https://dev.w3.org/html5/html-sourcing-inband-tracks/": {
+      "comment": "no longer worked on and implementation status is unclear"
     }
   }
 }

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -409,6 +409,14 @@
     "https://wicg.github.io/anonymous-iframe/": {
       "lastreviewed": "2023-10-12",
       "comment": "no real group name in w3c.json file"
+    },
+    "https://w3c.github.io/editing/docs/execCommand/": {
+      "lastreviewed": "2023-10-12",
+      "comment": "no longer worked on and not implemented consistently or fully by user agents"
+    },
+    "https://dev.w3.org/html5/html-sourcing-inband-tracks/": {
+      "lastreviewed": "2023-10-12",
+      "comment": "no longer worked on and implementation status is unclear"
     }
   }
 }


### PR DESCRIPTION
Discussed in #1008. Both specs are referenced by HTML. Both specs are in a sorrow state with no plan to resume work in the foreseeable future. Adding them to the ignore list as a result.

We may want to revisit that if the situation evolves, but I don't think we should (or want ;)) to do that every 3 months.