### PR TITLE
Bump major versions, document breaking change in package READMEs

### DIFF
--- a/packages/browser-specs/README.md
+++ b/packages/browser-specs/README.md
@@ -11,6 +11,7 @@ cross-references, WebIDL, quality, etc.
 ## Table of Contents
 
 - [Installation and usage](#installation-and-usage)
+- [Upgrading](#upgrading)
 <!-- COMMON-TOC: start --><!-- COMMON-TOC: end -->
 - [Spec selection criteria](#spec-selection-criteria)
 
@@ -34,6 +35,15 @@ Alternatively, you can fetch [`index.json`](https://w3c.github.io/browser-specs/
 or retrieve the list from the [`web-specs@latest` branch](https://github.com/w3c/browser-specs/tree/web-specs%40latest),
 and filter the resulting list to only preserve specs that have `"browser"` in
 their `categories` property.
+
+## Upgrading
+
+The only breaking change in version `4.x` is that some spec entries may not
+have a `nightly` property. This happens for specs that are not public. An
+example of a non public spec is an ISO standard. In such cases, the `url`
+property targets the public page that describes the spec on the standardization
+organization's web site. To upgrade from version `3.x` to version `4.x`, make
+sure that your code can handle specs without a `nightly` property.
 
 <!-- COMMON-BODY: start -->
 <!-- COMMON-BODY: end -->

--- a/packages/browser-specs/package.json
+++ b/packages/browser-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-specs",
-  "version": "3.76.0",
+  "version": "4.0.0",
   "description": "Curated list of technical Web specifications that are directly implemented or that will be implemented by Web browsers.",
   "repository": {
     "type": "git",

--- a/packages/web-specs/README.md
+++ b/packages/web-specs/README.md
@@ -10,6 +10,7 @@ cross-references, WebIDL, quality, etc.
 ## Table of Contents
 
 - [Installation and usage](#installation-and-usage)
+- [Upgrading](#upgrading)
 <!-- COMMON-TOC: start --><!-- COMMON-TOC: end -->
 - [Spec selection criteria](#spec-selection-criteria)
 
@@ -32,6 +33,15 @@ console.log(JSON.stringify(specs, null, 2));
 
 Alternatively, you can fetch [`index.json`](https://w3c.github.io/browser-specs/index.json)
 or retrieve the list from the [`web-specs@latest` branch](https://github.com/w3c/browser-specs/tree/web-specs%40latest).
+
+## Upgrading
+
+The only breaking change in version `3.x` is that some spec entries may not
+have a `nightly` property. This happens for specs that are not public. An
+example of a non public spec is an ISO standard. In such cases, the `url`
+property targets the public page that describes the spec on the standardization
+organization's web site. To upgrade from version `2.x` to version `3.x`, make
+sure that your code can handle specs without a `nightly` property.
 
 <!-- COMMON-BODY: start -->
 <!-- COMMON-BODY: end -->

--- a/packages/web-specs/package.json
+++ b/packages/web-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-specs",
-  "version": "2.80.0",
+  "version": "3.0.0",
   "description": "Curated list of technical Web specifications",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Both packages needed a major bump due to the possibility to now have specs without a `nightly` property. Package readmes now contain a short text to clarify breaking changes between major versions. To be completed over time as new major versions get released.