### PR TITLE
Look for auth token in GITHUB_TOKEN (was GH_TOKEN)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,12 @@ jobs:
 
     - name: Build new index file
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npm run build
 
     - name: Test new index file
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         npm run test
 
@@ -57,12 +57,12 @@ jobs:
     - name: Create/Update pre-release PR for web-specs
       run: node src/prepare-release.js web-specs
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create/Update pre-release PR for browser-specs
       run: node src/prepare-release.js browser-specs
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Following step runs even if a previous step failed to upload intermediary
     # build files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Test
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ env.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.GITHUB_TOKEN }}
         run: |
           npm run test
 

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Release package if needed
       run: node src/release-package.js ${{ github.event.pull_request.number }}
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Request review of pre-release PR
       run: node src/request-pr-review.js
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -3,7 +3,7 @@
  * "specs.json" input file.
  *
  * The script will extract the github token it needs from a "config.json" file
- * in the root folder, which must exist and must contain a "GH_TOKEN" key.
+ * in the root folder or from a `GITHUB_TOKEN` environment variable.
  */
 
 const fs = require("fs").promises;
@@ -29,12 +29,12 @@ const fetchGroups = require("./fetch-groups.js");
 const throttle = require("./throttle");
 const githubToken = (_ => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require("../config.json").GITHUB_TOKEN;
   }
   catch {
     return null;
   }
-})() ?? process.env.GH_TOKEN;
+})() ?? process.env.GITHUB_TOKEN;
 
 
 async function sleep(ms) {

--- a/src/prepare-release.js
+++ b/src/prepare-release.js
@@ -346,23 +346,23 @@ ${diff}
 
 
 /*******************************************************************************
-Retrieve GH_TOKEN from environment, prepare Octokit and kick things off
+Retrieve GITHUB_TOKEN from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (_ => {
+const GITHUB_TOKEN = (_ => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require("../config.json").GITHUB_TOKEN;
   }
   catch {
     return "";
   }
-})() || process.env.GH_TOKEN;
-if (!GH_TOKEN) {
-  console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
+})() || process.env.GITHUB_TOKEN;
+if (!GITHUB_TOKEN) {
+  console.error("GITHUB_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);
 }
 
 const octokit = new Octokit({
-  auth: GH_TOKEN,
+  auth: GITHUB_TOKEN,
   //log: console
 });
 

--- a/src/release-package.js
+++ b/src/release-package.js
@@ -118,16 +118,16 @@ async function releasePackage(prNumber) {
 /*******************************************************************************
 Retrieve tokens from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (_ => {
+const GITHUB_TOKEN = (_ => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require("../config.json").GITHUB_TOKEN;
   }
   catch {
     return "";
   }
-})() || process.env.GH_TOKEN;
-if (!GH_TOKEN) {
-  console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
+})() || process.env.GITHUB_TOKEN;
+if (!GITHUB_TOKEN) {
+  console.error("GITHUB_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);
 }
 
@@ -149,7 +149,7 @@ if (!NPM_TOKEN) {
 process.env.INPUT_TOKEN = "";
 
 const octokit = new Octokit({
-  auth: GH_TOKEN
+  auth: GITHUB_TOKEN
   //, log: console
 });
 

--- a/src/request-pr-review.js
+++ b/src/request-pr-review.js
@@ -56,23 +56,23 @@ async function requestReview(type) {
 
 
 /*******************************************************************************
-Retrieve GH_TOKEN from environment, prepare Octokit and kick things off
+Retrieve GITHUB_TOKEN from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GH_TOKEN = (_ => {
+const GITHUB_TOKEN = (_ => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require("../config.json").GITHUB_TOKEN;
   }
   catch {
     return "";
   }
-})() || process.env.GH_TOKEN;
-if (!GH_TOKEN) {
-  console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
+})() || process.env.GITHUB_TOKEN;
+if (!GITHUB_TOKEN) {
+  console.error("GITHUB_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);
 }
 
 const octokit = new Octokit({
-  auth: GH_TOKEN,
+  auth: GITHUB_TOKEN,
   //log: console
 });
 

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -3,12 +3,12 @@ const fetchGroups = require("../src/fetch-groups.js");
 
 const githubToken = (function () {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require("../config.json").GITHUB_TOKEN;
   }
   catch (err) {
     return null;
   }
-})() ?? process.env.GH_TOKEN;
+})() ?? process.env.GITHUB_TOKEN;
 
 describe("fetch-groups module (without API keys)", function () {
   // Tests may need to send network requests


### PR DESCRIPTION
Via #1307.

The `gh` command that we now use in some of our jobs look for a `GITHUB_TOKEN` environment variable to find the authentication token, while our code rather used `GH_TOKEN`.

The job that checks a suggested spec uses both our code and the `gh` command. To avoid having to set the token to two different environment variables, this updates rather aligns everything to `GITHUB_TOKEN`.