### PR TITLE
Add Network Reporting API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -452,6 +452,13 @@
     }
   },
   {
+    "url": "https://w3c.github.io/reporting/network-reporting.html",
+    "shortname": "network-reporting",
+    "nightly": {
+      "sourcePath": "network-reporting.bs"
+    }
+  },
+  {
     "url": "https://w3c.github.io/sparql-concepts/spec/",
     "shortname": "sparql12-concepts",
     "categories": [


### PR DESCRIPTION
Detected when trying to use autolinks in network-error-logging as a result of https://github.com/w3c/strudy/pull/484
It wasn't automatically detected since it's "hidden" in the general Reporting API repo.


This adds the following JSON:

```json
    {
      "url": "https://w3c.github.io/reporting/network-reporting.html",
      "seriesComposition": "full",
      "shortname": "network-reporting",
      "series": {
        "shortname": "network-reporting",
        "currentSpecification": "network-reporting",
        "title": "Network Reporting API",
        "shortTitle": "Network Reporting API",
        "nightlyUrl": "https://w3c.github.io/reporting/network-reporting.html"
      },
      "nightly": {
        "url": "https://w3c.github.io/reporting/network-reporting.html",
        "status": "Editor's Draft",
        "sourcePath": "network-reporting.bs",
        "alternateUrls": [],
        "repository": "https://github.com/w3c/reporting",
        "filename": "network-reporting.html"
      },
      "organization": "W3C",
      "groups": [
        {
          "name": "Web Performance Working Group",
          "url": "https://www.w3.org/groups/wg/webperf/"
        }
      ],
      "title": "Network Reporting API",
      "source": "spec",
      "shortTitle": "Network Reporting API",
      "categories": [
        "browser"
      ],
      "standing": "good"
    }
```