### PR TITLE
Use actual previous index to determine filename

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -409,7 +409,7 @@ async function generateIndexFile(specsFile, targetFile, step) {
   // be refreshed due to some external (network) issue.
   const previousIndex = await (async function () {
     try {
-      const json = await fs.readFile(path.resolve(targetFile), 'utf8');
+      const json = await fs.readFile(path.join(__dirname, "..", "index.json"), 'utf8');
       return JSON.parse(json);
     }
     catch (err) {


### PR DESCRIPTION
If the code cannot determine the filename of a spec, it reuses the previously known filename... at least in theory. In practice, the code was not loading the previous index but the intermediary build step, which does not exist when the build is run as part of a job.

This makes the code load the previous `index.json` file. Filename is the only place where that previous index is used.

That won't fix #1333, but the build might actually succeed with this change.