### PR TITLE
Add formerNames properties to css-viewport-1 and WASM GC proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -499,7 +499,10 @@
   {
     "url": "https://webassembly.github.io/gc/core/bikeshed/",
     "forkOf": "wasm-core-2",
-    "title": "WebAssembly Core: Garbage Collection"
+    "title": "WebAssembly Core: Garbage Collection",
+    "formerNames": [
+      "wasm-core-1-fork-gc"
+    ]
   },
   {
     "url": "https://webassembly.github.io/js-promise-integration/js-api/",
@@ -949,7 +952,12 @@
     "shortTitle": "CSS Variables 1"
   },
   "https://www.w3.org/TR/css-view-transitions-1/",
-  "https://www.w3.org/TR/css-viewport-1/",
+  {
+    "url": "https://www.w3.org/TR/css-viewport-1/",
+    "formerNames": [
+      "css-viewport"
+    ]
+  },
   "https://www.w3.org/TR/css-will-change-1/",
   "https://www.w3.org/TR/css-writing-modes-3/",
   "https://www.w3.org/TR/css-writing-modes-4/",


### PR DESCRIPTION
That was missed in the update that changed their shortname. This affected Specref, see: https://github.com/tobie/specref/pull/777

Also see #1195 for detecting the problem before a new index gets released.