### PR TITLE
Handle FPWD for nightly, fix orientation-event series info, log filename responses

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1302,7 +1302,13 @@
   "https://www.w3.org/TR/navigation-timing-2/",
   "https://www.w3.org/TR/network-error-logging/",
   "https://www.w3.org/TR/openscreenprotocol/",
-  "https://www.w3.org/TR/orientation-event/",
+  {
+    "url": "https://www.w3.org/TR/orientation-event/",
+    "series": {
+      "shortname": "orientation-event",
+      "title": "Device Orientation and Motion"
+    }
+  },
   "https://www.w3.org/TR/orientation-sensor/",
   "https://www.w3.org/TR/paint-timing/",
   "https://www.w3.org/TR/payment-handler/",

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -33,8 +33,11 @@ module.exports = async function (url) {
 
   for (const candidate of candidates) {
     const res = await fetch(urlWithSlash + candidate, { method: "HEAD" });
-    if (res.status === 200) {
+    if (res.status >= 200 && res.status < 300) {
       return candidate;
+    }
+    else if (res.status !== 404) {
+      console.warn(`[warning] fetching "${urlWithSlash + candidate}" returned unexpected HTTP status ${res.status}`);
     }
   }
 

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -92,7 +92,7 @@ async function fetchInfoFromW3CApi(specs, options) {
         `for "${spec.shortname}" (${spec.url}), update the shortname!`);
     }
     if (res.status !== 200) {
-      throw new Error(`W3C API returned an error, status code is ${res.status}`);
+      throw new Error(`W3C API returned an error, status code is ${res.status}, url was ${url}`);
     }
     try {
       const body = await res.json();
@@ -590,7 +590,9 @@ async function fetchInfoFromSpecs(specs, options) {
           if (status === "Proposal" || status === "Unofficial Draft") {
             status = "Unofficial Proposal Draft";
           }
-          else if ((status === "Working Draft") || (status === "Working Group Draft")) {
+          else if (status === "First Public Working Draft" ||
+                   status === "Working Draft" ||
+                   status === "Working Group Draft") {
             // W3C specs that have a Working Draft nightly status are really
             // Editor's Drafts in practice. Similarly "Working Group Draft" is
             // an AOM status that really means Editor's Draft.


### PR DESCRIPTION
The updates fix a couple of test failures that currently prevent builds, and should provide more info about the remaining one (lack of `filename`).