### PR TITLE
Adjust check base URL script for CHIPS spec

### DIFF
--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -20,7 +20,7 @@ const problems = specs
   .filter(s => s.nightly &&
                !s.nightly.url.startsWith('https://httpwg.org') &&
                !s.nightly.url.startsWith('https://www.ietf.org/') &&
-               !s.nightly.url.startsWith('https://dcthetall.github.io/CHIPS-spec/'))
+               !s.nightly.url.startsWith('https://explainers-by-googlers.github.io/CHIPS-spec/'))
   .filter(s => (s.release && s.url !== s.release.url) || (!s.release && s.url !== s.nightly.url))
   .map(s => {
     const expected = s.release ? "release" : "nightly";


### PR DESCRIPTION
The CHIPS spec was already listed as an exception for which the mismatch is fine, but the URL needed to be adjusted following its transition to another repository.

Closes #1229.