### PR TITLE
Make css-overflow-5 a delta spec, add related test

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -113,7 +113,7 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS Multicol 2"
   },
-  "https://drafts.csswg.org/css-overflow-5/",
+  "https://drafts.csswg.org/css-overflow-5/ delta",
   "https://drafts.csswg.org/css-page-4/ delta",
   "https://drafts.csswg.org/css-position-4/ delta",
   "https://drafts.csswg.org/css-scroll-snap-2/ delta",

--- a/test/index.js
+++ b/test/index.js
@@ -103,6 +103,16 @@ describe("The `index.json` list", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("does not have a delta followed by a full spec in a series", () => {
+    const wrong = specs.filter(spec =>
+      spec.seriesComposition === "delta" &&
+      spec.seriesNext &&
+      specs.find(s =>
+        s.shortname === spec.seriesNext &&
+        s.seriesComposition === "full"));
+    assert.deepStrictEqual(wrong, []);
+  });
+
   it("has consistent series info", () => {
     const wrong = specs.filter(s => {
       if (!s.seriesPrevious) {


### PR DESCRIPTION
The css-overflow-5 spec was added last week as a full spec, but css-overflow-4 is a delta spec. On top of being incorrect because level 5 is also a delta spec, the succession full > delta > full confuses Reffy, who considers that level 5 is the "latest version" it should report extracts for, instead of level 3: it ends up with creating a `css/css-overflow.json` extract for level 5, `css/css-overflow-4.json` for level 4, and no extract for level 3.

This update makes css-overflow-5 a delta spec and adds a test to guarantee that a delta spec can never be followed by a full spec in its series.