### PR TITLE
Fix and improve processing of IETF specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -600,36 +600,11 @@
   "https://www.rfc-editor.org/rfc/rfc8297",
   "https://www.rfc-editor.org/rfc/rfc8470",
   "https://www.rfc-editor.org/rfc/rfc8942",
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc9110",
-    "nightly": {
-      "repository": "https://github.com/httpwg/httpwg.github.io"
-    }
-  },
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc9111",
-    "nightly": {
-      "repository": "https://github.com/httpwg/httpwg.github.io"
-    }
-  },
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc9112",
-    "nightly": {
-      "repository": "https://github.com/httpwg/httpwg.github.io"
-    }
-  },
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc9113",
-    "nightly": {
-      "repository": "https://github.com/httpwg/httpwg.github.io"
-    }
-  },
-  {
-    "url": "https://www.rfc-editor.org/rfc/rfc9114",
-    "nightly": {
-      "repository": "https://github.com/httpwg/httpwg.github.io"
-    }
-  },
+  "https://www.rfc-editor.org/rfc/rfc9110",
+  "https://www.rfc-editor.org/rfc/rfc9111",
+  "https://www.rfc-editor.org/rfc/rfc9112",
+  "https://www.rfc-editor.org/rfc/rfc9113",
+  "https://www.rfc-editor.org/rfc/rfc9114",
   {
     "url": "https://www.rfc-editor.org/rfc/rfc9163",
     "nightly": {


### PR DESCRIPTION
Take 3 :)

PR #1135 actually had a couple of issues that made the code essentially useless because it only ran on a handful of IETF specs:
- the code favored info from Specref over info from IETF
- the code only really applied to drafts due to a buggy RegExp

Fixing these problems yielded a new issue: the assumption that HTTP WG specs are always available under `httpwg.org` turns out to be wrong. Also, there are other specs that are not published by the HTTP WG but that still have an `httpwg.org` version. The code now looks at the actual list of specs in the underlying GitHub repository: https://github.com/httpwg/httpwg.github.io.

As a result, the nightly URL of all IETF specs that have an `httpwg.org` version now targets that version, implementing the suggestion in #933 (see that issue for the list of affected specs). A companion PR was sent to Specref to implement a similar switch there:
https://github.com/tobie/specref/pull/766

The code also looks at the obsolescence data in datatracker and sets the `standing` and `obsoletedBy` properties accordingly. This fixes #327.