### PR TITLE
Update repository for core-aam

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -882,7 +882,7 @@
     "url": "https://www.w3.org/TR/core-aam-1.2/",
     "nightly": {
       "repository": "https://github.com/w3c/aria",
-      "sourcePath": "accname/index.html"
+      "sourcePath": "core-aam/index.html"
     }
   },
   "https://www.w3.org/TR/credential-management-1/",

--- a/specs.json
+++ b/specs.json
@@ -878,7 +878,13 @@
   },
   "https://www.w3.org/TR/compute-pressure/",
   "https://www.w3.org/TR/contact-picker/",
-  "https://www.w3.org/TR/core-aam-1.2/",
+  {
+    "url": "https://www.w3.org/TR/core-aam-1.2/",
+    "nightly": {
+      "repository": "https://github.com/w3c/aria",
+      "sourcePath": "accname/index.html"
+    }
+  },
   "https://www.w3.org/TR/credential-management-1/",
   "https://www.w3.org/TR/csp-embedded-enforcement/",
   "https://www.w3.org/TR/CSP3/",


### PR DESCRIPTION
The source of the spec was moved to the main ARIA GitHub repository. The Editor's Draft is still being served from the previous repository though, meaning the URL of the Editor's Draft remains unchanged.