### PR TITLE
Make nightly URL of CSS Viewport explicit

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1041,6 +1041,9 @@
   "https://www.w3.org/TR/css-view-transitions-1/",
   {
     "url": "https://www.w3.org/TR/css-viewport-1/",
+    "nightly": {
+      "url": "https://drafts.csswg.org/css-viewport/"
+    },
     "formerNames": [
       "css-viewport"
     ]

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -237,9 +237,11 @@ async function runInfo(specs) {
     // Latest ED link in TR versions of CSS specs sometimes target the spec series
     // entry point on the CSS drafts server. To make sure that the nightly URL
     // targets the same level as the TR level we're looking at, we'll add the
-    // level to the nightly URL when it's not already there (note the resulting
-    // URL should always exist given the way the CSS drafts server is setup)
-    if (res.seriesVersion &&
+    // level to the nightly URL when it's not already there, unless the nightly
+    // URL was set explicitly in specs.json (note the resulting URL should always
+    // exist given the way the CSS drafts server is setup)
+    if (!spec.nightly?.url &&
+        res.seriesVersion &&
         res.nightly &&
         res.nightly.url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org/) &&
         !res.nightly.url.match(/\d+\/$/)) {


### PR DESCRIPTION
The build logic expects that, for CSS specs, when a /TR/ spec that has some level links to a nightly draft without level, then it should add the level back. That no longer works for CSS Viewport, as css-viewport-1 no longer exists on the draft CSS server.

This update forces the nightly URL of the CSS Viewport to be without level (and fixes the build code to actually use that URL when it is specified).