### PR TITLE
Add WASM Threads proposal to update the JS API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -531,6 +531,11 @@
     "forkOf": "wasm-core-2",
     "title": "WebAssembly Core: Threading"
   },
+  {
+    "url": "https://webassembly.github.io/threads/js-api/",
+    "forkOf": "wasm-js-api-2",
+    "title": "WebAssembly JavaScript Interface: Threading"
+  },
   "https://webbluetoothcg.github.io/web-bluetooth/",
   {
     "url": "https://webbluetoothcg.github.io/web-bluetooth/scanning.html",


### PR DESCRIPTION
The list documents the WASM threads proposal as an extension to WASM Core. The proposal also updates the WASM JS API:
https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md#javascript-api-changes

... and BCD needs to link to that spec, see:
https://github.com/mdn/browser-compat-data/blob/019005fc03eecb34e557183420a2f5482ebf9293/test/linter/test-spec-urls.ts#L28