### PR TITLE
Update URL of Source Map

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -464,7 +464,7 @@
   },
   "https://tc39.es/proposal-temporal/",
   {
-    "url": "https://tc39.es/source-map-spec/",
+    "url": "https://tc39.es/source-map/",
     "shortname": "sourcemap",
     "nightly": {
       "status": "Editor's Draft",

--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -76,7 +76,7 @@ function areDistinctSpecsInSameSeries(s1, s2) {
     const computed2 = computeShortname(spec2.shortname ?? spec2.url, spec2.forkOf);
     const series1 = spec1?.series?.shortname ?? computed1.series.shortname;
     const series2 = spec2?.series?.shortname ?? computed2.series.shortname;
-    return series1 === series2;
+    return (computed1.shortname !== computed2.shortname) && (series1 === series2);
   }
   catch {
     return false;


### PR DESCRIPTION
Per #1427.

This also fixes the build-diff logic which duplicated the entry in the new index it creates for testing purpose, because the check on whether specs are effectively distinct did not take the spec's shortname into account.