### PR TITLE
Refresh throttling logic (based on code used in Reffy)

### DIFF
--- a/src/load-spec.js
+++ b/src/load-spec.js
@@ -13,7 +13,7 @@ module.exports = async function (url, page) {
     return async function ({ requestId, request }) {
       try {
         // Abort network requests to common image formats
-        if (/\.(gif|ico|jpg|jpeg|png|ttf|woff|svg)$/i.test(request.url)) {
+        if (/\.(gif|ico|jpg|jpeg|png|ttf|woff|svg|css)$/i.test(request.url)) {
           await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
           return;
         }


### PR DESCRIPTION
This imports the adjustments made to the throttling logic in Reffy. In the end, it seems useful to adopt the same strategy regarding sleeping between requests: 2s for CSS server, 1s for www.w3.org, and 100ms for other origins.

This raises the question of whether that logic should rather be integrated into throttled-queue.js if we use the same logic everywhere. Oh well ;)

Refresh also skips CSS resources as done in Reffy.