### PR TITLE
Update nightly URL of CHIPS spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -66,8 +66,8 @@
   {
     "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
     "nightly": {
-      "url": "https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html",
-      "repository": "https://github.com/DCtheTall/CHIPS-spec"
+      "url": "https://explainers-by-googlers.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html",
+      "repository": "https://github.com/explainers-by-googlers/CHIPS-spec"
     }
   },
   {


### PR DESCRIPTION
The draft was moved to another repository. Previous URL returns a 404.