### PR TITLE
Add https://privacycg.github.io/saa-non-cookie-storage/

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -188,6 +188,7 @@
   "https://privacycg.github.io/nav-tracking-mitigations/",
   "https://privacycg.github.io/private-click-measurement/",
   "https://privacycg.github.io/requestStorageAccessFor/",
+  "https://privacycg.github.io/saa-non-cookie-storage/",
   "https://privacycg.github.io/storage-access/",
   "https://quirks.spec.whatwg.org/",
   {


### PR DESCRIPTION
This was adopted by PrivacyCG for incubation and is shipping in Chrome 125.

Needed for https://github.com/mdn/browser-compat-data/pull/22977 https://github.com/mdn/browser-compat-data/pull/22978