### PR TITLE
Adjust URL of long-animation-frame

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -470,7 +470,7 @@
   "https://w3c.github.io/audio-session/",
   "https://w3c.github.io/contentEditable/",
   "https://w3c.github.io/gamepad/extensions.html",
-  "https://w3c.github.io/long-animation-frames/",
+  "https://w3c.github.io/long-animation-frame/",
   "https://w3c.github.io/mathml-aam/",
   "https://w3c.github.io/media-playback-quality/",
   "https://w3c.github.io/mediacapture-automation/",


### PR DESCRIPTION
Meanwhile in Veracruz, the repository was renamed and the shortname changed.

I suspect the title will be updated soon to reflect the switch to singular as well.

Cc @tunetheweb