### PR TITLE
Add alternate URLs for IETF RFCs

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -17,6 +17,7 @@ const computePrevNext = require("./compute-prevnext.js");
 const computeCurrentLevel = require("./compute-currentlevel.js");
 const computeRepository = require("./compute-repository.js");
 const computeSeriesUrls = require("./compute-series-urls.js");
+const computeAlternateUrls = require("./compute-alternate-urls.js");
 const computeShortTitle = require("./compute-shorttitle.js");
 const computeCategories = require("./compute-categories.js");
 const computeStanding = require("./compute-standing.js");
@@ -276,23 +277,10 @@ async function runInfo(specs) {
     delete res.series.forceCurrent;
 
 
-    // Add alternate w3c.github.io URLs for CSS specs
-    // (Note drafts of CSS Houdini and Visual effects task forces don't have a
-    // w3c.github.io version)
-    // (Also note the CSS WG uses the "css" series shortname for CSS snapshots
-    // and not for the CSS 2.x series)
     if (!res.nightly.alternateUrls) {
       res.nightly.alternateUrls = [];
-      if (res.nightly.url.match(/\/drafts\.csswg\.org/)) {
-        const draft = computeShortname(res.nightly.url);
-        res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
-        if ((res.series.currentSpecification === res.shortname) &&
-            (draft.shortname !== draft.series.shortname) &&
-            (draft.series.shortname !== 'css')) {
-          res.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
-        }
-      }
     }
+    res.nightly.alternateUrls = res.nightly.alternateUrls.concat(computeAlternateUrls(res));
 
     return res;
   });

--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -1,0 +1,35 @@
+/**
+ * Module that exports a function that takes a spec object as input that already
+ * has most of its info filled out and returns an object with "alternativeUrls"
+ * based on well-known patterns for certain publishers.
+ */
+const computeShortname = require("./compute-shortname.js");
+
+module.exports = function computeAlternateUrls(spec) {
+  if (!spec?.url) {
+    throw "Invalid spec object passed as parameter";
+  }
+  const alternate = [];
+  // Document well-known patterns also used in other specs
+  // datatracker and (now deprecated) tools.ietf.org
+  if (spec.organization === "IETF" && spec.url.startsWith("https://www.rfc-editor.org/rfc/")) {
+    alternate.push(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://datatracker.ietf.org/doc/html/"));
+    alternate.push(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://tools.ietf.org/html/"));
+  }
+
+  // Add alternate w3c.github.io URLs for CSS specs
+  // (Note drafts of CSS Houdini and Visual effects task forces don't have a
+  // w3c.github.io version)
+  // (Also note the CSS WG uses the "css" series shortname for CSS snapshots
+  // and not for the CSS 2.x series)
+  if (spec?.nightly?.url.match(/\/drafts\.csswg\.org/)) {
+    const draft = computeShortname(spec.nightly.url);
+    alternate.push(`https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
+    if ((spec.series.currentSpecification === spec.shortname) &&
+        (draft.shortname !== draft.series.shortname) &&
+        (draft.series.shortname !== 'css')) {
+      spec.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
+    }
+  }
+  return alternate;
+};

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,19 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("has a datatracker alternate URL for IETF RFCS", () => {
+    const wrong = specs
+      .filter(s => s.url.match(/\/www.rfc-editor\.org\/rfc/))
+      .filter(s => {
+	console.log(s);
+        const draft = computeShortname(s.url);
+        return !s.nightly.alternateUrls.includes(
+          `https://datatracker.ietf.org/doc/html/${draft.shortname}/`);
+      });
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  
   it("has distinct source paths for all specs", () => {
     // ... provided entries don't share the same nightly draft
     // (typically the case for CSS 2.1 and CSS 2.2)


### PR DESCRIPTION
This help e.g. to detect outdated references in specs.

This will fail CI since it will need an updated index to pass (and am getting rate-limited when trying to do so locally)