### PR TITLE
Force update of index.json, adjusting discontinued entry

### DIFF
--- a/index.json
+++ b/index.json
@@ -288,6 +288,46 @@
     }
   },
   {
+    "url": "https://compression.spec.whatwg.org/",
+    "seriesComposition": "full",
+    "shortname": "compression",
+    "series": {
+      "shortname": "compression",
+      "currentSpecification": "compression",
+      "title": "Compression Streams",
+      "shortTitle": "Compression Streams",
+      "nightlyUrl": "https://wicg.github.io/compression/"
+    },
+    "organization": "WHATWG",
+    "groups": [
+      {
+        "name": "Streams Workstream",
+        "url": "https://compression.spec.whatwg.org/"
+      }
+    ],
+    "nightly": {
+      "url": "https://wicg.github.io/compression/",
+      "status": "Draft Community Group Report",
+      "alternateUrls": [],
+      "repository": "https://github.com/WICG/compression",
+      "sourcePath": "index.bs",
+      "filename": "index.html"
+    },
+    "title": "Compression Streams",
+    "source": "specref",
+    "shortTitle": "Compression Streams",
+    "categories": [
+      "browser"
+    ],
+    "standing": "good",
+    "tests": {
+      "repository": "https://github.com/web-platform-tests/wpt",
+      "testPaths": [
+        "compression"
+      ]
+    }
+  },
+  {
     "url": "https://console.spec.whatwg.org/",
     "seriesComposition": "full",
     "shortname": "console",
@@ -1529,45 +1569,6 @@
         "css/css-variables"
       ]
     }
-  },
-  {
-    "url": "https://drafts.csswg.org/css-view-transitions-2/",
-    "seriesComposition": "delta",
-    "shortname": "css-view-transitions-2",
-    "series": {
-      "shortname": "css-view-transitions",
-      "currentSpecification": "css-view-transitions-1",
-      "title": "CSS View Transitions Module",
-      "shortTitle": "CSS View Transitions",
-      "releaseUrl": "https://www.w3.org/TR/css-view-transitions/",
-      "nightlyUrl": "https://drafts.csswg.org/css-view-transitions/"
-    },
-    "seriesVersion": "2",
-    "seriesPrevious": "css-view-transitions-1",
-    "organization": "W3C",
-    "groups": [
-      {
-        "name": "Cascading Style Sheets (CSS) Working Group",
-        "url": "https://www.w3.org/Style/CSS/"
-      }
-    ],
-    "nightly": {
-      "url": "https://drafts.csswg.org/css-view-transitions-2/",
-      "status": "Editor's Draft",
-      "alternateUrls": [
-        "https://w3c.github.io/csswg-drafts/css-view-transitions-2/"
-      ],
-      "repository": "https://github.com/w3c/csswg-drafts",
-      "sourcePath": "css-view-transitions-2/Overview.bs",
-      "filename": "index.html"
-    },
-    "title": "CSS View Transitions Module Level 2",
-    "source": "spec",
-    "shortTitle": "CSS View Transitions 2",
-    "categories": [
-      "browser"
-    ],
-    "standing": "good"
   },
   {
     "url": "https://drafts.fxtf.org/compositing-2/",
@@ -7593,46 +7594,6 @@
     }
   },
   {
-    "url": "https://wicg.github.io/compression/",
-    "seriesComposition": "full",
-    "shortname": "compression",
-    "series": {
-      "shortname": "compression",
-      "currentSpecification": "compression",
-      "title": "Compression Streams",
-      "shortTitle": "Compression Streams",
-      "nightlyUrl": "https://wicg.github.io/compression/"
-    },
-    "organization": "W3C",
-    "groups": [
-      {
-        "name": "Web Platform Incubator Community Group",
-        "url": "https://www.w3.org/community/wicg/"
-      }
-    ],
-    "nightly": {
-      "url": "https://wicg.github.io/compression/",
-      "status": "Draft Community Group Report",
-      "alternateUrls": [],
-      "repository": "https://github.com/WICG/compression",
-      "sourcePath": "index.bs",
-      "filename": "index.html"
-    },
-    "title": "Compression Streams",
-    "source": "specref",
-    "shortTitle": "Compression Streams",
-    "categories": [
-      "browser"
-    ],
-    "standing": "good",
-    "tests": {
-      "repository": "https://github.com/web-platform-tests/wpt",
-      "testPaths": [
-        "compression"
-      ]
-    }
-  },
-  {
     "url": "https://wicg.github.io/content-index/spec/",
     "seriesComposition": "full",
     "shortname": "content-index",
@@ -7831,6 +7792,10 @@
       "shortTitle": "Custom State Pseudo Class",
       "nightlyUrl": "https://wicg.github.io/custom-state-pseudo-class/"
     },
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "html"
+    ],
     "organization": "W3C",
     "groups": [
       {
@@ -7851,8 +7816,7 @@
     "shortTitle": "Custom State Pseudo Class",
     "categories": [
       "browser"
-    ],
-    "standing": "good"
+    ]
   },
   {
     "url": "https://wicg.github.io/datacue/",
@@ -17392,6 +17356,50 @@
     "standing": "good"
   },
   {
+    "url": "https://www.w3.org/TR/css-view-transitions-2/",
+    "seriesComposition": "delta",
+    "shortname": "css-view-transitions-2",
+    "series": {
+      "shortname": "css-view-transitions",
+      "currentSpecification": "css-view-transitions-1",
+      "title": "CSS View Transitions Module",
+      "shortTitle": "CSS View Transitions",
+      "releaseUrl": "https://www.w3.org/TR/css-view-transitions/",
+      "nightlyUrl": "https://drafts.csswg.org/css-view-transitions/"
+    },
+    "seriesVersion": "2",
+    "seriesPrevious": "css-view-transitions-1",
+    "organization": "W3C",
+    "groups": [
+      {
+        "name": "Cascading Style Sheets (CSS) Working Group",
+        "url": "https://www.w3.org/Style/CSS/"
+      }
+    ],
+    "release": {
+      "url": "https://www.w3.org/TR/css-view-transitions-2/",
+      "status": "First Public Working Draft",
+      "filename": "Overview.html"
+    },
+    "nightly": {
+      "url": "https://drafts.csswg.org/css-view-transitions-2/",
+      "status": "Editor's Draft",
+      "alternateUrls": [
+        "https://w3c.github.io/csswg-drafts/css-view-transitions-2/"
+      ],
+      "repository": "https://github.com/w3c/csswg-drafts",
+      "sourcePath": "css-view-transitions-2/Overview.bs",
+      "filename": "index.html"
+    },
+    "title": "CSS View Transitions Module Level 2",
+    "source": "w3c",
+    "shortTitle": "CSS View Transitions 2",
+    "categories": [
+      "browser"
+    ],
+    "standing": "good"
+  },
+  {
     "url": "https://www.w3.org/TR/css-viewport-1/",
     "seriesComposition": "full",
     "shortname": "css-viewport-1",
@@ -21087,9 +21095,9 @@
     "shortname": "orientation-event",
     "series": {
       "shortname": "orientation-event",
+      "title": "Device Orientation and Motion",
       "currentSpecification": "orientation-event",
-      "title": "DeviceOrientation Event",
-      "shortTitle": "DeviceOrientation Event",
+      "shortTitle": "Device Orientation and Motion",
       "releaseUrl": "https://www.w3.org/TR/orientation-event/",
       "nightlyUrl": "https://w3c.github.io/deviceorientation/"
     },
@@ -21117,9 +21125,9 @@
       "sourcePath": "index.bs",
       "filename": "index.html"
     },
