### PR TITLE
Ignore WICG/protected-auction-services-discussion

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -89,6 +89,9 @@
     "WICG/open-ui": {
       "comment": "not targeted at browsers"
     },
+    "WICG/protected-auction-services-discussion": {
+      "comment": "for discussions only"
+    },
     "WICG/urlpattern": {
       "comment": "moved to WHATWG"
     },


### PR DESCRIPTION
Repository is for discussions only.

The [`w3c.json`](https://github.com/WICG/protected-auction-services-discussion/blob/main/w3c.json) mentions `cg-report` as repository type. That's not completely wrong (the repo could perhaps end up containing a CG report of the discussions), but perhaps worth updating to... [`others`](https://w3c.github.io/w3c.json.html#repo-type)?

Replaces #1154