### PR TITLE
Always reuse previously determined filenames

### DIFF
--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -22,15 +22,6 @@ module.exports = async function (url) {
     return rfcMatch[1] + '.html';
   }
 
-  // W3C /TR specs should all have an "Overview.html" filename, let's not make
-  // additional network requests to avoid running into rate limiting issues
-  // (W3C servers can easily be made to return 429 Too Many Requests responses)
-  // Note: exceptions to the rule need to be handled in "specs.json".
-  const w3cTr = url.match(/^https?:\/\/(?:www\.)?w3\.org\/TR\/([^\/]+)\/$/);
-  if (w3cTr) {
-    return "Overview.html";
-  }
-
   // Make sure that url ends with a "/"
   const urlWithSlash = url.endsWith("/") ? url : url + "/";
 


### PR DESCRIPTION
This update restricts the actual determination of filenames to new specs, to avoid network requests. When network requests need to be sent, they are now sent sequentially, with a 1s delay between requests. There should be a handful of specs for which network requests are needed at most.