### PR TITLE
Add merchant-validation as discontinued spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1073,6 +1073,10 @@
     }
   },
   {
+    "url": "https://www.w3.org/TR/merchant-validation/",
+    "standing": "discontinued"
+  },
+  {
     "url": "https://www.w3.org/TR/miniapp-lifecycle/",
     "categories": [
       "-browser"

--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -215,9 +215,6 @@
     "WICG/construct-stylesheets": {
       "comment": "Integrated in CSSOM"
     },
-    "w3c/merchant-validation": {
-      "comment": "Deprecated API documenting legacy implementation"
-    },
     "WICG/frame-timing": {
       "comment": "No longer being pursued, see https://github.com/w3c/browser-specs/pull/394"
     },
@@ -416,9 +413,6 @@
       "comment": "no longer worked on"
     },
     "https://w3c.github.io/webpayments-methods-tokenization/": {
-      "comment": "no longer worked on"
-    },
-    "https://w3c.github.io/merchant-validation/": {
       "comment": "no longer worked on"
     },
     "https://tabatkins.github.io/css-toggle/": {


### PR DESCRIPTION
The spec was being ignored (twice!) because it documents a deprecated API, and we didn't have a `discontinued` standing back in the days.

Needed by BCD, see request in #1162.

FWIW, the code misses the "Unofficial Draft" status of the nightly version because it expects this status to be "Editor's Draft" for all... well... Editor's Drafts linked to a /TR spec.

This will add:

```json
{
  "url": "https://www.w3.org/TR/merchant-validation/",
  "seriesComposition": "full",
  "shortname": "merchant-validation",
  "series": {
    "shortname": "merchant-validation",
    "currentSpecification": "merchant-validation",
    "title": "The MerchantValidationEvent interface",
    "shortTitle": "The MerchantValidationEvent interface",
    "releaseUrl": "https://www.w3.org/TR/merchant-validation/",
    "nightlyUrl": "https://w3c.github.io/merchant-validation/"
  },
  "standing": "discontinued",
  "organization": "W3C",
  "groups": [
    {
      "name": "Web Payments Working Group",
      "url": "https://www.w3.org/Payments/WG/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/merchant-validation/",
    "status": "Note",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/merchant-validation/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/w3c/merchant-validation",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "The MerchantValidationEvent interface",
  "source": "w3c",
  "shortTitle": "The MerchantValidationEvent interface",
  "categories": [],
  "tests": {
    "repository": "https://github.com/web-platform-tests/wpt",
    "testPaths": [
      "merchant-validation"
    ]
  }
}
```