### PR TITLE
Add AOM specs

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -10,7 +10,7 @@
 
     "filename": {
       "type": "string",
-      "pattern": "^[\\w\\-\\.]+\\.html$"
+      "pattern": "^[\\w\\-\\.]+\\.(html|pdf)$"
     },
 
     "relativePath": {
@@ -75,6 +75,7 @@
             "Discontinued Draft",
             "Draft Note",
             "Draft Registry",
+            "Final Deliverable",
             "First Public Working Draft",
             "Note",
             "Proposed Recommendation",
@@ -101,10 +102,12 @@
           "enum": [
             "A Collection of Interesting Ideas",
             "Draft Community Group Report",
+            "Draft Deliverable",
             "Draft Finding",
             "Draft Registry",
             "Editor's Draft",
             "Experimental",
+            "Final Deliverable",
             "Informational",
             "Internet Standard",
             "Living Standard",

--- a/specs.json
+++ b/specs.json
@@ -1,5 +1,10 @@
 [
-  "https://aomediacodec.github.io/afgs1-spec/",
+  {
+    "url": "https://aomediacodec.github.io/afgs1-spec/",
+    "categories": [
+      "-browser"
+    ]
+  },
   {
     "url": "https://aomediacodec.github.io/av1-avif/",
     "groups": [

--- a/specs.json
+++ b/specs.json
@@ -12,9 +12,17 @@
         "name": "Storage and Transport Formats Working Group",
         "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
       }
-    ]
+    ],
+    "nightly": {
+      "status": "Final Deliverable"
+    }
   },
-  "https://aomediacodec.github.io/av1-hdr10plus/",
+  {
+    "url": "https://aomediacodec.github.io/av1-hdr10plus/",
+    "nightly": {
+      "status": "Final Deliverable"
+    }
+  },
   {
     "url": "https://aomediacodec.github.io/av1-isobmff/",
     "groups": [
@@ -42,7 +50,12 @@
       }
     ]
   },
