### PR TITLE
Automate processing of IETF (group) drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ The `excludePaths` property is seldom set.
 The provenance for the `title` and `nightly` property values. Can be one of:
 - `w3c`: information retrieved from the [W3C API](https://w3c.github.io/w3c-api/)
 - `specref`: information retrieved from [Specref](https://www.specref.org/)
+- `ietf`: information retrieved from the [IETF datatracker](https://datatracker.ietf.org)
 - `spec`: information retrieved from the spec itself
 
 The `source` property is always set.

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -60,7 +60,7 @@
 
     "source": {
       "type": "string",
-      "enum": ["w3c", "specref", "spec"]
+      "enum": ["w3c", "specref", "spec", "ietf"]
     },
 
     "release": {

--- a/specs.json
+++ b/specs.json
@@ -18,12 +18,10 @@
   "https://console.spec.whatwg.org/",
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
-    "shortname": "partitioned-cookies",
-    "organization": "IETF",
     "groups": [
       {
-        "name": "HTTP Working Group",
-        "url": "https://datatracker.ietf.org/wg/httpbis/"
+        "name": "Dylan Cutler (individual)",
+        "url": "https://datatracker.ietf.org/person/dylancutler@google.com"
       }
     ],
     "nightly": {
@@ -33,65 +31,27 @@
   },
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
-    "shortname": "client-hint-reliability",
-    "organization": "IETF",
     "groups": [
       {
-        "name": "HTTP Working Group",
-        "url": "https://datatracker.ietf.org/wg/httpbis/"
+        "name": "David Benjamin (individual)",
+        "url": "https://datatracker.ietf.org/person/davidben@google.com"
       }
     ],
     "nightly": {
-      "url": "https://www.ietf.org/archive/id/draft-davidben-http-client-hint-reliability-03.html",
       "repository": "https://github.com/davidben/http-client-hint-reliability",
       "sourcePath": "draft-davidben-http-client-hint-reliability.md"
     }
   },
-  {
-    "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
-    "shortname": "digest-headers",
-    "organization": "IETF",
-    "groups": [
-      {
-        "name": "HTTP Working Group",
-        "url": "https://datatracker.ietf.org/wg/httpbis/"
-      }
-    ],
-    "nightly": {
-      "url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html",
-      "repository": "https://github.com/httpwg/http-extensions",
-      "sourcePath": "draft-ietf-httpbis-digest-headers.md"
-    }
-  },
-  {
-    "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
-    "shortname": "rfc6265bis",
-    "organization": "IETF",
-    "groups": [
-      {
-        "name": "HTTP Working Group",
-        "url": "https://datatracker.ietf.org/wg/httpbis/"
-      }
-    ],
-    "nightly": {
-      "url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html",
-      "repository": "https://github.com/httpwg/http-extensions",
-      "sourcePath": "draft-ietf-httpbis-rfc6265bis.md"
-    }
-  },
+  "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
+  "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-zern-webp/",
-    "shortname": "webp",
-    "organization": "IETF",
     "groups": [
       {
-        "name": "Network Working Group",
-        "url": "https://datatracker.ietf.org/group/app/"
+        "name": "James Zern (individual)",
+        "url": "https://datatracker.ietf.org/person/jzern@google.com"
       }
-    ],
-    "nightly": {
-      "url": "https://www.ietf.org/archive/id/draft-zern-webp-13.html"
-    }
+    ]
   },
   "https://dom.spec.whatwg.org/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
@@ -676,7 +636,7 @@
     "url": "https://www.rfc-editor.org/rfc/rfc8288",
     "groups": [
       {
-        "name": "Mark Nottingham (individual in art area)",
+        "name": "Mark Nottingham (individual)",
         "url": "https://datatracker.ietf.org/person/mnot@mnot.net"
       }
     ]

--- a/specs.json
+++ b/specs.json
@@ -18,12 +18,6 @@
   "https://console.spec.whatwg.org/",
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
-    "groups": [
-      {
-        "name": "Dylan Cutler (individual)",
-        "url": "https://datatracker.ietf.org/person/dylancutler@google.com"
-      }
-    ],
     "nightly": {
       "url": "https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html",
       "repository": "https://github.com/DCtheTall/CHIPS-spec"
@@ -31,12 +25,6 @@
   },
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
-    "groups": [
-      {
-        "name": "David Benjamin (individual)",
-        "url": "https://datatracker.ietf.org/person/davidben@google.com"
-      }
-    ],
     "nightly": {
       "repository": "https://github.com/davidben/http-client-hint-reliability",
       "sourcePath": "draft-davidben-http-client-hint-reliability.md"
@@ -44,15 +32,7 @@
   },
   "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
   "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
-  {
-    "url": "https://datatracker.ietf.org/doc/html/draft-zern-webp/",
-    "groups": [
-      {
-        "name": "James Zern (individual)",
-        "url": "https://datatracker.ietf.org/person/jzern@google.com"
-      }
-    ]
-  },
+  "https://datatracker.ietf.org/doc/html/draft-zern-webp/",
   "https://dom.spec.whatwg.org/",
   "https://drafts.css-houdini.org/css-typed-om-2/ delta",
   {
@@ -586,15 +566,7 @@
   "https://wicg.github.io/webpackage/loading.html",
   "https://wicg.github.io/webusb/",
   "https://wicg.github.io/window-controls-overlay/",
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc2397",
-    "groups": [
-      {
-        "name": "Network Working Group",
-        "url": "https://datatracker.ietf.org/group/app/"
-      }
-    ]
-  },
+  "https://www.rfc-editor.org/rfc/rfc2397",
   {
     "url": "https://www.rfc-editor.org/rfc/rfc4120",
     "shortTitle": "Kerberos"
@@ -604,15 +576,7 @@
     "url": "https://www.rfc-editor.org/rfc/rfc6266",
     "shortTitle": "Content-Disposition in HTTP"
   },
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc6386",
-    "groups": [
-      {
-        "name": "Independent Submission",
-        "url": "https://datatracker.ietf.org/stream/ise/"
-      }
-    ]
-  },
+  "https://www.rfc-editor.org/rfc/rfc6386",
   "https://www.rfc-editor.org/rfc/rfc6454",
   "https://www.rfc-editor.org/rfc/rfc6797",
   "https://www.rfc-editor.org/rfc/rfc7034",
