### PR TITLE
Relax permission constraint on PR submission job

### DIFF
--- a/.github/workflows/submit-suggested-spec.yml
+++ b/.github/workflows/submit-suggested-spec.yml
@@ -13,7 +13,11 @@ jobs:
   prepare:
     name: Prepare update to specs.json
     runs-on: ubuntu-latest
-    if: ${{ github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '@browser-specs-bot pr') }}
+    # TODO: Check comment user permissions more thoroughly, for instance using
+    # the REST API (see link below). This is going to be needed if we decide to
+    # remove the PR step and have the bot merge directly to the `main` branch.
+    # https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user
+    if: ${{ github.event.comment.author_association == 'MEMBER' && contains(github.event.comment.body, '@browser-specs-bot pr') }}
     steps:
       - name: Setup node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/1274#issuecomment-2020227300

This moves the permission check from `OWNER` (which is never returned for organization repos) to `MEMBER` (which is looser, especially in the case of W3C that has thousands of organization members).

The permissions check is not absolutely needed for now, it just prevents a bit of spam. The check would become necessary if we decide to skip the PR phase and have the bot merge the change to the `main` branch directly though.