### PR TITLE
Use last published information for discontinued specs

### DIFF
--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -33,7 +33,7 @@ module.exports = async function (specs, options) {
   async function fetchJSON(url, options) {
     const body = cache[url] ?? await fetch(url, options).then(res => {
       if (res.status !== 200) {
-        throw new Error(`W3C API returned an error, status code is ${res.status}`);
+        throw new Error(`W3C API returned an error for ${url}, status code is ${res.status}`);
       }
       return res.json();
     });
@@ -42,6 +42,12 @@ module.exports = async function (specs, options) {
   }
 
   for (const spec of specs) {
+    if (spec.__last?.standing === 'discontinued' &&
+        (!spec.standing || spec.standing === 'discontinued')) {
+      spec.organization = spec.__last.organization;
+      spec.groups = spec.__last.groups;
+      continue;
+    }
     const info = parseSpecUrl(spec.url);
     if (!info) {
       // For IETF documents, retrieve the group info from datatracker

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -195,5 +195,23 @@ describe("fetch-groups module (without API keys)", function () {
         url: "https://www.w3.org/Style/CSS/"
       }]);
     });
+
+    it("uses last published info for discontinued specs", async () => {
+      const spec = {
+        url: "https://wicg.github.io/close-watcher/",
+        shortname: "close-watcher",
+        __last: {
+          standing: "discontinued",
+          organization: "Acme Corporation",
+          groups: [{
+            name: "Road Runner",
+            url: "beep beep"
+          }]
+        }
+      };
+      const result = await fetchGroups([spec]);
+      assert.equal(result[0].organization, spec.__last.organization);
+      assert.deepStrictEqual(result[0].groups, spec.__last.groups);
+    });
   });
 });

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -18,7 +18,6 @@ describe("fetch-info module", function () {
     return spec;
   }
 
-
   describe("fetch from Specref", () => {
     it("works on a WHATWG spec", async () => {
       const spec = {
@@ -264,6 +263,20 @@ describe("fetch-info module", function () {
 
 
   describe("fetch from all sources", () => {
+    it("uses the last published info for discontinued specs", async () => {
+      const spec = {
+        url: "https://wicg.github.io/close-watcher/",
+        shortname: "close-watcher",
+        __last: {
+          standing: "discontinued",
+          organization: "Acme Corporation"
+        }
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].organization, spec.__last.organization);
+    });
+
     it("merges info from sources", async () => {
       const w3c = getW3CSpec("presentation-api");
       const whatwg = {


### PR DESCRIPTION
This fixes #1130 by turning the "discontinued" standing into a frozen state: when the last published version of web-specs says that the standing of a spec is "discontinued", the code directly reuses the information from that last published version for that spec.

There remained a couple of places in the build script that did not give priority to information specified in `specs.json`. This update also fixes that (and needs it!).

If a discontinued spec needs to be revived, the only way to do that will be to make the new standing explicit in `specs.json`.

Loading the last published version of web-specs could prove useful for #61 as well, but that's not part of this update.