### PR TITLE
[breaking] Add support for ISO standards, add JPEG XL ISO/IEC spec

### DIFF
--- a/schema/index.json
+++ b/schema/index.json
@@ -29,7 +29,7 @@
       "formerNames": { "$ref": "definitions.json#/$defs/formerNames" }
     },
     "required": [
-      "url", "shortname", "series", "seriesComposition", "nightly",
+      "url", "shortname", "series", "seriesComposition",
       "title", "shortTitle", "source", "organization", "groups", "categories",
       "standing"
     ],

--- a/specs.json
+++ b/specs.json
@@ -664,6 +664,11 @@
   "https://wicg.github.io/webpackage/loading.html",
   "https://wicg.github.io/webusb/",
   "https://wicg.github.io/window-controls-overlay/",
+  {
+    "url": "https://www.iso.org/standard/85253.html",
+    "shortname": "iso18181-2",
+    "shortTitle": "JPEG XL: File Format"
+  },
   "https://www.rfc-editor.org/rfc/rfc2397",
   {
     "url": "https://www.rfc-editor.org/rfc/rfc4120",

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -240,6 +240,7 @@ async function runInfo(specs) {
     // level to the nightly URL when it's not already there (note the resulting
     // URL should always exist given the way the CSS drafts server is setup)
     if (res.seriesVersion &&
+        res.nightly &&
         res.nightly.url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org/) &&
         !res.nightly.url.match(/\d+\/$/)) {
       res.nightly.url = res.nightly.url.replace(/\/$/, `-${res.seriesVersion}/`);
@@ -278,14 +279,16 @@ async function runInfo(specs) {
 
     // If we're reusing last published discontinued info,
     // forget alternate URLs and rebuild them from scratch.
-    if (res.__last?.standing === 'discontinued' &&
-        (!res.standing || res.standing === 'discontinued')) {
-      res.nightly.alternateUrls = [];
+    if (res.nightly) {
+      if (res.__last?.standing === 'discontinued' &&
+          (!res.standing || res.standing === 'discontinued')) {
+        res.nightly.alternateUrls = [];
+      }
+      else if (!res.nightly.alternateUrls) {
+        res.nightly.alternateUrls = [];
+      }
+      res.nightly.alternateUrls = res.nightly.alternateUrls.concat(computeAlternateUrls(res));
     }
-    else if (!res.nightly.alternateUrls) {
-      res.nightly.alternateUrls = [];
-    }
-    res.nightly.alternateUrls = res.nightly.alternateUrls.concat(computeAlternateUrls(res));
 
     return res;
   });
@@ -350,7 +353,9 @@ async function runFilename(index, { previousIndex, log }) {
 
   async function checkSpec(spec) {
     log(`- find filenames for ${spec.shortname}`);
-    spec.nightly.filename = spec.nightly.filename ?? await determineSpecFilename(spec, "nightly");
+    if (spec.nightly) {
+      spec.nightly.filename = spec.nightly.filename ?? await determineSpecFilename(spec, "nightly");
+    }
     if (spec.release) {
       spec.release.filename = spec.release.filename ?? await determineSpecFilename(spec, "release");
     }

--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -17,7 +17,8 @@ const problems = specs
   // A subset of the IETF RFCs are crawled from their httpwg.org rendering
   // see https://github.com/tobie/specref/issues/672 and
   // https://github.com/w3c/browser-specs/issues/280
-  .filter(s => !s.nightly.url.startsWith('https://httpwg.org') &&
+  .filter(s => s.nightly &&
+               !s.nightly.url.startsWith('https://httpwg.org') &&
                !s.nightly.url.startsWith('https://www.ietf.org/') &&
                !s.nightly.url.startsWith('https://dcthetall.github.io/CHIPS-spec/'))
   .filter(s => (s.release && s.url !== s.release.url) || (!s.release && s.url !== s.nightly.url))

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -39,7 +39,7 @@ function getFirstFoundInTree(paths, ...items) {
  * info won't include the source file).
  */
 module.exports = async function (specs, options) {
-  if (!specs || specs.find(spec => !spec.nightly || !spec.nightly.url)) {
+  if (!specs) {
     throw "Invalid list of specifications passed as parameter";
   }
   options = options || {};
@@ -177,7 +177,9 @@ module.exports = async function (specs, options) {
   }
 
   // Compute GitHub repositories with lowercase owner names
-  const repos = specs.map(spec => parseSpecUrl(spec.nightly.repository ?? spec.nightly.url));
+  const repos = specs.map(spec => spec.nightly ?
+    parseSpecUrl(spec.nightly.repository ?? spec.nightly.url) :
+    null);
 
   if (options.githubToken) {
     // Fetch the real name of repository owners (preserving case)
@@ -201,7 +203,7 @@ module.exports = async function (specs, options) {
         }
       }
     }
-    else if (spec.nightly.url.match(/\/httpwg\.org\//)) {
+    else if (spec.nightly?.url.match(/\/httpwg\.org\//)) {
       const draftName = spec.nightly.url.match(/\/(draft-ietf-(.+))\.html$/);
       spec.nightly.repository = 'https://github.com/httpwg/http-extensions';
       spec.nightly.sourcePath = `${draftName[1]}.md`;

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -175,7 +175,11 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
   // Shortnames of WebGL extensions sometimes end up with digits which are *not*
   // to be interpreted as level numbers. Similarly, shortnames of ECMA specs
   // typically have the form "ecma-ddd", and "ddd" is *not* a level number.
-  if (seriesBasename.match(/^ecma-/) || url.match(/^https:\/\/registry\.khronos\.org\/webgl\/extensions\//)) {
+  // And that's the same for ISO standards which end with plenty of non-level
+  // digits, as in "iso18181-2".
+  if (seriesBasename.match(/^ecma-/) ||
+      seriesBasename.startsWith("iso") ||
+      url.match(/^https:\/\/registry\.khronos\.org\/webgl\/extensions\//)) {
     return {
       shortname: specShortname,
       series: { shortname: seriesBasename }

--- a/src/compute-standing.js
+++ b/src/compute-standing.js
@@ -20,7 +20,7 @@ const unofficialStatuses = [
  * the spec.
  */
 module.exports = function (spec) {
-  if (!spec || !spec.nightly?.status) {
+  if (!spec) {
     throw "Invalid spec object passed as parameter";
   }
 
@@ -29,7 +29,7 @@ module.exports = function (spec) {
     return spec.standing;
   }
 
-  const status = spec.release?.status ?? spec.nightly.status;
+  const status = spec.release?.status ?? spec.nightly?.status;
   if (status === "Discontinued Draft") {
     return "discontinued";
   }

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -151,7 +151,7 @@ module.exports = async function (specs, options) {
       return info;
     }
 
-    if (spec.url.startsWith("https://tc39.es/proposal-")) {
+    if (spec.url.startsWith("https://tc39.es/proposal-") || !spec.nightly) {
       // TODO: proposals may or may not have tests under tc39/test262, it would
       // be good to have that info here. However, that seems hard to assess
       // automatically and tedious to handle as exceptions in specs.json.

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -265,10 +265,19 @@ async function fetchInfoFromSpecref(specs, options) {
           specrefStatusMapping[info.status] ??
           info.status ??
           "Editor's Draft";
-        results[name] = {
-          nightly: { url: nightly, status },
-          title: info.title
-        };
+        if (nightly?.startsWith("https://www.iso.org/")) {
+          // The URL is to a page that describes the spec, not to the spec
+          // itself (ISO specs are not public).
+          results[name] = {
+            title: info.title
+          }
+        }
+        else {
+          results[name] = {
+            nightly: { url: nightly, status },
+            title: info.title
+          };
+        }
       }
     });
   });
@@ -527,6 +536,17 @@ async function fetchInfoFromSpecs(specs, options) {
           return {
             nightly: { url: url, status: "Editor's Draft" },
             title: ecmaTitle
+          };
+        }
+      }
+      else if (spec.url.startsWith("https://www.iso.org/")) {
+        const isoTitle = await page.evaluate(_ => {
+          const meta = document.querySelector('head meta[property="og:description"]');
+          return meta ? meta.getAttribute('content').trim() : null;
+        });
+        if (isoTitle) {
+          return {
+            title: isoTitle
           };
         }
       }

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -71,7 +71,7 @@ const hasMoreRecentLevel = (s, url, loose) => {
     return false;
   }
 };
-const hasUntrackedURL = ({spec: url}) => !specs.find(s => s.nightly.url.startsWith(trimSlash(url))
+const hasUntrackedURL = ({spec: url}) => !specs.find(s => s.nightly?.url.startsWith(trimSlash(url))
                                                     || (s.release && trimSlash(s.release.url) === trimSlash(url)))
       && !specs.find(s => hasMoreRecentLevel(s, url, url.match(/\/drafts\./) && !url.match(/\/w3\.org/) // Because CSS specs have editors draft with and without levels, we look loosely for more recent levels when checking with editors draft
                                             ));

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -80,6 +80,12 @@ describe("compute-repository module", async () => {
       "https://github.com/httpwg/http-extensions");
   });
 
+  it("handles specs without nightly URLs", async () => {
+    const spec = { url: "https://www.iso.org/standard/85253.html" };
+    const result = await computeRepo([spec]);
+    assert.equal(result[0].nightly, undefined);
+  });
+
   it("returns null when repository cannot be derived from URL", async () => {
     assert.equal(
       await computeSingleRepo("https://example.net/repoless"),

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -178,6 +178,10 @@ describe("compute-shortname module", () => {
       assertSeries("ecma-402", "ecma-402");
     });
 
+    it("preserves ISO spec numbers", () => {
+      assertSeries("iso18181-2", "iso18181-2");
+    });
+
     it("preserves digits at the end of WebGL extension names", () => {
       assertSeries("https://registry.khronos.org/webgl/extensions/EXT_wow32/", "EXT_wow32");
     });
@@ -240,6 +244,10 @@ describe("compute-shortname module", () => {
 
     it("does not confuse an ECMA spec number with a series version", () => {
       assertNoSeriesVersion("ecma-402");
+    });
+
+    it("does not confuse an ISO spec number with a series version", () => {
+      assertNoSeriesVersion("iso18181-2");
     });
 
     it("does not confuse digits at the end of a WebGL extension spec with a series version", () => {

--- a/test/compute-standing.js
+++ b/test/compute-standing.js
@@ -43,23 +43,16 @@ describe("compute-standing module", () => {
     assert.strictEqual(computeStanding(spec), "discontinued");
   });
 
+  it("returns `good` for an ISO spec", function () {
+    const spec = { url: "https://www.iso.org/standard/85253.html" };
+    assert.strictEqual(computeStanding(spec), "good");
+  });
+
   it("returns the standing that the spec says it has", function () {
     const spec = {
       standing: "good",
       nightly: { status: "Unofficial Proposal Draft" }
     };
     assert.strictEqual(computeStanding(spec), "good");
-  });
-
-  it("throws if spec object is empty", () => {
-    assert.throws(
-      () => computeStanding({}),
-      /^Invalid spec object passed as parameter$/);
-  });
-
-  it("throws if spec object does not have a nightly.status property", () => {
-    assert.throws(
-      () => computeStanding({ url: "https://example.org/" }),
-      /^Invalid spec object passed as parameter$/);
   });
 });

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -102,6 +102,24 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
+  it("handles simple ISO specs", async () => {
+    const res = await fetchGroupsFor("https://www.iso.org/standard/72482.html");
+    assert.equal(res.organization, "ISO");
+    assert.deepStrictEqual(res.groups, [{
+      name: "ISO/TC 46",
+      url: "https://www.iso.org/committee/48750.html"
+    }]);
+  });
+
+  it("handles ISO/IEC specs", async () => {
+    const res = await fetchGroupsFor("https://www.iso.org/standard/85253.html");
+    assert.equal(res.organization, "ISO/IEC");
+    assert.deepStrictEqual(res.groups, [{
+      name: "ISO/IEC JTC 1/SC 29",
+      url: "https://www.iso.org/committee/45316.html"
+    }]);
+  });
+
   it("preserves provided info", async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -216,6 +216,18 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].release.url, spec.url);
       assert.equal(info[spec.shortname].release.status, "Final Deliverable");
     });
+
+    it("extracts spec info from an ISO spec page", async () => {
+      const spec = {
+        url: "https://www.iso.org/standard/61292.html",
+        shortname: "iso18074-2015"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "spec");
+      assert.equal(info[spec.shortname].title, "Textiles — Identification of some animal fibres by DNA analysis method — Cashmere, wool, yak and their blends");
+      assert.equal(info[spec.shortname].nightly, undefined);
+    });
   });
 
     describe("fetch from W3C API", () => {
@@ -291,6 +303,18 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].nightly.status, "Living Standard");
       assert.equal(info[spec.shortname].title, "DOM Standard");
     });
+
+    it("works on an ISO spec", async () => {
+      const spec = {
+        url: "https://www.iso.org/standard/85253.html",
+        shortname: "iso18181-2"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].title, "Information technology — JPEG XL image coding system — Part 2: File format");
+      assert.equal(info[spec.shortname].nightly, undefined);
+    })
   });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -136,8 +136,11 @@ describe("List of specs", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
-  it("contains nightly URLs for all specs", () => {
-    const wrong = specs.filter(s => !s.nightly.url);
+  it("contains nightly URLs for all specs except ISO ones", () => {
+    const wrong = specs.filter(s =>
+      s.organization !== 'ISO' &&
+      s.organization !== 'ISO/IEC' &&
+      !s.nightly?.url);
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -145,7 +148,7 @@ describe("List of specs", () => {
     // IETF and FIDO Allianace specs (may but) usually don't have a repository.
     // No repository either when the nightly URL of a W3C spec is the published
     // URL.
-    const wrong = specs.filter(s => !s.nightly.repository &&
+    const wrong = specs.filter(s => s.nightly && !s.nightly.repository &&
       s.organization !== 'IETF' &&
       s.organization !== 'FIDO Alliance' &&
       (!s.url.match(/\/www\.w3\.org\//) || s.nightly.url !== s.url));
@@ -155,13 +158,13 @@ describe("List of specs", () => {
   it("contains relative paths to source of nightly spec when repository is known", () => {
     // One exception to the rule: when the source is not in the default branch
     // of the repository
-    const wrong = specs.filter(s => s.nightly.repository &&
+    const wrong = specs.filter(s => s.nightly && s.nightly.repository &&
       !s.nightly.sourcePath && s.shortname !== 'tc39-decorators');
     assert.deepStrictEqual(wrong, []);
   });
 
   it("contains filenames for all nightly URLs", () => {
-    const wrong = specs.filter(s => !s.nightly.filename);
+    const wrong = specs.filter(s => s.nightly && !s.nightly.filename);
     assert.deepStrictEqual(wrong, []);
   });
 
@@ -196,7 +199,7 @@ describe("List of specs", () => {
 
   it("has a w3c.github.io alternate URL for CSS drafts", () => {
     const wrong = specs
-      .filter(s => s.nightly.url.match(/\/drafts\.csswg\.org/))
+      .filter(s => s.nightly?.url.match(/\/drafts\.csswg\.org/))
       .filter(s => {
         const draft = computeShortname(s.nightly.url);
         return !s.nightly.alternateUrls.includes(
@@ -218,7 +221,7 @@ describe("List of specs", () => {
 
   it("does not list duplicate alternate URLs", () => {
     const wrong = specs
-      .filter(s => s.nightly.alternateUrls.length > 0)
+      .filter(s => s.nightly && s.nightly.alternateUrls.length > 0)
       .filter(s => {
         const set = new Set(s.nightly.alternateUrls);
         return set.size !== s.nightly.alternateUrls.length;
@@ -228,7 +231,7 @@ describe("List of specs", () => {
 
   it("lists alternate URLs that are actual alternate URLs", () => {
     const wrong = specs
-      .filter(s => s.nightly.alternateUrls.length > 0)
+      .filter(s => s.nightly && s.nightly.alternateUrls.length > 0)
       .filter(s => {
         const mainSet = new Set();
         mainSet.add(s.url);
@@ -250,9 +253,10 @@ describe("List of specs", () => {
   it("has distinct source paths for all specs", () => {
     // ... provided entries don't share the same nightly draft
     // (typically the case for CSS 2.1 and CSS 2.2)
-    const wrong = specs.filter(s =>
+    const wrong = specs.filter(s => s.nightly &&
       s.nightly.repository && s.nightly.sourcePath &&
       specs.find(spec => spec !== s &&
+        spec.nightly &&
         spec.nightly.url !== s.nightly.url &&
         spec.nightly.repository === s.nightly.repository &&
         spec.nightly.sourcePath === s.nightly.sourcePath));


### PR DESCRIPTION
To add ISO/IEC standards related to JPEG XL (see #1089), there needs to be a way to add an entry in browser-specs that has a canonical URL but no actual nightly URL, because ISO standards are not public (see also #1191).

This update amends the code to allow and create entries without a `nightly` property when needed (only for ISO standards for now). The code also retrieves the name of the group that develops an ISO standard.

This is a BREAKING CHANGE because the `nightly` property used to be mandatory. Projects that expect to find a `nightly.url` property need to be updated to only look at the root `url` property or to skip the entry altogether.

First ISO spec added to the list is JPEG XL, which will appear as:

```json
{
  "url": "https://www.iso.org/standard/85253.html",
  "seriesComposition": "full",
  "shortname": "iso18181-2",
  "series": {
    "shortname": "iso18181-2",
    "currentSpecification": "iso18181-2",
    "title": "Information technology — JPEG XL image coding system — Part 2: File format",
    "shortTitle": "JPEG XL: File Format"
  },
  "shortTitle": "JPEG XL: File Format",
  "organization": "ISO/IEC",
  "groups": [
    {
      "name": "ISO/IEC JTC 1/SC 29",
      "url": "https://www.iso.org/committee/45316.html"
    }
  ],
  "title": "Information technology — JPEG XL image coding system — Part 2: File format",
  "source": "specref",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```

Worth noting: the absence of a `nightly` property means that there is no place to store the status of the spec, which could in theory be "Under development" or "Published" for ISO specs (there are additional stages in the ISO process but they are probably not worth capturing in any case). An alternative would be to have a `nightly.status` property, but that seems clumsy.