### PR TITLE
Fix handling of CSS specs and CSS snapshots

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -143,6 +143,14 @@ async function fetchInfoFromW3CApi(specs, options) {
     }
     try {
       const body = await res.json();
+
+      // The CSS specs and the CSS snapshots have different series shortnames for
+      // us ("CSS" vs. "css"), but the W3C API is case-insentive, mixes the two
+      // series,  and claims that the series shortname is "CSS" or "css"
+      // depending on which spec got published last. Let's get back to the
+      // shortname we requested.
+      body.shortname = shortname;
+
       return body;
     }
     catch (err) {
@@ -154,10 +162,27 @@ async function fetchInfoFromW3CApi(specs, options) {
   seriesInfo.forEach(info => {
     const currSpecUrl = info._links["current-specification"].href;
     const currSpec = currSpecUrl.substring(currSpecUrl.lastIndexOf('/') + 1);
-    results.__series[info.shortname] = {
-      title: info.name,
-      currentSpecification: currSpec
-    };
+
+    // The W3C API mixes CSS specs and CSS snapshots, let's hardcode the titles
+    // of these series. No way to determine the current specification from the
+    // W3C API for them, latest spec will be used by default. If needed, a
+    // different current specification can be forced in specs.json.
+    if (info.shortname === "CSS") {
+      results.__series[info.shortname] = {
+        title: "Cascading Style Sheets"
+      };
+    }
+    else if (info.shortname === "css") {
+      results.__series[info.shortname] = {
+        title: "CSS Snapshot"
+      };
+    }
+    else {
+      results.__series[info.shortname] = {
+        title: info.name,
+        currentSpecification: currSpec
+      };
+    }
   });
 
   return results;

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -262,6 +262,20 @@ describe("fetch-info module", function () {
       assert.equal(info.__series["hr-time"].currentSpecification, "hr-time-3");
       assert.equal(info.__series["tracking-dnt"].currentSpecification, "tracking-dnt");
     });
+
+    it("does not get confused by CSS snapshots", async () => {
+      const css = getW3CSpec("CSS21", "CSS");
+      const snapshot = getW3CSpec("css-2023", "css");
+      const info = await fetchInfo([css, snapshot]);
+      assert.equal(info[css.shortname].source, "w3c");
+      assert.equal(info[snapshot.shortname].source, "w3c");
+
+      assert.ok(info.__series);
+      assert.ok(info.__series["CSS"]);
+      assert.ok(info.__series["css"]);
+      assert.equal(info.__series["CSS"].title, "Cascading Style Sheets");
+      assert.equal(info.__series["css"].title, "CSS Snapshot");
+    });
   });
 
   describe("fetch from Specref", () => {


### PR DESCRIPTION
The W3C API cannot be trusted for CSS specs and CSS snapshots because it mixes the two in the same series, is case-insensitive on the shortname, and may change the case of the returned shortname when a new spec gets published in one of these series. That typically happened with the recent publication of the CSS 2023 snapshot, which broke the build as a result.

This update makes the code ignore the info from the W3C API for these series, and rather hardcodes the series titles. The code will also use the latest version as the current specification for each of these series. If we need to override this, we'll have to do it in `specs.json`.