### PR TITLE
[CLI] Add "close" to commit message to close issue automatically

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -378,7 +378,7 @@ Examples:
       if (options.commit) {
         logProgress(`Commit changes...`);
         const commitFile = path.join(__dirname, '..', '__commit.md');
-        const linkToIssue = issueNumber ? `Spec suggested in #${issueNumber}\n` : '';
+        const linkToIssue = issueNumber ? `Close #${issueNumber}, adding the suggested spec to the list.\n` : '';
         await fs.writeFile(
           commitFile,
           `Add ${spec.title}


### PR DESCRIPTION
Close #1282 by adding a "close" statement in the commit message that references the parent issue.