### PR TITLE
Add GIF and JPEG (JFIF) specs

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -10,7 +10,7 @@
 
     "filename": {
       "type": "string",
-      "pattern": "^[\\w\\-\\.]+\\.(html|pdf)$"
+      "pattern": "^[\\w\\-\\.]+\\.(html|pdf|txt)$"
     },
 
     "relativePath": {

--- a/specs.json
+++ b/specs.json
@@ -788,10 +788,7 @@
         "name": "CompuServe Incorporated",
         "url": "https://www.compuserve.com/"
       }
-    ],
-    "nightly": {
-      "filename": "spec-gif89a.txt"
-    }
+    ]
   },
   "https://www.w3.org/TR/accelerometer/",
   "https://www.w3.org/TR/accname-1.2/",

--- a/specs.json
+++ b/specs.json
@@ -683,6 +683,11 @@
   "https://wicg.github.io/webusb/",
   "https://wicg.github.io/window-controls-overlay/",
   {
+    "url": "https://www.iso.org/standard/54989.html",
+    "shortname": "iso10918-5",
+    "shortTitle": "JPEG"
+  },
+  {
     "url": "https://www.iso.org/standard/85253.html",
     "shortname": "iso18181-2",
     "shortTitle": "JPEG XL: File Format"
@@ -771,6 +776,21 @@
     ],
     "nightly": {
       "repository": "https://github.com/w3c/w3process/"
+    }
+  },
+  {
+    "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
+    "shortname": "GIF",
+    "shortTitle": "GIF",
+    "organization": "CompuServe Incorporated",
+    "groups": [
+      {
+        "name": "CompuServe Incorporated",
+        "url": "https://www.compuserve.com/"
+      }
+    ],
+    "nightly": {
+      "filename": "spec-gif89a.txt"
     }
   },
   "https://www.w3.org/TR/accelerometer/",

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -11,7 +11,7 @@
 
 module.exports = async function (url) {
   // Extract filename directly from the URL when possible
-  const match = url.match(/\/([^/]+\.(html|pdf))$/);
+  const match = url.match(/\/([^/]+\.(html|pdf|txt))$/);
   if (match) {
     return match[1];
   }


### PR DESCRIPTION
This adds the GIF and JPEG specifications to the list, as requested in #1089.

For GIF, the most canonical URL is the specification published under `w3.org`, consistent with Specref and Wikipedia.

The notion of group does not mean much for the GIF spec. Also, the link to the CompuServe website seems a bit wrong, but a URL is needed...

For JPEG, the usual reference is to the interchange format (JFIF). A PDF version of the 1992 spec exists under `w3.org` at: https://www.w3.org/Graphics/JPEG/jfif3.pdf

That is the spec that Specref returns for JPEG. That said, JPEG is published and maintained by ISO/IEC under the name `iso10918-5`: https://www.iso.org/standard/54989.html

That spec (and name) is used in the list instead of the PDF version because it provides a more official entry point. If we want to record the public version from 1992 somewhere, a new "JPEG" or "JPEG-1992" entry could perhaps be created.

This would add the following entries:

```json
[
  {
    "url": "https://www.iso.org/standard/54989.html",
    "seriesComposition": "full",
    "shortname": "iso10918-5",
    "series": {
      "shortname": "iso10918-5",
      "currentSpecification": "iso10918-5",
      "title": "Information technology — Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF) — Part 5:",
      "shortTitle": "JPEG"
    },
    "shortTitle": "JPEG",
    "organization": "ISO/IEC",
    "groups": [
      {
        "name": "ISO/IEC JTC 1/SC 29",
        "url": "https://www.iso.org/committee/45316.html"
      }
    ],
    "title": "Information technology — Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF) — Part 5:",
    "source": "specref",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
    "seriesComposition": "full",
    "shortname": "GIF",
    "series": {
      "shortname": "GIF",
      "currentSpecification": "GIF",
      "title": "Graphics Interchange Format",
      "shortTitle": "GIF",
      "nightlyUrl": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt"
    },
    "shortTitle": "GIF",
    "organization": "CompuServe Incorporated",
    "groups": [
      {
        "name": "CompuServe Incorporated",
        "url": "https://www.compuserve.com/"
      }
    ],
    "nightly": {
      "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
      "status": "Editor's Draft",
      "filename": "spec-gif89a.txt",
      "alternateUrls": []
    },
    "title": "Graphics Interchange Format",
    "source": "specref",
    "categories": [
      "browser"
    ],
    "standing": "good"
  }
]
```