### PR TITLE
Force filename to Overview.html for W3C /TR URLs

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -63,36 +63,6 @@
       "enum": ["w3c", "specref", "spec", "ietf"]
     },
 
-    "release": {
-      "type": "object",
-      "properties": {
-        "url": { "$ref": "#/$defs/url" },
-        "status": {
-          "type": "string",
-          "enum": [
-            "Candidate Recommendation Draft",
-            "Candidate Recommendation Snapshot",
-            "Discontinued Draft",
-            "Draft Note",
-            "Draft Registry",
-            "Final Deliverable",
-            "First Public Working Draft",
-            "Note",
-            "Proposed Recommendation",
-            "Recommendation",
-            "Working Draft"
-          ]
-        },
-        "filename": { "$ref": "#/$defs/filename" },
-        "pages": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/url" }
-        }
-      },
-      "required": ["url", "status"],
-      "additionalProperties": false
-    },
-
     "nightly": {
       "type": "object",
       "properties": {
@@ -213,6 +183,44 @@
       "type": "array",
       "items": { "$ref": "#/$defs/shortname" },
       "minItems": 1
+    },
+
+    "specsfile": {
+      "release": {
+        "type": "object",
+        "properties": {
+          "url": { "$ref": "#/$defs/url" },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Candidate Recommendation Draft",
+              "Candidate Recommendation Snapshot",
+              "Discontinued Draft",
+              "Draft Note",
+              "Draft Registry",
+              "Final Deliverable",
+              "First Public Working Draft",
+              "Note",
+              "Proposed Recommendation",
+              "Recommendation",
+              "Working Draft"
+            ]
+          },
+          "filename": { "$ref": "#/$defs/filename" },
+          "pages": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/url" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+
+    "indexfile": {
+      "release": {
+        "$ref": "#/$defs/specsfile/release",
+        "required": ["url", "status"]
+      }
     }
   }
 }

--- a/schema/index.json
+++ b/schema/index.json
@@ -17,7 +17,7 @@
       "seriesNext": { "$ref": "definitions.json#/$defs/shortname" },
       "nightly": { "$ref": "definitions.json#/$defs/nightly" },
       "tests": { "$ref": "definitions.json#/$defs/tests" },
-      "release": { "$ref": "definitions.json#/$defs/release" },
+      "release": { "$ref": "definitions.json#/$defs/indexfile/release" },
       "title": { "$ref": "definitions.json#/$defs/title" },
       "shortTitle": { "$ref": "definitions.json#/$defs/title" },
       "source": { "$ref": "definitions.json#/$defs/source" },

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -19,6 +19,7 @@
           "seriesVersion": { "$ref": "definitions.json#/$defs/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },
           "nightly": { "$ref": "definitions.json#/$defs/nightly" },
+          "release": { "$ref": "definitions.json#/$defs/specsfile/release" },
           "tests": { "$ref": "definitions.json#/$defs/tests" },
           "title": { "$ref": "definitions.json#/$defs/title" },
           "shortTitle": { "$ref": "definitions.json#/$defs/title" },

--- a/specs.json
+++ b/specs.json
@@ -1485,7 +1485,10 @@
   },
   {
     "url": "https://www.w3.org/TR/SRI/",
-    "shortTitle": "SRI"
+    "shortTitle": "SRI",
+    "release": {
+      "filename": "index.html"
+    }
   },
   "https://www.w3.org/TR/svg-aam-1.0/",
   "https://www.w3.org/TR/svg-integration/",
@@ -1515,7 +1518,12 @@
       "sourcePath": "drafts/tracking-dnt.html"
     }
   },
-  "https://www.w3.org/TR/trusted-types/",
+  {
+    "url": "https://www.w3.org/TR/trusted-types/",
+    "release": {
+      "filename": "index.html"
+    }
+  },
   {
     "url": "https://www.w3.org/TR/uievents-code/",
     "nightly": {

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -22,6 +22,15 @@ module.exports = async function (url) {
     return rfcMatch[1] + '.html';
   }
 
+  // W3C /TR specs should all have an "Overview.html" filename, let's not make
+  // additional network requests to avoid running into rate limiting issues
+  // (W3C servers can easily be made to return 429 Too Many Requests responses)
+  // Note: exceptions to the rule need to be handled in "specs.json".
+  const w3cTr = url.match(/^https?:\/\/(?:www\.)?w3\.org\/TR\/([^\/]+)\/$/);
+  if (w3cTr) {
+    return "Overview.html";
+  }
+
   // Make sure that url ends with a "/"
   const urlWithSlash = url.endsWith("/") ? url : url + "/";
 


### PR DESCRIPTION
W3C servers have started to become stricter about rate limits, making build jobs fail with "429 Too Many Requests" responses received. In practice, as reported in #1333, all /TR specs have an "Overview.html" but two. This update hardcodes the rule: "All /TR URLs have an Overview.html filename" and adds the two exceptions to the rule to specs.json.

Note the `release` property was not yet allowed in `specs.json` (because we never had a need for it). The schemas needed to be updated as a result. To avoid requiring properties under `release` that are useless in specs.json, the definition was split into two: one for specs.json without constraint, and one for index.json that reuses the first one but also adds required constraints.