### PR TITLE
Fix alternate URLs computation

### DIFF
--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -28,7 +28,7 @@ module.exports = function computeAlternateUrls(spec) {
     if ((spec.series.currentSpecification === spec.shortname) &&
         (draft.shortname !== draft.series.shortname) &&
         (draft.series.shortname !== 'css')) {
-      spec.nightly.alternateUrls.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
+      alternate.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
     }
   }
   return alternate;


### PR DESCRIPTION
The `computeAlternateUrls` function is supposed to return the list of alternate URLs. For CSS specs, it both returned an alternate URL *and* set another one in the spec directly. Surprisingly, this did not have any bad consequence other that swapping the entries...