### PR TITLE
Add WASM Core 2 spec and phase 3+ WASM proposals

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -473,12 +473,63 @@
   "https://w3c.github.io/webdriver-bidi/",
   "https://w3c.github.io/webrtc-ice/",
   {
+    "url": "https://webassembly.github.io/branch-hinting/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Branch Hinting"
+  },
+  {
+    "url": "https://webassembly.github.io/content-security-policy/js-api/",
+    "forkOf": "wasm-js-api-2",
+    "title": "WebAssembly JavaScript Interface: Content Security Policy"
+  },
+  {
     "url": "https://webassembly.github.io/exception-handling/js-api/",
     "forkOf": "wasm-js-api-2"
   },
   {
+    "url": "https://webassembly.github.io/extended-const/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Extended Const Expressions"
+  },
+  {
+    "url": "https://webassembly.github.io/function-references/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Function Reference Types"
+  },
+  {
     "url": "https://webassembly.github.io/gc/core/bikeshed/",
-    "forkOf": "wasm-core-1"
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Garbage Collection"
+  },
+  {
+    "url": "https://webassembly.github.io/js-promise-integration/js-api/",
+    "forkOf": "wasm-js-api-2",
+    "title": "WebAssembly JavaScript Interface: Promise Integration"
+  },
+  {
+    "url": "https://webassembly.github.io/js-types/js-api/",
+    "forkOf": "wasm-js-api-2",
+    "title": "WebAssembly JavaScript Interface: Type Reflection"
+  },
+  {
+    "url": "https://webassembly.github.io/memory64/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Memory64"
+  },
+  {
+    "url": "https://webassembly.github.io/multi-memory/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Multi Memory"
+  },
+  {
+    "url": "https://webassembly.github.io/tail-call/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Tail Call"
+  },
+  {
+    "url": "https://webassembly.github.io/threads/core/bikeshed/",
+    "forkOf": "wasm-core-2",
+    "title": "WebAssembly Core: Threading"
   },
   "https://webbluetoothcg.github.io/web-bluetooth/",
   {
@@ -1372,7 +1423,10 @@
     "title": "Accessible Rich Internet Applications (WAI-ARIA)"
   },
   {
-    "url": "https://www.w3.org/TR/wasm-core-1/",
+    "url": "https://www.w3.org/TR/wasm-core-2/",
+    "nightly": {
+      "url": "https://webassembly.github.io/spec/core/bikeshed/"
+    },
     "tests": {
       "repository": "https://github.com/WebAssembly/spec/",
       "testPaths": [

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -225,7 +225,7 @@ const hasPublishedContent = (candidate) => fetch(candidate.spec).then(({ok, url}
                                  .filter(isInScope));
 
   // Check for new WASM phase 3+ proposals
-  candidates = candidates.concat(wasmProposals.map(s => { return {repo: s.replace('https://github.com/', ''), spec: s.replace(/^https:\/\/github.com\/WebAssembly\/([^/]+)/i, 'https://webassembly.github.io/$1/core/bikeshed/')}})
+  candidates = candidates.concat(wasmProposals.map(s => { return {repo: s.replace('https://github.com/', ''), spec: s.replace(/^https:\/\/github.com\/WebAssembly\/([^/]+)/i, 'https://webassembly.github.io/$1/')}})
                                  .filter(hasUntrackedURL)
                                  .filter(isInScope));
 


### PR DESCRIPTION
The list only contained Level 1 of WASM Core (see #1059). This adds Level 2. In practice, crawling will work fine for the Editor's Draft but Reffy will basically not extract anything from the /TR version of the spec because it does not follow usual patterns. That seems fine enough for now.

This update also introduces missing WASM proposals as forks of the WASM Core or WASM JavaScript API specification. Most of the time, the title needs to be created because the actual specification remains that of the base spec.

One difficulty is that the WebAssembly group approaches extensions proposals as generic WASM extensions, and not necessarily as WASM *Core* extensions or WASM *JS API* extensions, whereas we need to make a choice to set the `forkOf` property. Things look good for this batch of updates, because current proposals still seem to extend either of these specs. That may not always be the case though in the future!

Similarly, the find-specs script assumed that proposals were always extending the Core spec. It now reports the URL of the home page, both to make it clearer that a choice needs to be made, and to avoid reporting a proposal that is already in the list as a WASM JS API fork.

Via #1186.
