### PR TITLE
Wait until network is idle to account for redirects in meta tags

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -248,7 +248,7 @@ async function fetchInfoFromSpecs(specs, options) {
     const page = await browser.newPage();
 
     try {
-      await page.goto(url);
+      await page.goto(url, { timeout: 120000, waitUntil: 'networkidle0' });
 
       // Wait until the generation of the spec is completely over
       // (same code as in Reffy, except Reffy forces the latest version of


### PR DESCRIPTION
This update makes the code use the same fetch options as Reffy, waiting until the page has fully loaded. This makes the code follow redirects implemented as a `<meta>` tag in particular (e.g. Close Watcher).

Note build will continue to fail for now because of the URL Pattern spec that currently returns "Testing" as content.
