### PR TITLE
Add VC Data Model 2 to Web Specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1361,6 +1361,12 @@
   "https://www.w3.org/TR/uievents/",
   "https://www.w3.org/TR/upgrade-insecure-requests/",
   "https://www.w3.org/TR/user-timing/",
+  {
+    "url": "https://www.w3.org/TR/vc-data-model-2.0/",
+    "categories": [
+      "-browser"
+    ]
+  },  
   "https://www.w3.org/TR/vibration/",
   "https://www.w3.org/TR/virtual-keyboard/",
   {


### PR DESCRIPTION
needed for w3c/respec#4522
Will add the following entry:
```
    {
      "url": "https://www.w3.org/TR/vc-data-model-2.0/",
      "seriesComposition": "full",
      "shortname": "vc-data-model-2.0",
      "series": {
        "shortname": "vc-data-model",
        "currentSpecification": "vc-data-model-2.0",
        "title": "Verifiable Credentials Data Model",
        "shortTitle": "Verifiable Credentials Data Model",
        "releaseUrl": "https://www.w3.org/TR/vc-data-model/",
        "nightlyUrl": "https://w3c.github.io/vc-data-model/"
      },
      "seriesVersion": "2.0",
      "categories": [],
      "organization": "W3C",
      "groups": [
        {
          "name": "Verifiable Credentials Working Group",
          "url": "https://www.w3.org/2017/vc/"
        }
      ],
      "release": {
        "url": "https://www.w3.org/TR/vc-data-model-2.0/",
        "status": "Candidate Recommendation Draft",
        "filename": "Overview.html"
      },
      "nightly": {
        "url": "https://w3c.github.io/vc-data-model/",
        "status": "Editor's Draft",
        "alternateUrls": [],
        "repository": "https://github.com/w3c/vc-data-model",
        "filename": "index.html"
      },
      "title": "Verifiable Credentials Data Model v2.0",
      "source": "w3c",
      "shortTitle": "Verifiable Credentials Data Model v2.0",
      "standing": "good"
    }
```