### PR TITLE
Add OpenGL ES Shading Language and glTF 2.0

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -199,6 +199,9 @@
         "url": "https://www.khronos.org/gltf/"
       }
     ],
+    "categories": [
+      "-browser"
+    ],
     "nightly": {
       "sourcePath": "specification/2.0/Specification.adoc"
     }

--- a/specs.json
+++ b/specs.json
@@ -190,6 +190,30 @@
   "https://privacycg.github.io/requestStorageAccessFor/",
   "https://privacycg.github.io/storage-access/",
   "https://quirks.spec.whatwg.org/",
+  {
+    "url": "https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html",
+    "shortname": "glTF",
+    "groups": [
+      {
+        "name": "glTF Working Group",
+        "url": "https://www.khronos.org/gltf/"
+      }
+    ],
+    "nightly": {
+      "sourcePath": "specification/2.0/Specification.adoc"
+    }
+  },
+  {
+    "url": "https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html",
+    "shortname": "ESSL",
+    "shortTitle": "OpenGL ES® Shading Language 3.20",
+    "groups": [
+      {
+        "name": "OpenGL ES Working Group",
+        "url": "https://www.khronos.org/opengles/"
+      }
+    ]
+  },
   "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
   "https://registry.khronos.org/webgl/extensions/EXT_blend_minmax/",
   "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/",

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -141,7 +141,7 @@ module.exports = async function (specs, options) {
       return Object.assign(info, spec.tests);
     }
 
-    if (spec.url.startsWith("https://registry.khronos.org/")) {
+    if (spec.url.startsWith("https://registry.khronos.org/webgl/")) {
       info.repository = "https://github.com/KhronosGroup/WebGL";
       info.testPaths = ["conformance-suites"];
       // TODO: Be more specific, tests for extensions should one of the files in:

--- a/src/parse-spec-url.js
+++ b/src/parse-spec-url.js
@@ -60,6 +60,11 @@ module.exports = function (url) {
     return { type: "custom", owner: "khronosgroup", name: "WebGL" };
   }
 
+  const khronos = url.match(/^https:\/\/registry\.khronos\.org\/([^\/]+)\//);
+  if (khronos) {
+    return { type: "custom", owner: "khronosgroup", name: khronos[1] };
+  }
+
   const httpwg = url.match(/^https:\/\/httpwg\.org\/specs\/rfc[0-9]+\.html$/);
   if (httpwg) {
     return { type: "custom", owner: "httpwg", name: "httpwg.github.io" };


### PR DESCRIPTION
This adds 2 additional specifications developed by the Khronos Group, as requested in #1089, and adjusts the code that was a bit too specific to WebGL specs and extensions accordingly.

The notion of "Working Group" within the Khronos Group appears somewhat informal, but the terminology is used in the page that lists Working Group officers at least: https://www.khronos.org/about/working-group-officers/

Issue #1089 mentions GLSL, and not OpenGL **ES** Shading Language, but the latter is what WebGL uses, and so should be what browsers implement. The name `ESSL` is the official name for the ES variant, see: https://github.com/KhronosGroup/GLSL

That repository only contains extensions and the issue tracker for the GLSL and ESSL specifications, but not the actual specifications. I did not set the `nightly.repository` property as a result (but that may be up for debate).

This will add the following entries to the list:

```json
[
  {
    "url": "https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html",
    "seriesComposition": "full",
    "shortname": "ESSL",
    "series": {
      "shortname": "ESSL",
      "currentSpecification": "ESSL",
      "title": "The OpenGL ES® Shading Language, Version 3.20.8",
      "shortTitle": "OpenGL ES® Shading Language",
      "nightlyUrl": "https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html"
    },
    "shortTitle": "OpenGL ES® Shading Language 3.20",
    "groups": [
      {
        "name": "OpenGL ES Working Group",
        "url": "https://www.khronos.org/opengles/"
      }
    ],
    "organization": "Khronos Group",
    "nightly": {
      "url": "https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html",
      "status": "Editor's Draft",
      "alternateUrls": [],
      "filename": "GLSL_ES_Specification_3.20.html"
    },
    "title": "The OpenGL ES® Shading Language, Version 3.20.8",
    "source": "spec",
    "categories": [
      "browser"
    ],
    "standing": "good"
  },
  {
    "url": "https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html",
    "seriesComposition": "full",
    "shortname": "glTF",
    "series": {
      "shortname": "glTF",
      "currentSpecification": "glTF",
      "title": "glTF™ 2.0 Specification",
      "shortTitle": "glTF™",
      "nightlyUrl": "https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html"
    },
    "groups": [
      {
        "name": "glTF Working Group",
        "url": "https://www.khronos.org/gltf/"
      }
    ],
    "nightly": {
      "url": "https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html",
      "status": "Editor's Draft",
      "sourcePath": "specification/2.0/Specification.adoc",
      "alternateUrls": [],
      "repository": "https://github.com/KhronosGroup/glTF",
      "filename": "glTF-2.0.html"
    },
    "organization": "Khronos Group",
    "title": "glTF™ 2.0 Specification",
    "source": "spec",
    "shortTitle": "glTF™ 2.0",
    "categories": [
      "browser"
    ],
    "standing": "good"
  }
]
```