### PR TITLE
Deal with ARIA exodus

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -849,7 +849,12 @@
     ]
   },
   "https://www.w3.org/TR/accelerometer/",
-  "https://www.w3.org/TR/accname-1.2/",
+  {
+    "url": "https://www.w3.org/TR/accname-1.2/",
+    "nightly": {
+      "repository": "https://github.com/w3c/aria"
+    }
+  },
   "https://www.w3.org/TR/ambient-light/",
   "https://www.w3.org/TR/appmanifest/",
   "https://www.w3.org/TR/audio-output/",
@@ -878,13 +883,7 @@
   },
   "https://www.w3.org/TR/compute-pressure/",
   "https://www.w3.org/TR/contact-picker/",
-  {
-    "url": "https://www.w3.org/TR/core-aam-1.2/",
-    "nightly": {
-      "repository": "https://github.com/w3c/aria",
-      "sourcePath": "core-aam/index.html"
-    }
-  },
+  "https://www.w3.org/TR/core-aam-1.2/",
   "https://www.w3.org/TR/credential-management-1/",
   "https://www.w3.org/TR/csp-embedded-enforcement/",
   "https://www.w3.org/TR/CSP3/",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -96,6 +96,9 @@ module.exports = async function (specs, options) {
       `${spec.series.shortname}/Overview.bs`,
       `${spec.series.shortname}/Overview.src.html`,
 
+      // Used for ARIA specs
+      `${spec.series.shortname}/index.html`,
+
       // Named after the nightly filename
       `${nightlyFilename}.bs`,
       `${nightlyFilename}.html`,

--- a/src/parse-spec-url.js
+++ b/src/parse-spec-url.js
@@ -19,7 +19,13 @@ module.exports = function (url) {
 
   const githubio = url.match(/^https:\/\/([^\.]*)\.github\.io\/([^\/]*)\/?/);
   if (githubio) {
-    return { type: "github", owner: githubio[1], name: githubio[2] };
+    let name = githubio[2];
+    if ((name.endsWith("-aam") || name.endsWith("-aria")) && name !== "html-aria") {
+      // AAM and ARIA specs moved to the ARIA mono-repo, except HTML-ARIA,
+      // which is maintained by the Web Apps WG.
+      name = "aria";
+    }
+    return { type: "github", owner: githubio[1], name };
   }
 
   const whatwg = url.match(/^https:\/\/([^\.]*).spec.whatwg.org\//);

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -91,4 +91,10 @@ describe("compute-repository module", async () => {
       await computeSingleRepo("https://example.net/repoless"),
       null);
   });
+
+  it("reports right ARIA mono-repository for relevant specs", async () => {
+    assert.equal(
+      await computeSingleRepo("https://w3c.github.io/core-aam"),
+      "https://github.com/w3c/aria");
+  });
 });


### PR DESCRIPTION
[Now I know why I was confused with accname and core-aam. Both had already moved! ;)]

More specs have moved in the past few hours. Migration of the html-aam spec is still pending but there's an open PR for that, and the spec already exists under the ARIA mono-repository.

This update hardcodes the rule "all specs whose nightly URL end with -aam or -aria are in the w3c/aria repository". Except for html-aria, which is developed by the WebApps WG in a different group. The logic now also finds the source file on its own in that repository.

This avoids having to add `repository` and `sourcePath` in `specs.json` for all these specs. The `accname` spec remains an exception to the rule because it does not end with `-aam` or `-aria`.