### PR TITLE
Flag custom-state-pseudo-class as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -520,8 +520,7 @@
     "url": "https://wicg.github.io/custom-state-pseudo-class/",
     "standing": "discontinued",
     "obsoletedBy": [
-      "html",
-      "selectors-4"
+      "html"
     ]
   },
   "https://wicg.github.io/datacue/",

--- a/specs.json
+++ b/specs.json
@@ -516,7 +516,14 @@
     }
   },
   "https://wicg.github.io/css-parser-api/",
-  "https://wicg.github.io/custom-state-pseudo-class/",
+  {
+    "url": "https://wicg.github.io/custom-state-pseudo-class/",
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "html",
+      "selectors-4"
+    ]
+  },
   "https://wicg.github.io/datacue/",
   "https://wicg.github.io/deprecation-reporting/",
   "https://wicg.github.io/digital-goods/",


### PR DESCRIPTION
The WICG spec moved to actual standardization with two parts:

1. The IDL part was moved to HTML in https://github.com/whatwg/html/pull/8467
2. The CSS part is to be integrated in Selectors, see https://github.com/w3c/csswg-drafts/issues/4805

This flags the spec as obsoleted by these two specs, using `selectors-4` for the CSS part. The CSS WG resolution mentions Selectors 5 but it does not exist yet. Alternatively, we could keep this PR open until the CSS part gets specified, or not mention `selectors-4` at all for now. Not sure which is better. Merging earlier rather than later would help with Webref (to remove the duplicate IDL).