### PR TITLE
Add `encrypted-media` as former name for `encrypted-media-2`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1134,7 +1134,10 @@
     "url": "https://www.w3.org/TR/encrypted-media-2/",
     "nightly": {
       "sourcePath": "encrypted-media-respec.html"
-    }
+    },
+    "formerNames": [
+      "encrypted-media"
+    ]
   },
   {
     "url": "https://www.w3.org/TR/epub-33/",


### PR DESCRIPTION
Missed during previous update.

Arguably, the continuity exists through the series shortname, but the guarantee that we make is that any shortname that used to appear will either appear as a shortname or in a `formerNames` property.