### PR TITLE
Fix alternateUrls logic for discontinued specs, add related tests

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -234,6 +234,13 @@ async function runInfo(specs) {
       }
     });
 
+    // If we're reusing last published discontinued info, no need to run
+    // further adjustments
+    if (res.__last?.standing === 'discontinued' &&
+        (!res.standing || res.standing === 'discontinued')) {
+      return res;
+    }
+
     // Latest ED link in TR versions of CSS specs sometimes target the spec series
     // entry point on the CSS drafts server. To make sure that the nightly URL
     // targets the same level as the TR level we're looking at, we'll add the

--- a/test/index.js
+++ b/test/index.js
@@ -216,6 +216,36 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("does not list duplicate alternate URLs", () => {
+    const wrong = specs
+      .filter(s => s.nightly.alternateUrls.length > 0)
+      .filter(s => {
+        const set = new Set(s.nightly.alternateUrls);
+        return set.size !== s.nightly.alternateUrls.length;
+      });
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("lists alternate URLs that are actual alternate URLs", () => {
+    const wrong = specs
+      .filter(s => s.nightly.alternateUrls.length > 0)
+      .filter(s => {
+        const mainSet = new Set();
+        mainSet.add(s.url);
+        mainSet.add(s.nightly.url);
+        if (s.release) {
+          mainSet.add(s.release.url);
+        }
+        const alternateSet = new Set(s.nightly.alternateUrls);
+        const alternateSize = alternateSet.size;
+        for (const url of mainSet) {
+          alternateSet.add(url);
+        }
+        return alternateSet.size !== (mainSet.size + alternateSize);
+      });
+    assert.deepStrictEqual(wrong, []);
+  });
+
   
   it("has distinct source paths for all specs", () => {
     // ... provided entries don't share the same nightly draft


### PR DESCRIPTION
Index building now skips over some quirks when processing a discontinued spec for which we reuse information from the previously published version.

New tests make sure that we never list duplicate alternate URLs, and that alternate URLs are *alternate* URLs indeed.