### PR TITLE
Add Khronos Group specs to the list of exceptions for repository test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -151,6 +151,7 @@ describe("List of specs", () => {
     const wrong = specs.filter(s => s.nightly && !s.nightly.repository &&
       s.organization !== 'IETF' &&
       s.organization !== 'FIDO Alliance' &&
+      s.organization !== 'Khronos Group' &&
       (!s.url.match(/\/www\.w3\.org\//) || s.nightly.url !== s.url));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
New Khronos Group specs do not have a repository. The test now stops looking at Khronos Group specs. That's a bit loose since all WebGL specs do link to a repository, but that test is not meant to be too precise either.