### PR TITLE
Add the AVIF specification

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1,5 +1,15 @@
 [
   {
+    "url": "https://aomediacodec.github.io/av1-avif/",
+    "organization": "Alliance for Open Media",
+    "groups": [
+      {
+        "name": "Storage and Transport Formats Working Group",
+        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
+      }
+    ]
+  },
+  {
     "url": "https://compat.spec.whatwg.org/",
     "nightly": {
       "sourcePath": "compatibility.bs"


### PR DESCRIPTION
Partially addresses #1088.

This would add the following entry to the list. Note that the code currently fails to extract the "Final Deliverable" status of the spec and rather says that it is an "Editor's Draft". That seems fine for now, but we should look into it when we address the other specs mentioned in #1088.

```json
{
  "url": "https://aomediacodec.github.io/av1-avif/",
  "seriesComposition": "full",
  "shortname": "av1-avif",
  "series": {
    "shortname": "av1-avif",
    "currentSpecification": "av1-avif",
    "title": "AV1 Image File Format (AVIF)",
    "shortTitle": "AVIF",
    "nightlyUrl": "https://aomediacodec.github.io/av1-avif/"
  },
  "organization": "Alliance for Open Media",
  "groups": [
    {
      "name": "Storage and Transport Formats Working Group",
      "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
    }
  ],
  "nightly": {
    "url": "https://aomediacodec.github.io/av1-avif/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/AOMediaCodec/av1-avif",
    "sourcePath": "index.bs",
    "filename": "index.html"
  },
  "title": "AV1 Image File Format (AVIF)",
  "source": "spec",
  "shortTitle": "AVIF",
  "categories": [
    "browser"
  ],
  "standing": "good",
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "avif"
    ]
  }
}
```