### PR TITLE
Test monitor/ignore entries against main list, adjust find-specs

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -80,9 +80,6 @@
     "w3c/sparql-new": {
       "comment": "group note and not targeted at browsers"
     },
-    "WICG/close-watcher": {
-      "comment": "merged into HTML"
-    },
     "WICG/discourse-archive": {
       "comment": "not a spec"
     },
@@ -372,9 +369,6 @@
     },
     "https://tc39.es/proposal-regexp-legacy-features/": {
       "comment": "no proper spec, legacy"
-    },
-    "https://tc39.es/proposal-resizablearraybuffer/": {
-      "comment": "Integrated in ECMAScript"
     },
     "https://tc39.es/proposal-hashbang/": {
       "comment": "not meant for browsers environments"

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -144,10 +144,6 @@
       "lastreviewed": "2024-03-01",
       "comment": "no published content yet"
     },
-    "immersive-web/real-world-geometry": {
-      "lastreviewed": "2024-03-01",
-      "comment": "no published content yet"
-    },
     "immersive-web/spatial-favicons": {
       "lastreviewed": "2024-03-01",
       "comment": "no published content yet"

--- a/test/data.js
+++ b/test/data.js
@@ -25,6 +25,30 @@ describe("Ignore/Monitor lists", () => {
       const isValid = validate(list, { format: "full" });
       assert.strictEqual(validate.errors, null);
     });
+
+    it("does not contain repos that are in the main list", () => {
+      const list = require("../src/data/ignore.json");
+      const main = require("../index.json");
+      const wrongRepos = Object.keys(list.repos).filter(repo => {
+        const githubRepo = `https://github.com/${repo}`.toLowerCase();
+        return main.find(spec =>
+          spec.nightly?.repository?.toLowerCase() === githubRepo);
+      });
+      assert.deepStrictEqual(wrongRepos, []);
+    });
+
+    it("does not contain specs that are in the main list", () => {
+      const list = require("../src/data/ignore.json");
+      const main = require("../index.json");
+      const wrongSpecs = Object.keys(list.specs).filter(url => {
+        const lurl = url.toLowerCase();
+        return main.find(spec =>
+          spec.url.toLowerCase() === lurl ||
+          spec.nightly?.url?.toLowerCase() === lurl ||
+          spec.release?.url?.toLowerCase() === lurl);
+      });
+      assert.deepStrictEqual(wrongSpecs, []);
+    });
   });
 
   describe("The monitor list", () => {
@@ -45,6 +69,30 @@ describe("Ignore/Monitor lists", () => {
       const wrongSpecs = Object.entries(list.specs)
         .filter(([key, value]) => !value.lastreviewed)
         .map(([key, value]) => key);
+      assert.deepStrictEqual(wrongSpecs, []);
+    });
+
+    it("does not contain repos that are in the main list", () => {
+      const list = require("../src/data/monitor.json");
+      const main = require("../index.json");
+      const wrongRepos = Object.keys(list.repos).filter(repo => {
+        const githubRepo = `https://github.com/${repo}`.toLowerCase();
+        return main.find(spec =>
+          spec.nightly?.repository?.toLowerCase() === githubRepo);
+      });
+      assert.deepStrictEqual(wrongRepos, []);
+    });
+
+    it("does not contain specs that are in the main list", () => {
+      const list = require("../src/data/monitor.json");
+      const main = require("../index.json");
+      const wrongSpecs = Object.keys(list.specs).filter(url => {
+        const lurl = url.toLowerCase();
+        return main.find(spec =>
+          spec.url.toLowerCase() === lurl ||
+          spec.nightly?.url?.toLowerCase() === lurl ||
+          spec.release?.url?.toLowerCase() === lurl);
+      });
       assert.deepStrictEqual(wrongSpecs, []);
     });
   });


### PR DESCRIPTION
This addresses #238, adding checks that there are no entries in the monitor or ignore list that are already in the main list.

This also adjusts the find-specs script to:
1. skip fragments in repository homepage URLs (`WICG/close-watcher` does that)
2. also look at spec pages to find URLs, to avoid reporting a spec that is already in the list (`WICG/close-watcher` also does that as it now points to an HTML page)
3. compare strings in a case insensitive way, as we sometimes end up with different casing for repo names and URLs.

A couple of entries needed to be removed from the monitor/ignore list as a result ;)