### PR TITLE
Don't load resources from test.csswg.org

### DIFF
--- a/src/load-spec.js
+++ b/src/load-spec.js
@@ -23,7 +23,8 @@ module.exports = async function (url, page) {
         if (request.url.startsWith('https://drafts.csswg.org/api/drafts/') ||
             request.url.startsWith('https://drafts.css-houdini.org/api/drafts/') ||
             request.url.startsWith('https://drafts.fxtf.org/api/drafts/') ||
-            request.url.startsWith('https://api.csswg.org/shepherd/')) {
+            request.url.startsWith('https://api.csswg.org/shepherd/') ||
+            request.url.startsWith('https://test.csswg.org/harness/')) {
           await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
           return;
         }


### PR DESCRIPTION
Resources from test.csswg.org are used to add test annotations to a CSS spec. We don't need that information, and these resources seem to contribute to network timeouts. This update adds them to the blocklist of resources that get intercepted when the spec is loaded in Puppeteer.

Note: I'm not really expecting that change to solve the timeout issue on SVG2, but hopefully that can help...