### PR TITLE
Add Long Animation Frames (LoAF)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -480,6 +480,7 @@
       "sourcePath": "actions/index.html"
     }
   },
+  "https://w3c.github.io/long-animation-frames/",
   "https://w3c.github.io/permissions-registry/",
   {
     "url": "https://w3c.github.io/PNG-spec/",


### PR DESCRIPTION
Shipping in Chrome 123 and now separated from the Long Tasks spec: https://github.com/w3c/longtasks/issues/132#event-12069245858