### PR TITLE
Switch jobs to use Node.js v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Setup environment

--- a/.github/workflows/check-base-url.yml
+++ b/.github/workflows/check-base-url.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Setup environment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/monitor-specs.yml
+++ b/.github/workflows/monitor-specs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/report-new-specs.yml
+++ b/.github/workflows/report-new-specs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
Some dependency updates seem to require Node.js v20. Switching all jobs for consistency.