-  "https://aomediacodec.github.io/av1-spec/",
+  {
+    "url": "https://aomediacodec.github.io/av1-spec/av1-spec.pdf",
+    "nightly": {
+      "url": "https://aomediacodec.github.io/av1-spec/"
+    }
+  },
   {
     "url": "https://compat.spec.whatwg.org/",
     "nightly": {

--- a/specs.json
+++ b/specs.json
@@ -1,7 +1,7 @@
 [
+  "https://aomediacodec.github.io/afgs1-spec/",
   {
     "url": "https://aomediacodec.github.io/av1-avif/",
-    "organization": "Alliance for Open Media",
     "groups": [
       {
         "name": "Storage and Transport Formats Working Group",
@@ -9,6 +9,35 @@
       }
     ]
   },
+  "https://aomediacodec.github.io/av1-hdr10plus/",
+  {
+    "url": "https://aomediacodec.github.io/av1-isobmff/",
+    "groups": [
+      {
+        "name": "Storage and Transport Formats Working Group",
+        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
+      }
+    ]
+  },
+  {
+    "url": "https://aomediacodec.github.io/av1-mpeg2-ts/",
+    "groups": [
+      {
+        "name": "Storage and Transport Formats Working Group",
+        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
+      }
+    ]
+  },
+  {
+    "url": "https://aomediacodec.github.io/av1-rtp-spec/",
+    "groups": [
+      {
+        "name": "Storage and Transport Formats Working Group",
+        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
+      }
+    ]
+  },
+  "https://aomediacodec.github.io/av1-spec/",
   {
     "url": "https://compat.spec.whatwg.org/",
     "nightly": {

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -130,6 +130,7 @@ module.exports = async function (specs, options) {
       "index.src.html",
       "index.bs",
       "spec.bs",
+      "index.md",
       "index.html"
     );
 

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -28,16 +28,20 @@ module.exports = function (title) {
 
   const level = title.match(/\s(\d+(\.\d+)?)$/);
   const shortTitle = title
-    .replace(/\s/g, ' ')                // Replace non-breaking spaces
-    .replace(/ \d+(\.\d+)?$/, '')       // Drop level number for now
-    .replace(/( -)? Level$/, '')        // Drop "Level"
-    .replace(/ Module$/, '')            // Drop "Module" (now followed by level)
-    .replace(/ Proposal$/, '')          // Drop "Proposal" (TC39 proposals)
-    .replace(/ Specification$/, '')     // Drop "Specification"
-    .replace(/ Standard$/, '')          // Drop "Standard" and "Living Standard"
-    .replace(/ Living$/, '')
-    .replace(/ \([^\)]+ Edition\)/, '') // Drop edition indication
-    .replace(/^.*\(([^\)]+)\).*$/, '$1'); // Use abbr between parentheses
+    .trim()
+    .replace(/\s/g, ' ')                  // Replace non-breaking spaces
+    .replace(/ \d+(\.\d+)?$/, '')         // Drop level number for now
+    .replace(/( -)? Level$/i, '')         // Drop "Level"
+    .replace(/ \(\v\d+(\.\d+)?\)/i, '')   // Drop "(vx.y)"
+    .replace(/\(Draft\)/i, '')            // Drop "(Draft)" indication
+    .replace(/ Module$/i, '')             // Drop "Module" (now followed by level)
+    .replace(/ Proposal$/i, '')           // Drop "Proposal" (TC39 proposals)
+    .replace(/ Specification$/i, '')      // Drop "Specification"
+    .replace(/ Standard$/i, '')           // Drop "Standard" and "Living Standard"
+    .replace(/ Living$/i, '')
+    .replace(/ \([^\)]+ Edition\)/i, '')  // Drop edition indication
+    .replace(/^.*\(([^\)]+)\).*$/, '$1')  // Use abbr between parentheses
+    .trim();
 
   if (level) {
     return shortTitle + " " + level[1];

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -11,7 +11,7 @@
 
 module.exports = async function (url) {
   // Extract filename directly from the URL when possible
-  const match = url.match(/\/([^/]+\.html)$/);
+  const match = url.match(/\/([^/]+\.(html|pdf))$/);
   if (match) {
     return match[1];
   }

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -126,6 +126,17 @@ module.exports = async function (specs, options) {
       }];
     }
 
+    // For the Alliance for Open Media (AOM), let's consider that the Codec WG
+    // is the default group, noting that it is not super clear which AOM group
+    // develops which spec in practice: https://aomedia.org/about/
+    if (info && info.owner === "aomediacodec") {
+      spec.organization = spec.organization ?? "Alliance for Open Media";
+      spec.groups = spec.groups ?? [{
+        name: "Codec Working Group",
+        url: "https://aomedia.org/about/#codec-working-group"
+      }]
+    }
+
     // All specs that remain should be developed by some W3C group.
     spec.organization = spec.organization ?? "W3C";
 

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -558,10 +558,27 @@ async function fetchInfoFromSpecs(specs, options) {
         throw new Error(titleAndStatus.error + `, in ${url} for ${spec.shortname}`);
       }
       else {
-        return {
+        const res = {
           nightly: { url, status: titleAndStatus.status },
           title: titleAndStatus.title
         };
+
+        // The AOM has Draft Deliverables and Final Deliverables. Most AOM
+        // specs don't say what they are, we'll assume that they are drafts.
+        if (spec.organization === "Alliance for Open Media") {
+          if (res.nightly.status === "Editor's Draft" ||
+              res.nightly.status === "AOM Working Group Draft") {
+            res.nightly.status = "Draft Deliverable";
+          }
+          if (spec.nightly?.url && spec.url !== spec.nightly.url) {
+            res.release = {
+              url: spec.url,
+              status: "Final Deliverable"
+            };
+          }
+        }
+
+        return res;
       }
     }
     finally {

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -79,6 +79,12 @@ describe("compute-shorttitle module", () => {
       "Foo Bar");
   });
 
+  it("drops '(Draft)' from title", () => {
+    assertTitle(
+      "(Draft) Beer",
+      "Beer");
+  });
+
   it("preserves title when needed", () => {
     assertTitle(
       "Edition Module Standard Foo",
@@ -95,5 +101,11 @@ describe("compute-shorttitle module", () => {
     assertTitle(
       "Hypertext Transfer Protocol (HTTP/1.1): Foo bar",
       "HTTP/1.1 Foo bar")
+  });
+
+  it("applies rules in order", () => {
+    assertTitle(
+      " AOMedia Film Grain Synthesis (v1.0) (AFGS1) specification (Draft) ",
+      "AFGS1")
   });
 });

--- a/test/determine-filename.js
+++ b/test/determine-filename.js
@@ -6,10 +6,16 @@ describe("determine-filename module", function () {
   this.slow(5000);
   this.timeout(30000);
 
-  it("extracts filename from URL", async () => {
+  it("extracts filename from URL (.html)", async () => {
     const url = "https://example.org/spec/filename.html";
     const filename = await determineFilename(url);
     assert.equal(filename, "filename.html");
+  });
+
+  it("extracts filename from URL (.pdf)", async () => {
+    const url = "https://example.org/spec/filename.pdf";
+    const filename = await determineFilename(url);
+    assert.equal(filename, "filename.pdf");
   });
 
   it("finds index.html filenames", async () => {

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -93,6 +93,15 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
+  it("handles AOM specs", async () => {
+    const res = await fetchGroupsFor("https://aomediacodec.github.io/afgs1-spec/");
+    assert.equal(res.organization, "Alliance for Open Media");
+    assert.deepStrictEqual(res.groups, [{
+      name: "Codec Working Group",
+      url: "https://aomedia.org/about/#codec-working-group"
+    }]);
+  });
+
   it("preserves provided info", async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -198,6 +198,22 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].nightly.status, "Editor's Draft");
       assert.equal(info[spec.shortname].title, "Intl.Segmenter Proposal");
     });
+
+    it("creates a release for final AOM deliverables published as PDF", async () => {
+      const spec = {
+        url: "https://aomediacodec.github.io/av1-spec/av1-spec.pdf",
+        shortname: "av1-spec",
+        nightly: {
+          url: "https://aomediacodec.github.io/av1-spec/"
+        }
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].nightly.url, spec.nightly.url);
+      assert.equal(info[spec.shortname].release.url, spec.url);
+      assert.equal(info[spec.shortname].release.status, "Final Deliverable");
+    });
   });
 
     describe("fetch from W3C API", () => {

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -201,6 +201,7 @@ describe("fetch-info module", function () {
 
     it("creates a release for final AOM deliverables published as PDF", async () => {
       const spec = {
+        organization: "Alliance for Open Media",
         url: "https://aomediacodec.github.io/av1-spec/av1-spec.pdf",
         shortname: "av1-spec",
         nightly: {
@@ -211,6 +212,7 @@ describe("fetch-info module", function () {
       assert.ok(info[spec.shortname]);
       assert.equal(info[spec.shortname].source, "spec");
       assert.equal(info[spec.shortname].nightly.url, spec.nightly.url);
+      assert.ok(info[spec.shortname].release);
       assert.equal(info[spec.shortname].release.url, spec.url);
       assert.equal(info[spec.shortname].release.status, "Final Deliverable");
     });


### PR DESCRIPTION
AVIF had already been added to the list. This adds remaining specs from the Alliance for Open Media related to AV1.

Logic also updated to find more info about these specs automatically.

Fixes #1088.

A couple of information points that are ok-ish but that could further be improved:
1. We only record the nightly URL for now, but the official final deliverable is the PDF version. The same is true for other specs, see PDF list at https://aomedia.org/av1-features/get-started/
2. The specs are extracted as "Editor's Draft" but the status should rather be "Final Deliverable" for some of them

<details><summary>Changes to index.json</summary>

```json
[
  {
    "url": "https://aomediacodec.github.io/afgs1-spec/",
    "seriesComposition": "full",
    "shortname": "afgs1-spec",
    "series": {
      "shortname": "afgs1-spec",
      "currentSpecification": "afgs1-spec",
      "title": "AOMedia Film Grain Synthesis 1 (AFGS1) specification (Draft)",
      "shortTitle": "Draft",
      "nightlyUrl": "https://aomediacodec.github.io/afgs1-spec/"
    },
    "organization": "Alliance for Open Media",
    "groups": [
      {
        "name": "Codec Working Group",
        "url": "https://aomedia.org/about/#codec-working-group"
      }
    ],
    "nightly": {
      "url": "https://aomediacodec.github.io/afgs1-spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/afgs1-spec",
      "sourcePath": "index.md",
      "filename": "index.html"
    },
    "title": "AOMedia Film Grain Synthesis 1 (AFGS1) specification (Draft)",
    "source": "spec",
    "shortTitle": "Draft",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-hdr10plus/",
    "seriesComposition": "full",
    "shortname": "av1-hdr10plus",
    "series": {
      "shortname": "av1-hdr10plus",
      "currentSpecification": "av1-hdr10plus",
      "title": "HDR10+ AV1 Metadata Handling Specification",
      "shortTitle": "HDR10+ AV1 Metadata Handling",
      "nightlyUrl": "https://aomediacodec.github.io/av1-hdr10plus/"
    },
    "organization": "Alliance for Open Media",
    "groups": [
      {
        "name": "Codec Working Group",
        "url": "https://aomedia.org/about/#codec-working-group"
      }
    ],
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-hdr10plus/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-hdr10plus",
      "sourcePath": "index.bs",
      "filename": "index.html"
    },
    "title": "HDR10+ AV1 Metadata Handling Specification",
    "source": "spec",
    "shortTitle": "HDR10+ AV1 Metadata Handling",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-isobmff/",
    "seriesComposition": "full",
    "shortname": "av1-isobmff",
    "series": {
      "shortname": "av1-isobmff",
      "currentSpecification": "av1-isobmff",
      "title": "AV1 Codec ISO Media File Format Binding",
      "shortTitle": "AV1 Codec ISO Media File Format Binding",
      "nightlyUrl": "https://aomediacodec.github.io/av1-isobmff/"
    },
    "groups": [
      {
        "name": "Storage and Transport Formats Working Group",
        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
      }
    ],
    "organization": "Alliance for Open Media",
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-isobmff/",
      "status": "AOM Working Group Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-isobmff",
      "sourcePath": "index.bs",
      "filename": "index.html"
    },
    "title": "AV1 Codec ISO Media File Format Binding",
    "source": "spec",
    "shortTitle": "AV1 Codec ISO Media File Format Binding",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-mpeg2-ts/",
    "seriesComposition": "full",
    "shortname": "av1-mpeg2-ts",
    "series": {
      "shortname": "av1-mpeg2-ts",
      "currentSpecification": "av1-mpeg2-ts",
      "title": "Carriage of AV1 in MPEG-2 TS",
      "shortTitle": "Carriage of AV1 in MPEG-2 TS",
      "nightlyUrl": "https://aomediacodec.github.io/av1-mpeg2-ts/"
    },
    "groups": [
      {
        "name": "Storage and Transport Formats Working Group",
        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
      }
    ],
    "organization": "Alliance for Open Media",
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-mpeg2-ts/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-mpeg2-ts",
      "sourcePath": "index.html",
      "filename": "index.html"
    },
    "title": "Carriage of AV1 in MPEG-2 TS",
    "source": "spec",
    "shortTitle": "Carriage of AV1 in MPEG-2 TS",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-rtp-spec/",
    "seriesComposition": "full",
    "shortname": "av1-rtp-spec",
    "series": {
      "shortname": "av1-rtp-spec",
      "currentSpecification": "av1-rtp-spec",
      "title": "RTP Payload Format For AV1 (v1.0)",
      "shortTitle": "v1.0",
      "nightlyUrl": "https://aomediacodec.github.io/av1-rtp-spec/"
    },
    "groups": [
      {
        "name": "Storage and Transport Formats Working Group",
        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
      }
    ],
    "organization": "Alliance for Open Media",
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-rtp-spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-rtp-spec",
      "sourcePath": "index.md",
      "filename": "index.html"
    },
    "title": "RTP Payload Format For AV1 (v1.0)",
    "source": "spec",
    "shortTitle": "v1.0",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-spec/",
    "seriesComposition": "full",
    "shortname": "av1-spec",
    "series": {
      "shortname": "av1-spec",
      "currentSpecification": "av1-spec",
      "title": "AV1 Bitstream & Decoding Process Specification",
      "shortTitle": "AV1 Bitstream & Decoding Process",
      "nightlyUrl": "https://aomediacodec.github.io/av1-spec/"
    },
    "organization": "Alliance for Open Media",
    "groups": [
      {
        "name": "Codec Working Group",
        "url": "https://aomedia.org/about/#codec-working-group"
      }
    ],
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-spec/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-spec",
      "sourcePath": "index.md",
      "filename": "index.html"
    },
    "title": "AV1 Bitstream & Decoding Process Specification",
    "source": "spec",
    "shortTitle": "AV1 Bitstream & Decoding Process",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://aomediacodec.github.io/av1-avif/",
    "seriesComposition": "full",
    "shortname": "av1-avif",
    "series": {
      "shortname": "av1-avif",
      "currentSpecification": "av1-avif",
      "title": "AV1 Image File Format (AVIF)",
      "shortTitle": "AVIF",
      "nightlyUrl": "https://aomediacodec.github.io/av1-avif/"
    },
    "groups": [
      {
        "name": "Storage and Transport Formats Working Group",
        "url": "https://aomedia.org/about/#storage-and-transport-formats-working-group"
      }
    ],
    "organization": "Alliance for Open Media",
    "nightly": {
      "url": "https://aomediacodec.github.io/av1-avif/",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "repository": "https://github.com/AOMediaCodec/av1-avif",
      "sourcePath": "index.bs",
      "filename": "index.html"
    },
    "title": "AV1 Image File Format (AVIF)",
    "source": "spec",
    "shortTitle": "AVIF",
    "categories": [
      "browser"
    ],
    "standing": "good",
    "tests": {
      "repository": "https://github.com/web-platform-tests/wpt",
      "testPaths": [
        "avif"
      ]
    }
  }
]
```

</details>