### PR TITLE
Add FPWD of WAI-ARIA 1.3

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1368,6 +1368,10 @@
     "title": "Accessible Rich Internet Applications (WAI-ARIA)"
   },
   {
+    "url": "https://www.w3.org/TR/wai-aria-1.3/",
+    "title": "Accessible Rich Internet Applications (WAI-ARIA)"
+  },
+  {
     "url": "https://www.w3.org/TR/wasm-core-1/",
     "tests": {
       "repository": "https://github.com/WebAssembly/spec/",


### PR DESCRIPTION
Note WAI-ARIA 1.2 should remain the current specification for now.

Via #1173.