### PR TITLE
ESM all the things!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-const specs = require("./index.json");
+import specs from "./index.json" with { type: "json" };
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
 
 
 /**
@@ -31,13 +33,10 @@ function getSpecs(filter) {
   }
 }
 
+export { getSpecs };
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // Code used as command-line interface (CLI), output info about known specs.
   const res = getSpecs(process.argv[2]);
   console.log(JSON.stringify(res.length === 1 ? res[0] : res, null, 2));
-}
-else {
-  // Code referenced from another JS module, export
-  module.exports = { getSpecs };
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "mocha",
     "test-index": "mocha test/index.js"
   },
+  "type": "module",
   "bin": {
     "browser-specs": "./src/cli.js",
     "find-specs": "./src/find-specs.js"

--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -19,11 +19,16 @@
  * node src/build-diff HEAD..HEAD~3
  */
 
-const assert = require("assert");
-const path = require("path");
-const { execSync } = require("child_process");
-const { generateIndex } = require("./build-index");
-const computeShortname = require("./compute-shortname.js");
+import assert from "node:assert";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { generateIndex } from "./build-index.js";
+import computeShortname from "./compute-shortname.js";
+import loadJSON from "./load-json.js";
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Spec sort function.
@@ -162,7 +167,7 @@ async function buildCommits(newRef, baseRef, { diffType = "diff", log = console.
   log(`Retrieve specs.json at "${newRef}"...`);
   let newSpecs;
   if (newRef.toLowerCase() === "working") {
-    newSpecs = require(path.resolve(__dirname, "..", "specs.json"));
+    newSpecs = await loadJSON(path.resolve(scriptPath, "..", "specs.json"));
   }
   else {
     const newSpecsStr = execSync(`git show ${newRef}:specs.json`, { encoding: "utf8" });
@@ -216,11 +221,11 @@ async function buildCommits(newRef, baseRef, { diffType = "diff", log = console.
  */
 async function buildSpec(spec, { diffType = "diff", log = console.log }) {
   log(`Retrieve specs.json...`);
-  const baseSpecs = require(path.resolve(__dirname, "..", "specs.json"));
+  const baseSpecs = await loadJSON(path.resolve(scriptPath, "..", "specs.json"));
   log(`Retrieve specs.json... done`);
 
   log(`Retrieve index.json...`);
-  const baseIndex = require(path.resolve(__dirname, "..", "index.json"));
+  const baseIndex = await loadJSON(path.resolve(scriptPath, "..", "index.json"));
   log(`Retrieve index.json... done`);
 
   log(`Prepare diff...`);
@@ -294,7 +299,7 @@ async function buildDiff(diff, baseSpecs, baseIndex, { diffType = "diff", log = 
 /*******************************************************************************
 Export main function for use as module
 *******************************************************************************/
-module.exports = {
+export {
   build,
   buildCommits,
   buildSpec
@@ -304,7 +309,7 @@ module.exports = {
 /*******************************************************************************
 Main loop
 *******************************************************************************/
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const what = process.argv[2] ?? "working";
   const diffType = process.argv[3] ?? "diff";
 

--- a/src/check-base-url.js
+++ b/src/check-base-url.js
@@ -10,8 +10,8 @@
  * No content is returned when everything looks good.
  */
 
-const core = require("@actions/core");
-const specs = require("../index.json");
+import core from "@actions/core";
+import specs from "../index.json";
 
 const problems = specs
   // A subset of the IETF RFCs are crawled from their httpwg.org rendering

--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -3,9 +3,9 @@
  * has most of its info filled out and returns an object with "alternativeUrls"
  * based on well-known patterns for certain publishers.
  */
-const computeShortname = require("./compute-shortname.js");
+import computeShortname from "./compute-shortname.js";
 
-module.exports = function computeAlternateUrls(spec) {
+export default function (spec) {
   if (!spec?.url) {
     throw "Invalid spec object passed as parameter";
   }

--- a/src/compute-categories.js
+++ b/src/compute-categories.js
@@ -13,7 +13,8 @@
 // specs targeted at browsers. That logic will also very likely evolve over
 // time, be it only to give the file a different name (the list of specs will
 // be expanded to contain specs in that "ignore" list)
-const { groups: nonbrowserGroups, repos: nonbrowserRepos } = require('./data/ignore.json');
+import ignore from './data/ignore.json' with { type: 'json' };
+const { groups: nonbrowserGroups, repos: nonbrowserRepos } = ignore;
 
 /**
  * Exports main function that takes a spec object and returns a list of
@@ -26,7 +27,7 @@ const { groups: nonbrowserGroups, repos: nonbrowserRepos } = require('./data/ign
  * contains `reset`, the function does not attempt to compute a list but rather
  * returns the list of categories in the spec object.
  */
-module.exports = function (spec) {
+export default function (spec) {
   if (!spec || !spec.groups) {
     throw "Invalid spec object passed as parameter";
   }

--- a/src/compute-currentlevel.js
+++ b/src/compute-currentlevel.js
@@ -19,7 +19,7 @@
  * "currentSpecification" property. Function always sets the property (value is
  * the name of the spec itself when it is the current level)
  */
-module.exports = function (spec, list) {
+export default function (spec, list) {
   list = list || [];
   if (!spec) {
     throw "Invalid spec object passed as parameter";

--- a/src/compute-prevnext.js
+++ b/src/compute-prevnext.js
@@ -13,7 +13,7 @@
  * "seriesPrevious" and/or "seriesNext" set. Function only sets the
  * properties when needed, so returned object may be empty.
  */
-module.exports = function (spec, list) {
+export default function (spec, list) {
   if (!spec || !spec.shortname || !spec.series || !spec.series.shortname) {
     throw "Invalid spec object passed as parameter";
   }

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -7,8 +7,8 @@
  * The function needs an authentication token for the GitHub API.
  */
 
-const Octokit = require("./octokit");
-const parseSpecUrl = require("./parse-spec-url.js");
+import Octokit from "./octokit.js";
+import parseSpecUrl from "./parse-spec-url.js";
 
 
 /**
@@ -38,7 +38,7 @@ function getFirstFoundInTree(paths, ...items) {
  * by the function will remain the lowercased version, and that the returned
  * info won't include the source file).
  */
-module.exports = async function (specs, options) {
+export default async function (specs, options) {
   if (!specs) {
     throw "Invalid list of specifications passed as parameter";
   }

--- a/src/compute-series-urls.js
+++ b/src/compute-series-urls.js
@@ -55,7 +55,7 @@ function computeSeriesUrls(spec) {
  * the list to look for previous versions of a spec to find a suitable release
  * URL when the latest version does not have one.
  */
-module.exports = function (spec, list) {
+export default function (spec, list) {
   list = list || [];
 
   // Compute series info for current version of the spec if it is in the list

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -232,7 +232,7 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
  * Exports main function that takes a URL (or a spec name) and returns an
  * object with a name, a shortname and a level (if needed).
  */
-module.exports = function (url, forkOf) {
+export default function (url, forkOf) {
   if (!url) {
     throw "No URL passed as parameter";
   }

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -15,7 +15,7 @@
  *
  * The function throws if it cannot compute a meaningful name from the URL.
  */
-module.exports = function (title) {
+export default function (title) {
   if (!title) {
     return title;
   }

--- a/src/compute-standing.js
+++ b/src/compute-standing.js
@@ -19,7 +19,7 @@ const unofficialStatuses = [
  * Exports main function that takes a spec object and returns the standing of
  * the spec.
  */
-module.exports = function (spec) {
+export default function (spec) {
   if (!spec) {
     throw "Invalid spec object passed as parameter";
   }

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -9,7 +9,7 @@
  * the filename is "index.html".
  */
 
-module.exports = async function (url) {
+export default async function (url) {
   // Extract filename directly from the URL when possible
   const match = url.match(/\/([^/]+\.(html|pdf|txt))$/);
   if (match) {

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -7,12 +7,14 @@
  * ".cache" folder.
  */
 
-const fs = require("fs");
-const path = require("path");
-const execSync = require("child_process").execSync;
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 // Cache folder under which the WPT repository will be cloned
-const cacheFolder = path.resolve(__dirname, "..", ".cache");
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const cacheFolder = path.resolve(scriptPath, "..", ".cache");
 const wptFolder = path.resolve(cacheFolder, "wpt");
 
 /**
@@ -124,7 +126,7 @@ function getFirstFoundInArray(paths, ...items) {
  *
  * The options parameter is used to specify the GitHub API authentication token.
  */
-module.exports = async function (specs, options) {
+export default async function (specs, options) {
   if (!specs || specs.find(spec => !spec.shortname || !spec.series || !spec.series.shortname)) {
     throw "Invalid list of specifications passed as parameter";
   }

--- a/src/extract-pages.js
+++ b/src/extract-pages.js
@@ -4,9 +4,9 @@
  * the table of contents, in document order, excluding the index page.
  */
 
-const loadSpec = require('./load-spec');
+import loadSpec from './load-spec.js';
 
-module.exports = async function (url, browser) {
+export default async function (url, browser) {
   const page = await browser.newPage();
   try {
     await loadSpec(url, page);

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -6,8 +6,8 @@
  * The function needs an authentication token for the GitHub API.
  */
 
-const Octokit = require("./octokit");
-const parseSpecUrl = require("./parse-spec-url.js");
+import Octokit from "./octokit.js";
+import parseSpecUrl from "./parse-spec-url.js";
 
 
 /**
@@ -79,7 +79,7 @@ async function setISOGroupFromPage(spec, options) {
  * The options parameter is used to specify the GitHub API
  * authentication token.
  */
-module.exports = async function (specs, options) {
+export default async function (specs, options) {
   // Maintain a cache of fetched resources in memory to avoid sending the
   // same fetch request again and again
   const cache = {};

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -38,11 +38,11 @@
  * bundle requests to Specref.
  */
 
-const puppeteer = require("puppeteer");
-const loadSpec = require("./load-spec");
-const computeShortname = require("./compute-shortname");
-const Octokit = require("./octokit");
-const ThrottledQueue = require("./throttled-queue");
+import puppeteer from "puppeteer";
+import loadSpec from "./load-spec.js";
+import computeShortname from "./compute-shortname.js";
+import Octokit from "./octokit.js";
+import ThrottledQueue from "./throttled-queue.js";
 
 // Map spec statuses returned by Specref to those used in specs
 // Note we typically won't get /TR statuses from Specref, since all /TR URLs
@@ -657,4 +657,4 @@ async function fetchInfo(specs, options) {
 }
 
 
-module.exports = fetchInfo;
+export default fetchInfo;

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -1,18 +1,22 @@
 #!/usr/bin/env node
 'use strict';
-const fs = require("fs").promises;
-const puppeteer = require('puppeteer');
-const path = require("path");
-const { Command } = require("commander");
-const { execSync } = require("child_process");
-const { version } = require(path.join(__dirname, "..", "package.json"));
-const execParams = { cwd: path.join(__dirname, '..') };
+import fs from "node:fs/promises";
+import puppeteer from 'puppeteer';
+import path from "node:path";
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import packageContents from "../package.json" with { type: "json" };
+const { version } = packageContents;
+import { fileURLToPath } from "node:url";
 
-const computeShortname = require("./compute-shortname");
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const execParams = { cwd: path.join(scriptPath, '..') };
 
-const specs = require("../index.json");
-const ignorable = require("./data/ignore.json");
-const monitorList = require("./data/monitor.json");
+import computeShortname from "./compute-shortname.js";
+
+import specs from "../index.json" with { type: "json" };
+import ignorable from "./data/ignore.json" with { type: "json" };
+import monitorList from "./data/monitor.json" with { type: "json" };
 
 const {repos: temporarilyIgnorableRepos, specs: temporarilyIgnorableSpecs} = monitorList;
 
@@ -371,7 +375,7 @@ Examples:
         // template. There is unfortunately no easy way to create an issue out
         // of such a template directly.
         const title = `Add ${candidate.shortname ?? candidate.spec}`;
-        const bodyFile = path.join(__dirname, "..", "__issue.md");
+        const bodyFile = path.join(scriptPath, "..", "__issue.md");
         const comments = [
           `- See repository: [${candidate.repo}](https://github.com/${candidate.repo})`,
           candidate.impl.chrome ? `- [chrome status](${candidate.impl.chrome})` : null,

--- a/src/lint.js
+++ b/src/lint.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const fs = require("fs").promises;
-const computeShortname = require("./compute-shortname.js");
-const computePrevNext = require("./compute-prevnext.js");
-
+import fs from "node:fs/promises";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import computeShortname from "./compute-shortname.js";
+import computePrevNext from "./compute-prevnext.js";
 
 function compareSpecs(a, b) {
   return a.url.localeCompare(b.url);
@@ -97,8 +98,12 @@ async function lint(fix = false) {
   return true;
 }
 
+export {
+  lintStr,
+  lint
+};
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // Code used as command-line interface (CLI), run linting process
   lint(process.argv.includes("--fix")).then(
     ok => {
@@ -109,9 +114,4 @@ if (require.main === module) {
       process.exit(1);
     }
   );
-}
-else {
-  // Code imported to another JS module, export lint functions
-  module.exports.lintStr = lintStr;
-  module.exports.lint = lint;
 }

--- a/src/load-json.js
+++ b/src/load-json.js
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises';
+
+/**
+ * Load a JSON file as JS object.
+ *
+ * @function
+ * @param {String} filename The path to the file to require
+ * @return {Object} The result of loading and parsing the file relative to the
+ *   current working directory.
+ */
+export default async function (filename) {
+  try {
+    const json = await readFile(filename, 'utf8');
+    return JSON.parse(json);
+  }
+  catch (err) {
+    return null;
+  }
+}

--- a/src/load-spec.js
+++ b/src/load-spec.js
@@ -4,7 +4,7 @@
  * cause timeout issues on CSS servers.
  */
 
-module.exports = async function (url, page) {
+export default async function (url, page) {
   // Inner function that returns a network interception method for Puppeteer,
   // to avoid downloading images and getting stuck on streams.
   // NB: this is a simplified version of the code used in Reffy:

--- a/src/monitor-specs.js
+++ b/src/monitor-specs.js
@@ -1,43 +1,36 @@
 'use strict';
-const fs = require("fs");
-
-const core = require('@actions/core');
-
-const fetch = require("node-fetch");
-
-const monitorList = require("./data/monitor.json");
+import fs from "node:fs/promises";
+import core from '@actions/core';
+import monitorList from "./data/monitor.json" with { type: "json" };
 
 const toGhUrl = repo => `https://${repo.split("/")[0].toLowerCase()}.github.io/${repo.split("/")[1]}/`;
 
 const today = new Date().toJSON().slice(0, 10);
 
-(async function() {
-  // Check last-modified HTTP header for specs to highlight those that needs
-  // re-review
-  let review_needed = [];
-  const candidates = Object.keys(monitorList.repos).map(r => {return {...monitorList.repos[r], url: toGhUrl(r)};}).concat(
-    Object.keys(monitorList.specs).map(s => {return {...monitorList.specs[s], url: s};}));
- for (let candidate of candidates) {
-   await fetch(candidate.url).then(({headers}) => {
-     // The CSS drafts use a proprietary header to expose the real last modification date
-     const lastRevised = headers.get('Last-Revised') ? new Date(headers.get('Last-Revised')) : new Date(headers.get('Last-Modified'));
-     if (lastRevised > new Date(candidate.lastreviewed)) {
-       review_needed.push({...candidate, lastupdated: lastRevised.toJSON()});
-     }
-   });
- }
- const review_list = review_needed.map(c => `- [ ] ${c.url} updated on ${c.lastupdated}; last comment: “${c.comment}” made on ${c.lastreviewed}`).join("\n");
- core.exportVariable("review_list", review_list);
- console.log(review_list);
+// Check last-modified HTTP header for specs to highlight those that needs
+// re-review
+let review_needed = [];
+const candidates = Object.keys(monitorList.repos).map(r => {return {...monitorList.repos[r], url: toGhUrl(r)};}).concat(
+  Object.keys(monitorList.specs).map(s => {return {...monitorList.specs[s], url: s};}));
+for (let candidate of candidates) {
+  const response = await fetch(candidate.url);
+  const { headers } = response;
+  // The CSS drafts use a proprietary header to expose the real last modification date
+  const lastRevised = headers.get('Last-Revised') ? new Date(headers.get('Last-Revised')) : new Date(headers.get('Last-Modified'));
+  if (lastRevised > new Date(candidate.lastreviewed)) {
+    review_needed.push({...candidate, lastupdated: lastRevised.toJSON()});
+  }
+  // We don't need the response's body, but not reading it means Node will keep
+  // the network request in memory, which prevents the CLI from returning until
+  // a timeout occurs.
+  await response.arrayBuffer();
+}
+const review_list = review_needed.map(c => `- [ ] ${c.url} updated on ${c.lastupdated}; last comment: “${c.comment}” made on ${c.lastreviewed}`).join("\n");
+core.exportVariable("review_list", review_list);
+console.log(review_list);
 
-  // Update monitor.json setting lastreviewed date today on all entries
-  // This will serve as input to the automated pull request
-  Object.values(monitorList.repos).forEach(r => r.lastreviewed = today);
-  Object.values(monitorList.specs).forEach(r => r.lastreviewed = today);
- fs.writeFileSync("./src/data/monitor.json", JSON.stringify(monitorList, null, 2));
-})().catch(e => {
-  console.error(e);
-  process.exit(1);
-});
-
-
+// Update monitor.json setting lastreviewed date today on all entries
+// This will serve as input to the automated pull request
+Object.values(monitorList.repos).forEach(r => r.lastreviewed = today);
+Object.values(monitorList.specs).forEach(r => r.lastreviewed = today);
+await fs.writeFile("./src/data/monitor.json", JSON.stringify(monitorList, null, 2));

--- a/src/octokit.js
+++ b/src/octokit.js
@@ -2,12 +2,13 @@
  * Wrapper around Octokit to add throttling and avoid hitting rate limits
  */
 
-const { throttling } = require("@octokit/plugin-throttling");
-const Octokit = require("@octokit/rest").Octokit.plugin(throttling);
+import { throttling } from "@octokit/plugin-throttling";
+import { Octokit as OctokitRest } from "@octokit/rest";
+const Octokit = OctokitRest.plugin(throttling);
 
 const MAX_RETRIES = 3;
 
-module.exports = function (params) {
+export default function (params) {
   params = params || {};
 
   const octoParams = Object.assign({

--- a/src/parse-spec-url.js
+++ b/src/parse-spec-url.js
@@ -7,7 +7,7 @@
  * shortnames do not always match the name of the actual repo).
  */
 
-module.exports = function (url) {
+export default function (url) {
   if (!url) {
     throw "No URL passed as parameter";
   }

--- a/src/prepare-packages.js
+++ b/src/prepare-packages.js
@@ -10,13 +10,17 @@
  * node src/prepare-packages.js
  */
 
-const fs = require('fs').promises;
-const path = require('path');
-const util = require('util');
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import util from 'node:util';
+import { fileURLToPath } from 'node:url';
+import loadJSON from './load-json.js';
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 async function preparePackages() {
   console.log('Load index file');
-  const index = require(path.join('..', 'index.json'));
+  const index = await loadJSON(path.join(scriptPath, '..', 'index.json'));
   console.log(`- ${index.length} specs in index file`);
 
   const packages = [
@@ -42,14 +46,14 @@ async function preparePackages() {
 
     // Write packages/${name}/index.json
     await fs.writeFile(
-      path.resolve(__dirname, '..', 'packages', name, 'index.json'),
+      path.resolve(scriptPath, '..', 'packages', name, 'index.json'),
       JSON.stringify(specs, null, 2),
       'utf8');
     console.log(`- packages/${name}/index.json updated`);
 
     // Update README.md
-    const commonReadme = await fs.readFile(path.resolve(__dirname, '..', 'README.md'), 'utf8');
-    const packageReadmeFile = path.resolve(__dirname, '..', 'packages', name, 'README.md');
+    const commonReadme = await fs.readFile(path.resolve(scriptPath, '..', 'README.md'), 'utf8');
+    const packageReadmeFile = path.resolve(scriptPath, '..', 'packages', name, 'README.md');
     let packageReadme = await fs.readFile(packageReadmeFile, 'utf8');
     const commonBlocks = [
       { start: '<!-- COMMON-TOC: start -->', end: '<!-- COMMON-TOC: end -->' },

--- a/src/release-package.js
+++ b/src/release-package.js
@@ -3,13 +3,14 @@
  * which the pre-release PR is based as source of data.
  */
 
-const Octokit = require("./octokit");
-const fs = require("fs");
-const path = require("path");
-const os = require("os");
-const { execSync } = require("child_process");
-const { rimraf } = require("rimraf");
-const { npmPublish } = require("@jsdevtools/npm-publish");
+import Octokit from "./octokit.js";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execSync } from "node:child_process";
+import { rimraf } from "rimraf";
+import { npmPublish } from "@jsdevtools/npm-publish";
+import loadJSON from "./load-json.js";
 
 const owner = "w3c";
 const repo = "browser-specs";
@@ -118,26 +119,14 @@ async function releasePackage(prNumber) {
 /*******************************************************************************
 Retrieve tokens from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GITHUB_TOKEN = (_ => {
-  try {
-    return require("../config.json").GITHUB_TOKEN;
-  }
-  catch {
-    return "";
-  }
-})() || process.env.GITHUB_TOKEN;
+const config = await loadJSON("config.json");
+const GITHUB_TOKEN = config?.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 if (!GITHUB_TOKEN) {
   console.error("GITHUB_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);
 }
 
-const NPM_TOKEN = (() => {
-  try {
-    return require("../config.json").NPM_TOKEN;
-  } catch {
-    return process.env.NPM_TOKEN;
-  }
-})();
+const NPM_TOKEN = config?.NPM_TOKEN ?? process.env.NPM_TOKEN;
 if (!NPM_TOKEN) {
   console.error("NPM_TOKEN must be set to an npm token as an env variable or in a config.json file");
   process.exit(1);

--- a/src/request-pr-review.js
+++ b/src/request-pr-review.js
@@ -2,7 +2,8 @@
  * Request a review on a pending pre-release PR
  */
 
-const Octokit = require("./octokit");
+import Octokit from "./octokit.js";
+import loadJSON from "./load-json.js";
 
 // Repository to process and PR reviewers
 const owner = "w3c";
@@ -58,14 +59,8 @@ async function requestReview(type) {
 /*******************************************************************************
 Retrieve GITHUB_TOKEN from environment, prepare Octokit and kick things off
 *******************************************************************************/
-const GITHUB_TOKEN = (_ => {
-  try {
-    return require("../config.json").GITHUB_TOKEN;
-  }
-  catch {
-    return "";
-  }
-})() || process.env.GITHUB_TOKEN;
+const config = await loadJSON("config.json");
+const GITHUB_TOKEN = config?.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 if (!GITHUB_TOKEN) {
   console.error("GITHUB_TOKEN must be set to some personal access token as an env variable or in a config.json file");
   process.exit(1);

--- a/src/throttled-queue.js
+++ b/src/throttled-queue.js
@@ -43,7 +43,7 @@ function getOrigin(url) {
  * while guaranteeing that only one request will be sent to a given origin
  * server at a time.
  */
-module.exports = class ThrottledQueue {
+export default class ThrottledQueue {
   originQueue = {};
   maxParallel = 4;
   sleepInterval = 2000;

--- a/test/compute-categories.js
+++ b/test/compute-categories.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeCategories = require("../src/compute-categories.js");
+import assert from "node:assert";
+import computeCategories from "../src/compute-categories.js";
 
 describe("compute-categories module", () => {
   it("sets `browser` category when group targets browsers", function () {

--- a/test/compute-currentlevel.js
+++ b/test/compute-currentlevel.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeCurrentLevel = require("../src/compute-currentlevel.js");
+import assert from "node:assert";
+import computeCurrentLevel from "../src/compute-currentlevel.js";
 
 describe("compute-currentlevel module", () => {
   function getCurrentName(spec, list) {

--- a/test/compute-prevnext.js
+++ b/test/compute-prevnext.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computePrevNext = require("../src/compute-prevnext.js");
+import assert from "node:assert";
+import computePrevNext from "../src/compute-prevnext.js";
 
 describe("compute-prevnext module", () => {
   function getSpec(seriesVersion) {

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeRepo = require("../src/compute-repository.js");
+import assert from "node:assert";
+import computeRepo from "../src/compute-repository.js";
 
 describe("compute-repository module", async () => {
   async function computeSingleRepo(url) {

--- a/test/compute-series-urls.js
+++ b/test/compute-series-urls.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeSeriesUrls = require("../src/compute-series-urls.js");
+import assert from "node:assert";
+import computeSeriesUrls from "../src/compute-series-urls.js";
 
 describe("compute-series-urls module", () => {
   it("returns spec URLs when spec has no level", () => {

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeInfo = require("../src/compute-shortname.js");
+import assert from "node:assert";
+import computeInfo from "../src/compute-shortname.js";
 
 describe("compute-shortname module", () => {
 

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeShortTitle = require("../src/compute-shorttitle.js");
+import assert from "node:assert";
+import computeShortTitle from "../src/compute-shorttitle.js";
 
 describe("compute-shorttitle module", () => {
   function assertTitle(title, expected) {

--- a/test/compute-standing.js
+++ b/test/compute-standing.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const computeStanding = require("../src/compute-standing.js");
+import assert from "node:assert";
+import computeStanding from "../src/compute-standing.js";
 
 describe("compute-standing module", () => {
   it("returns `good` for an Editor's Draft", function () {

--- a/test/determine-filename.js
+++ b/test/determine-filename.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const determineFilename = require("../src/determine-filename.js");
+import assert from "node:assert";
+import determineFilename from "../src/determine-filename.js";
 
 describe("determine-filename module", function () {
   // Tests need to send network requests

--- a/test/extract-pages.js
+++ b/test/extract-pages.js
@@ -1,6 +1,6 @@
-const assert = require("assert");
-const puppeteer = require("puppeteer");
-const extractPages = require("../src/extract-pages.js");
+import assert from "node:assert";
+import puppeteer from "puppeteer";
+import extractPages from "../src/extract-pages.js";
 
 describe("extract-pages module", function () {
   // Tests need to send network requests

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const fetchGroups = require("../src/fetch-groups.js");
+import assert from "node:assert";
+import fetchGroups from "../src/fetch-groups.js";
 
 const githubToken = (function () {
   try {

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -2,10 +2,10 @@
  * Tests for the fetch-info module
  */
 
-const assert = require("assert");
-const fetchInfo = require("../src/fetch-info.js");
+import assert from "node:assert";
+import fetchInfo from "../src/fetch-info.js";
 
-const { MockAgent, setGlobalDispatcher, getGlobalDispatcher } = require('undici');
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
 
 describe("fetch-info module", function () {
   // Tests need to send network requests

--- a/test/index.js
+++ b/test/index.js
@@ -4,15 +4,21 @@
  */
 
 // Tests may run against a test version of the index file
-const specs = require(process.env.testIndex ?? "../index.json");
-const assert = require("assert");
-const schema = require("../schema/index.json");
-const dfnsSchema = require("../schema/definitions.json");
-const computeShortname = require("../src/compute-shortname");
-const Ajv = require("ajv");
-const addFormats = require("ajv-formats")
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import schema from "../schema/index.json" with { type: "json" };
+import dfnsSchema from "../schema/definitions.json" with { type: "json" };
+import computeShortname from "../src/compute-shortname.js";
+import loadJSON from "../src/load-json.js";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
 const ajv = new Ajv();
 addFormats(ajv);
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const specsFile = process.env.testIndex ?? path.resolve(scriptPath, "..", "index.json");
+const specs = await loadJSON(specsFile);
 
 describe("The `index.json` list", () => {
   it("has a valid JSON schema", () => {

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const { lintStr } = require("../src/lint.js");
+import assert from "node:assert";
+import { lintStr } from "../src/lint.js";
 
 describe("Linter", () => {
   describe("lintStr()", () => {

--- a/test/shortname-continuity.js
+++ b/test/shortname-continuity.js
@@ -1,11 +1,17 @@
 // Tests may run against a test version of the index file
-const specs = require(process.env.testIndex ?? "../index.json");
-const assert = require("assert");
-const os = require("os");
-const fs = require("fs");
-const path = require("path");
-const util = require("util");
-const exec = util.promisify(require("child_process").exec);
+import assert from "node:assert";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import util from "node:util";
+import { exec as execCb } from "node:child_process";
+import { fileURLToPath } from "node:url";
+const exec = util.promisify(execCb);
+import loadJSON from "../src/load-json.js";
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const specsFile = process.env.testIndex ?? path.resolve(scriptPath, "..", "index.json");
+const specs = await loadJSON(specsFile);
 
 describe("The build", function () {
   this.slow(30000);
@@ -18,8 +24,8 @@ describe("The build", function () {
     await exec("npm install web-specs", { cwd: tmpdir });
   });
 
-  it("preserves shortnames", () => {
-    const lastPublishedSpecs = require(path.join(
+  it("preserves shortnames", async () => {
+    const lastPublishedSpecs = await loadJSON(path.join(
       tmpdir, "node_modules", "web-specs", "index.json"));
 
     const shortnames = lastPublishedSpecs.map(spec => spec.shortname);

--- a/test/specs.js
+++ b/test/specs.js
@@ -6,16 +6,22 @@
  */
 
 // Tests may run against a test version of the specs file
-const specs = require(process.env.testSpecs ?? "../specs.json");
-const assert = require("assert");
-const schema = require("../schema/specs.json");
-const dfnsSchema = require("../schema/definitions.json");
-const computeInfo = require("../src/compute-shortname.js");
-const computePrevNext = require("../src/compute-prevnext.js");
-const Ajv = require("ajv");
-const addFormats = require("ajv-formats")
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import schema from "../schema/specs.json" with { type: "json" };
+import dfnsSchema from "../schema/definitions.json" with { type: "json" };
+import computeInfo from "../src/compute-shortname.js";
+import computePrevNext from "../src/compute-prevnext.js";
+import loadJSON from "../src/load-json.js";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
 const ajv = (new Ajv()).addSchema(dfnsSchema);
 addFormats(ajv);
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const specsFile = process.env.testIndex ?? path.resolve(scriptPath, "..", "specs.json");
+const specs = await loadJSON(specsFile);
 
 // When an entry is invalid, the schema validator returns one error for each
 // "oneOf" option and one error on overall "oneOf" problem. This is confusing


### PR DESCRIPTION
Note that, while Mocha supports ESM modules when used as CLI, it does not support them out of the box when using Mocha programmatically. The code forces the loading of test modules as ESM through `loadFilesAsync()` before it calls `run()`, as suggested in the doc:
https://mochajs.org/api/mocha#loadFilesAsync