-    "title": "DeviceOrientation Event Specification",
+    "title": "Device Orientation and Motion",
     "source": "w3c",
-    "shortTitle": "DeviceOrientation Event",
+    "shortTitle": "Device Orientation and Motion",
     "categories": [
       "browser"
     ],
@@ -21887,7 +21895,7 @@
     ],
     "release": {
       "url": "https://www.w3.org/TR/rdf-canon/",
-      "status": "Proposed Recommendation",
+      "status": "Recommendation",
       "filename": "Overview.html"
     },
     "title": "RDF Dataset Canonicalization",
@@ -23458,6 +23466,11 @@
       "nightlyUrl": "https://w3c.github.io/webappsec-subresource-integrity/"
     },
     "shortTitle": "SRI",
+    "release": {
+      "url": "https://www.w3.org/TR/SRI/",
+      "status": "Recommendation",
+      "filename": "index.html"
+    },
     "organization": "W3C",
     "groups": [
       {
@@ -23465,11 +23478,6 @@
         "url": "https://www.w3.org/groups/wg/webappsec/"
       }
     ],
-    "release": {
-      "url": "https://www.w3.org/TR/SRI/",
-      "status": "Recommendation",
-      "filename": "index.html"
-    },
     "nightly": {
       "url": "https://w3c.github.io/webappsec-subresource-integrity/",
       "status": "Editor's Draft",
@@ -24030,6 +24038,11 @@
       "releaseUrl": "https://www.w3.org/TR/trusted-types/",
       "nightlyUrl": "https://w3c.github.io/trusted-types/dist/spec/"
     },
+    "release": {
+      "url": "https://www.w3.org/TR/trusted-types/",
+      "status": "First Public Working Draft",
+      "filename": "index.html"
+    },
     "organization": "W3C",
     "groups": [
       {
@@ -24037,11 +24050,6 @@
         "url": "https://www.w3.org/groups/wg/webappsec/"
       }
     ],
-    "release": {
-      "url": "https://www.w3.org/TR/trusted-types/",
-      "status": "First Public Working Draft",
-      "filename": "index.html"
-    },
     "nightly": {
       "url": "https://w3c.github.io/trusted-types/dist/spec/",
       "status": "Editor's Draft",


### PR DESCRIPTION
The build code gets lost with the `custom-state-pseudo-class` entry because the URL now redirects to a section of the HTML spec. Goal is to make the entry discontinued. Once that is done, the build code should reuse the info from index.json directly (the discontinued state is a frozen state).

This update forces the standing of the entry to discontinued, reusing previous info for other entry properties. This should fix the issue at hand and allow build to resume.

The other updates are triggered by recent changes to `specs.json` that have not yet been integrated in `index.json` because the build could not succeed. No manual changes were made to these updates.