### PR TITLE
Handle AOM Working Group Approved Draft status

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -113,7 +113,8 @@
             "Living Standard",
             "Proposed Standard",
             "TAG Finding",
-            "Unofficial Proposal Draft"
+            "Unofficial Proposal Draft",
+            "Working Group Approved Draft"
           ]
         },
         "alternateUrls": {

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -583,13 +583,17 @@ async function fetchInfoFromSpecs(specs, options) {
           const match = subtitle?.textContent.match(/^\s*(.+?)(,| — Last Updated)?\s+\d{1,2} \w+ \d{4}\s*$/);
           let status = (match ? match[1] : "Editor's Draft")
             .replace(/’/g, "'")     // Bikeshed generates curly quotes
-            .replace(/^W3C /, "");  // Once every full moon, a "W3C " prefix gets added
+            .replace(/^W3C /, "")   // Once every full moon, a "W3C " prefix gets added
+            .replace(/^AOM /, "");  // ... or an "AOM " prefix in AOM specs
           // And once every other full moon, spec has a weird status
           // (e.g., https://privacycg.github.io/gpc-spec/)
           if (status === "Proposal" || status === "Unofficial Draft") {
             status = "Unofficial Proposal Draft";
           }
-          else if (status === "Working Draft") {
+          else if ((status === "Working Draft") || (status === "Working Group Draft")) {
+            // W3C specs that have a Working Draft nightly status are really
+            // Editor's Drafts in practice. Similarly "Working Group Draft" is
+            // an AOM status that really means Editor's Draft.
             status = "Editor's Draft";
           }
           return { title, status };


### PR DESCRIPTION
On top of "Final Deliverable", the AOM also uses "Working Group Draft" and "Working Group Approved Draft", see:
https://github.com/speced/bikeshed/pull/2801/files

This updates the fetch-info code to:
- skip the "AOM" status prefix that at least one AOM spec started to use
- consider that "Working Group Draft" is "Editor's Draft", because that seems to be a good approximation that helps us keep status info readable.
- keep "Working Group Approved Draft" because that has a specific meaning in AOM (close to W3C PR?), and adjust the schema accordingly.