### PR TITLE
Limit test on builds to data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm run test-data
+        npm run test-index
 
     - name: Bump minor version of packages if needed
       run: node src/bump-packages-minor.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm run test
+        npm run test-data
 
     - name: Bump minor version of packages if needed
       run: node src/bump-packages-minor.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "node src/lint.js",
     "lint-fix": "node src/lint.js --fix",
     "test": "mocha",
-    "test-data": "mocha test/index.js"
+    "test-index": "mocha test/index.js"
+
   },
   "bin": {
     "browser-specs": "./src/cli.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "node src/build-index.js",
     "lint": "node src/lint.js",
     "lint-fix": "node src/lint.js --fix",
-    "test": "mocha"
+    "test": "mocha",
+    "test-data": "mocha test/index.js"
   },
   "bin": {
     "browser-specs": "./src/cli.js",


### PR DESCRIPTION
The build is failing because it is running the full test suite which makes HTTP requests that fail; while that is probably worth addressing on its own, it is not necessary to test the code when it is only the data we're updating, which this PR enables.