### PR TITLE
Optimize spec page loading everywhere

### DIFF
--- a/src/extract-pages.js
+++ b/src/extract-pages.js
@@ -4,10 +4,12 @@
  * the table of contents, in document order, excluding the index page.
  */
 
+const loadSpec = require('./load-spec');
+
 module.exports = async function (url, browser) {
   const page = await browser.newPage();
   try {
-    await page.goto(url);
+    await loadSpec(url, page);
     const allPages = await page.evaluate(_ =>
       [...document.querySelectorAll('.toc a[href]')]
         .map(link => link.href)

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -39,6 +39,7 @@
  */
 
 const puppeteer = require("puppeteer");
+const loadSpec = require("./load-spec");
 const throttle = require("./throttle");
 const throttledFetch = throttle(fetch, 2);
 const computeShortname = require("./compute-shortname");
@@ -360,7 +361,6 @@ async function fetchInfoFromIETF(specs, options) {
     return paths.filter(p => p.path.match(/^specs\/rfc\d+\.html$/))
       .map(p => p.path.match(/(rfc\d+)\.html$/)[1]);
   }
-  const httpwgRFCs = await getHttpwgRFCs();
 
   const info = await Promise.all(specs.map(async spec => {
     // IETF can only provide information about IETF specs
@@ -387,6 +387,7 @@ async function fetchInfoFromIETF(specs, options) {
     // Note we prefer the httpwg.org version for HTTP WG RFCs and drafts.
     let nightly;
     if (lastRevision.name.startsWith('rfc')) {
+      const httpwgRFCs = await getHttpwgRFCs();
       if (httpwgRFCs.includes(lastRevision.name)) {
         nightly = `https://httpwg.org/specs/${lastRevision.name}.html`
       }
@@ -449,80 +450,8 @@ async function fetchInfoFromSpecs(specs, options) {
     const url = spec.nightly?.url || spec.url;
     const page = await browser.newPage();
 
-    // Inner function that returns a network interception method for Puppeteer,
-    // to avoid downloading images and getting stuck on streams.
-    // NB: this is a simplified version of the code used in Reffy:
-    // https://github.com/w3c/reffy/blob/25bb1be05be63cae399d2648ecb1a5ea5ab8430a/src/lib/util.js#L351
-    function interceptRequest(cdp) {
-      return async function ({ requestId, request }) {
-        try {
-          // Abort network requests to common image formats
-          if (/\.(gif|ico|jpg|jpeg|png|ttf|woff)$/i.test(request.url)) {
-            await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
-            return;
-          }
-
-          // Abort network requests that return a "stream", they don't
-          // play well with Puppeteer's "networkidle0" option
-          if (request.url.startsWith('https://drafts.csswg.org/api/drafts/') ||
-              request.url.startsWith('https://drafts.css-houdini.org/api/drafts/') ||
-              request.url.startsWith('https://drafts.fxtf.org/api/drafts/') ||
-              request.url.startsWith('https://api.csswg.org/shepherd/')) {
-            await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
-            return;
-          }
-
-          // Proceed with the network request otherwise
-          await cdp.send('Fetch.continueRequest', { requestId });
-        }
-        catch (err) {
-          console.warn(`[warn] Network request to ${request.url} failed`, err);
-        }
-      }
-    }
-
-    // Intercept network requests to avoid downloading images and streams
-    const cdp = await page.target().createCDPSession();
-
     try {
-      await cdp.send('Fetch.enable');
-      cdp.on('Fetch.requestPaused', interceptRequest(cdp));
-
-      await page.goto(url, { timeout: 120000, waitUntil: 'networkidle0' });
-
-      // Wait until the generation of the spec is completely over
-      // (same code as in Reffy, except Reffy forces the latest version of
-      // Respec and thus does not need to deal with older specs that rely
-      // on a version that sets `respecIsReady` and not `respec.ready`.
-      await page.evaluate(async () => {
-        const usesRespec =
-          (window.respecConfig || window.eval('typeof respecConfig !== "undefined"')) &&
-          window.document.head.querySelector("script[src*='respec']");
-
-        function sleep(ms) {
-          return new Promise(resolve => setTimeout(resolve, ms, 'slept'));
-        }
-
-        async function isReady(counter) {
-          counter = counter || 0;
-          if (counter > 60) {
-            throw new Error(`Respec generation took too long for ${window.location.toString()}`);
-          }
-          if (document.respec?.ready || document.respecIsReady) {
-            // Wait for resolution of ready promise
-            const res = await Promise.race([document.respec?.ready ?? document.respecIsReady, sleep(60000)]);
-            if (res === 'slept') {
-              throw new Error(`Respec generation took too long for ${window.location.toString()}`);
-            }
-          }
-          else if (usesRespec) {
-            await sleep(1000);
-            await isReady(counter + 1);
-          }
-        }
-
-        await isReady();
-      });
+      await loadSpec(url, page);
 
       if (spec.url.startsWith("https://tc39.es/")) {
         // Title is either flagged with specific class or the second h1
@@ -633,7 +562,6 @@ async function fetchInfoFromSpecs(specs, options) {
       }
     }
     finally {
-      await cdp.detach();
       await page.close();
     }
   }

--- a/src/load-spec.js
+++ b/src/load-spec.js
@@ -1,0 +1,88 @@
+/**
+ * Loads a spec into a Puppeteer page, avoiding fetching resources that are not
+ * useful for our needs (images, streams) and that, once in a while, tend to
+ * cause timeout issues on CSS servers.
+ */
+
+module.exports = async function (url, page) {
+  // Inner function that returns a network interception method for Puppeteer,
+  // to avoid downloading images and getting stuck on streams.
+  // NB: this is a simplified version of the code used in Reffy:
+  // https://github.com/w3c/reffy/blob/25bb1be05be63cae399d2648ecb1a5ea5ab8430a/src/lib/util.js#L351
+  function interceptRequest(cdp) {
+    return async function ({ requestId, request }) {
+      try {
+        // Abort network requests to common image formats
+        if (/\.(gif|ico|jpg|jpeg|png|ttf|woff)$/i.test(request.url)) {
+          await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
+          return;
+        }
+
+        // Abort network requests that return a "stream", they don't
+        // play well with Puppeteer's "networkidle0" option
+        if (request.url.startsWith('https://drafts.csswg.org/api/drafts/') ||
+            request.url.startsWith('https://drafts.css-houdini.org/api/drafts/') ||
+            request.url.startsWith('https://drafts.fxtf.org/api/drafts/') ||
+            request.url.startsWith('https://api.csswg.org/shepherd/')) {
+          await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
+          return;
+        }
+
+        // Proceed with the network request otherwise
+        await cdp.send('Fetch.continueRequest', { requestId });
+      }
+      catch (err) {
+        console.warn(`[warn] Network request to ${request.url} failed`, err);
+      }
+    }
+  }
+
+  // Intercept network requests to avoid downloading images and streams
+  const cdp = await page.target().createCDPSession();
+
+  try {
+    await cdp.send('Fetch.enable');
+    cdp.on('Fetch.requestPaused', interceptRequest(cdp));
+
+    await page.goto(url, { timeout: 120000, waitUntil: 'networkidle0' });
+
+    // Wait until the generation of the spec is completely over
+    // (same code as in Reffy, except Reffy forces the latest version of
+    // Respec and thus does not need to deal with older specs that rely
+    // on a version that sets `respecIsReady` and not `respec.ready`.
+    await page.evaluate(async () => {
+      const usesRespec =
+        (window.respecConfig || window.eval('typeof respecConfig !== "undefined"')) &&
+        window.document.head.querySelector("script[src*='respec']");
+
+      function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms, 'slept'));
+      }
+
+      async function isReady(counter) {
+        counter = counter || 0;
+        if (counter > 60) {
+          throw new Error(`Respec generation took too long for ${window.location.toString()}`);
+        }
+        if (document.respec?.ready || document.respecIsReady) {
+          // Wait for resolution of ready promise
+          const res = await Promise.race([document.respec?.ready ?? document.respecIsReady, sleep(60000)]);
+          if (res === 'slept') {
+            throw new Error(`Respec generation took too long for ${window.location.toString()}`);
+          }
+        }
+        else if (usesRespec) {
+          await sleep(1000);
+          await isReady(counter + 1);
+        }
+      }
+
+      await isReady();
+    });
+
+    return page;
+  }
+  finally {
+    await cdp.detach();
+  }
+}


### PR DESCRIPTION
Build currently fails with a timeout when it tries to load the ED of CSS2 to extract the list of pages from the table of contents (the ED is not a multipage spec per se, but the /TR version is, and the "multipage" flag applies to both).

That timeout is due to images taking a long time to load on the CSS drafts server right now for some reason. Puppeteer surrenders after 30s of trying to fetch the images. That is not specific to the context under which the build is run: I get the same timeout when I run things locally.

As a workaround, this update reuses in extract-pages the same load logic as the one used in fetch-info, which itself is a copy-and-paste from the logic used in Reffy to crawl the specs. That logic notably avoids loading resources identified as images, which solves the timeout issue.

This also has the advantage of making us use a consistent approach whenever we need to load a spec using Puppeteer.

A side update: the fetch-info logic was always sending a GitHub API request to retrieve IETF HTTPWG repository info, even when that was clearly not necessary. To avoid hitting rate limits too fast, the request is now only sent when absolutely necessary.