### PR TITLE
Fix build when previous build steps already exist

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -373,16 +373,18 @@ async function generateIndex(specs, { step = "all", previousIndex = null, log = 
 async function generateIndexFile(specsFile, targetFile, step) {
   // If the index already exists, reuse the info it contains when info cannot
   // be refreshed due to some external (network) issue.
-  const previousIndex = (function () {
+  const previousIndex = await (async function () {
     try {
-      return require(path.resolve(targetFile));
+      const json = await fs.readFile(path.resolve(targetFile), 'utf8');
+      return JSON.parse(json);
     }
     catch (err) {
       return [];
     }
   })();
 
-  const specs = require(path.resolve(specsFile));
+  const specsJson = await fs.readFile(path.resolve(specsFile));
+  const specs = JSON.parse(specsJson);
   const index = await generateIndex(specs, { previousIndex, step });
   console.log(`Write ${targetFile}...`);
   await fs.writeFile(targetFile, JSON.stringify(index, null, 2));


### PR DESCRIPTION
Before it runs a build step, the code loads the results of the previous step. If the file exists, it also loads the previous results of the current step, for use as fallback if some network issue occurs.

The loading was done using `require()`. The problem is that `require()` maintains a cache of loaded modules, so if the previous results of the current step existed, the code actually reused them for the *following* step as well.

This bug did not occur in production because the build job starts from scratch. In particular, it does not have previous results of build steps.