@@ -632,15 +596,7 @@
   "https://www.rfc-editor.org/rfc/rfc7725",
   "https://www.rfc-editor.org/rfc/rfc7838",
   "https://www.rfc-editor.org/rfc/rfc8246",
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc8288",
-    "groups": [
-      {
-        "name": "Mark Nottingham (individual)",
-        "url": "https://datatracker.ietf.org/person/mnot@mnot.net"
-      }
-    ]
-  },
+  "https://www.rfc-editor.org/rfc/rfc8288",
   "https://www.rfc-editor.org/rfc/rfc8297",
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -200,6 +200,11 @@ module.exports = async function (specs, options) {
         }
       }
     }
+    else if (spec.nightly.url.match(/\/httpwg\.org\//)) {
+      const draftName = spec.nightly.url.match(/\/(draft-ietf-(.+))\.html$/);
+      spec.nightly.repository = 'https://github.com/httpwg/http-extensions';
+      spec.nightly.sourcePath = `${draftName[1]}.md`;
+    }
   }
 
   return specs;

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -102,6 +102,26 @@ function computeShortname(url) {
       return rfcs[1];
     }
 
+    // Handle IETF group drafts
+    const ietfDraft = url.match(/\/datatracker\.ietf\.org\/doc\/html\/draft-ietf-[^\-]+-([^\/]+)/);
+    if (ietfDraft) {
+      return ietfDraft[1];
+    }
+
+    // Handle IETF individual drafts, stripping group name
+    // (NB: there is no sure way to tell that the first token is a group name,
+    // it may be the beginning of the shortname. Code below could return a name
+    // that is truncated as a result)
+    const ietfIndDraft = url.match(/\/datatracker\.ietf\.org\/doc\/html\/draft-[^\-]+-([^\/]+)/);
+    if (ietfIndDraft) {
+      if (ietfIndDraft[1].indexOf('-') !== -1) {
+        return ietfIndDraft[1].slice(ietfIndDraft[1].indexOf('-') + 1);
+      }
+      else {
+        return ietfIndDraft[1];
+      }
+    }
+
     // Handle TAG findings
     const tag = url.match(/^https?:\/\/(?:www\.)?w3\.org\/2001\/tag\/doc\/([^\/]+)\/?$/);
     if (tag) {

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -109,9 +109,10 @@ function computeShortname(url) {
     }
 
     // Handle IETF individual drafts, stripping group name
-    // (NB: there is no sure way to tell that the first token is a group name,
-    // it may be the beginning of the shortname. Code below could return a name
-    // that is truncated as a result)
+    // TODO: retrieve the list of IETF groups to make sure that the group name
+    // is an actual group name and not the beginning of the shortname:
+    // https://datatracker.ietf.org/api/v1/group/group/
+    // (multiple requests needed due to pagination, "?limit=1000" is the max)
     const ietfIndDraft = url.match(/\/datatracker\.ietf\.org\/doc\/html\/draft-[^\-]+-([^\/]+)/);
     if (ietfIndDraft) {
       if (ietfIndDraft[1].indexOf('-') !== -1) {

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -44,28 +44,63 @@ module.exports = async function (specs, options) {
   for (const spec of specs) {
     const info = parseSpecUrl(spec.url);
     if (!info) {
-      // No general rule to identify repos and groups for IETF specs
-      // instead, fetching info on groups from https://www.rfc-editor.org/in-notes/rfcXXX.json
-      if (spec.url.match(/rfc-editor\.org/)) {
+      // There is no direct way to find the name of the group behind an IETF
+      // document. The name of the draft document must follow the rules in:
+      // https://authors.ietf.org/naming-your-internet-draft
+      // If the document has already been published as an RFC, we can retrieve
+      // the name of the Internet Draft from the "draft" property in:
+      // https://www.rfc-editor.org/in-notes/rfcXXX.json
+      if (spec.url.match(/rfc-editor\.org/) ||
+          spec.url.match(/datatracker\.ietf\.org/)) {
         spec.organization = spec.organization ?? "IETF";
+        let wgName = null;
+        let wgId = null;
         if (spec.groups) continue;
-        const rfcNumber = spec.url.slice(spec.url.lastIndexOf('/') + 1);
-        const rfcJSON = await fetchJSON(`https://www.rfc-editor.org/in-notes/${rfcNumber}.json`);
-        const wgName = rfcJSON.source;
-        // draft-ietf-websec-origin-06 → websec
-        // per https://www.ietf.org/standards/ids/guidelines/#7
-        // not clear there is anything forbidding hyphens in WG acronyms though
-        // https://datatracker.ietf.org/doc/html/rfc2418#section-2.2
-        const wgId = rfcJSON.draft.split('-')[2];
-        if (wgName && wgId) {
-          spec.groups = [{
-            name: `${wgName} Working Group`,
-            url: `https://datatracker.ietf.org/wg/${wgId}/`
-          }];
-          continue;
-        } else {
-          throw new Error(`Could not identify IETF group producing ${spec.url}`);
+        if (spec.url.match(/rfc-editor\.org/)) {
+          const rfcNumber = spec.url.slice(spec.url.lastIndexOf('/') + 1);
+          const rfcJSON = await fetchJSON(`https://www.rfc-editor.org/in-notes/${rfcNumber}.json`);
+          if (!rfcJSON.draft) {
+            throw new Error(`Cannot derive IETF group for ${spec.url}.
+              No draft URL found. Is it an individual submission?`);
+          }
+          wgId = rfcJSON.draft.split('-')[2];
+          if (!wgId) {
+            throw new Error (`Cannot derive IETF group for ${spec.url}.
+              Draft URL ${rfcJSON.draft} does not seem to contain a group ID.`);
+          }
+          wgName = rfcJSON.source;
+          if (!wgName) {
+            throw new Error (`The RFC info for ${spec.url} does not contain a group name.`);
+          }
         }
+        else {
+          const draftName = spec.url.match(/\/(draft-ietf-[^\/]+)/);
+          if (!draftName) {
+            throw new Error(`Cannot derive IETF group for ${spec.url}. Individual submission?`);
+          }
+          wgId = draftName[1].split('-')[2];
+          wgName = wgId;
+          if (wgId === 'http') {
+            // Someone forgot to update their reference...
+            wgId = 'httpbis';
+          }
+          if (wgId === 'httpbis') {
+            wgName = 'HTTP';
+          }
+          else {
+            // TODO: fetch actual group name from https://datatracker.ietf.org/wg/${wgId}/
+            throw new Error(
+              `Found unknown IETF group ID "${wgId}" for ${spec.url}.
+              Group name should appear in https://datatracker.ietf.org/wg/${wgId}/`
+            );
+          }
+        }
+
+        spec.groups = [{
+          name: `${wgName} Working Group`,
+          url: `https://datatracker.ietf.org/wg/${wgId}/`
+        }];
+        continue;
       }
       if (!spec.groups) {
         throw new Error(`Cannot extract any useful info from ${spec.url}`);

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -74,6 +74,12 @@ describe("compute-repository module", async () => {
       "https://github.com/khronosgroup/WebGL");
   });
 
+  it("handles IETF HTTP WG URLs", async () => {
+    assert.equal(
+      await computeSingleRepo("https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html"),
+      "https://github.com/httpwg/http-extensions");
+  });
+
   it("returns null when repository cannot be derived from URL", async () => {
     assert.equal(
       await computeSingleRepo("https://example.net/repoless"),

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -52,6 +52,22 @@ describe("compute-shortname module", () => {
       assertName("https://drafts.css-houdini.org/magic/", "magic");
     });
 
+    it("handles IETF RFCs", () => {
+      assertName("https://www.rfc-editor.org/rfc/rfc2397", "rfc2397");
+    });
+
+    it("handles IETF group drafts", () => {
+      assertName("https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis", "rfc6265bis");
+    });
+
+    it("handles IETF group drafts from individuals", () => {
+      assertName("https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies", "partitioned-cookies");
+    });
+
+    it("handles (simple) IETF individual drafts", () => {
+      assertName("https://datatracker.ietf.org/doc/html/draft-zern-webp/", "webp");
+    });
+
     it("handles SVG draft URLs", () => {
       assertName("https://svgwg.org/specs/module/", "svg-module");
     });

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -75,6 +75,24 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
+  it("handles IETF individual drafts", async () => {
+    const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies");
+    assert.equal(res.organization, "IETF");
+    assert.deepStrictEqual(res.groups, [{
+      name: "Individual Submissions",
+      url: "https://datatracker.ietf.org/wg/none/"
+    }]);
+  });
+
+  it("handles IETF area drafts", async () => {
+    const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-zern-webp");
+    assert.equal(res.organization, "IETF");
+    assert.deepStrictEqual(res.groups, [{
+      name: "Applications and Real-Time Area",
+      url: "https://datatracker.ietf.org/wg/art/"
+    }]);
+  });
+
   it("preserves provided info", async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -57,6 +57,24 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
+  it("handles IETF RFCs", async () => {
+    const res = await fetchGroupsFor("https://www.rfc-editor.org/rfc/rfc9110");
+    assert.equal(res.organization, "IETF");
+    assert.deepStrictEqual(res.groups, [{
+      name: "HTTP Working Group",
+      url: "https://datatracker.ietf.org/wg/httpbis/"
+    }]);
+  });
+
+  it("handles IETF group drafts", async () => {
+    const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers");
+    assert.equal(res.organization, "IETF");
+    assert.deepStrictEqual(res.groups, [{
+      name: "HTTP Working Group",
+      url: "https://datatracker.ietf.org/wg/httpbis/"
+    }]);
+  });
+
   it("preserves provided info", async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -99,6 +99,28 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].nightly.status, "Editor's Draft");
       assert.equal(info[spec.shortname].title, "Intl.Segmenter Proposal");
     });
+
+    it("extracts a suitable nightly URL from an IETF draft", async () => {
+      const spec = {
+        url: "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
+        shortname: "client-hint-reliability"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.match(info[spec.shortname].nightly.url, /^https:\/\/www\.ietf\.org\/archive\/id\/draft-davidben-http-client-hint-reliability-\d+\.html/);
+    });
+
+    it("extracts a suitable nightly URL from an IETF HTTP WG draft", async () => {
+      const spec = {
+        url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
+        shortname: "digest-headers"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].nightly.url, "https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html");
+    });
   });
 
     describe("fetch from W3C API", () => {

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -59,6 +59,41 @@ describe("fetch-info module", function () {
     });
   });
 
+  describe("fetch from IETF datatracker", () => {
+    it("extracts a suitable nightly URL from an IETF draft", async () => {
+      const spec = {
+        url: "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
+        shortname: "client-hint-reliability"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].title, "Client Hint Reliability");
+      assert.equal(info[spec.shortname].source, "ietf");
+      assert.match(info[spec.shortname].nightly.url, /^https:\/\/www\.ietf\.org\/archive\/id\/draft-davidben-http-client-hint-reliability-\d+\.html/);
+    });
+
+    it("extracts a suitable nightly URL from an IETF HTTP WG draft", async () => {
+      const spec = {
+        url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
+        shortname: "digest-headers"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].title, "Digest Fields");
+      assert.equal(info[spec.shortname].source, "ietf");
+      assert.equal(info[spec.shortname].nightly.url, "https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html");
+    });
+
+    it("throws when an IETF URL needs to be updated", async () => {
+      const spec = {
+        url: "https://datatracker.ietf.org/doc/html/draft-ietf-websec-strict-transport-sec",
+        shortname: "strict-transport-sec"
+      };
+      await assert.rejects(
+        fetchInfo([spec]),
+        /^Error: IETF spec (.*) published under a new name/);
+    });
+  });
 
   describe("fetch from spec", () => {
     it("extracts spec info from a Bikeshed spec when needed", async () => {
@@ -98,28 +133,6 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].nightly.url, spec.url);
       assert.equal(info[spec.shortname].nightly.status, "Editor's Draft");
       assert.equal(info[spec.shortname].title, "Intl.Segmenter Proposal");
-    });
-
-    it("extracts a suitable nightly URL from an IETF draft", async () => {
-      const spec = {
-        url: "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
-        shortname: "client-hint-reliability"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "spec");
-      assert.match(info[spec.shortname].nightly.url, /^https:\/\/www\.ietf\.org\/archive\/id\/draft-davidben-http-client-hint-reliability-\d+\.html/);
-    });
-
-    it("extracts a suitable nightly URL from an IETF HTTP WG draft", async () => {
-      const spec = {
-        url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
-        shortname: "digest-headers"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "spec");
-      assert.equal(info[spec.shortname].nightly.url, "https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html");
     });
   });
 


### PR DESCRIPTION
The code now recognizes IETF draft documents that have a `datatracker.ietf.org` URL:
- It associates them with the IETF organization
- It can compute a useful shortname (that code can in theory return a truncated shortname because there is no direct way to validate that the Internet Draft name contains a group ID).
- It extracts the group's ID from the nightly URL (that code could further be improved to fetch the actual group name, right now the code only knows about the "HTTP" working group).
- It associates IETF documents from the HTTP WG to the right repository.
- It computes the better-looking nightly URL at `www.ietf.org` or at `httpwg.org` for HTTP WG documents.

This allows to simplify IETF data in `specs.json` a bit.

Note that the code still cannot process drafts that have been submitted by individuals automatically, even when these drafts at targeted at a group. Such drafts should be associated with the individuals that submitted them and not with any group. A couple of spec entries, which incorrectly referenced the Network WG or the HTTP WG, were fixed accordingly in `specs.json`.

This fixes #1122, but note that the code does not need to fetch the datatracker page for the time being.