### PR TITLE
payment-request is switching back to a level-less shortname

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1377,7 +1377,12 @@
   "https://www.w3.org/TR/payment-handler/",
   "https://www.w3.org/TR/payment-method-id/",
   "https://www.w3.org/TR/payment-method-manifest/",
-  "https://www.w3.org/TR/payment-request/",
+  {
+    "url": "https://www.w3.org/TR/payment-request/",
+    "formerNames": [
+      "payment-request-1.1"
+    ]
+  },
   "https://www.w3.org/TR/performance-timeline/",
   "https://www.w3.org/TR/permissions-policy-1/",
   "https://www.w3.org/TR/permissions/",

--- a/specs.json
+++ b/specs.json
@@ -1377,7 +1377,7 @@
   "https://www.w3.org/TR/payment-handler/",
   "https://www.w3.org/TR/payment-method-id/",
   "https://www.w3.org/TR/payment-method-manifest/",
-  "https://www.w3.org/TR/payment-request-1.1/",
+  "https://www.w3.org/TR/payment-request/",
   "https://www.w3.org/TR/performance-timeline/",
   "https://www.w3.org/TR/permissions-policy-1/",
   "https://www.w3.org/TR/permissions/",


### PR DESCRIPTION
The Web Payment WG is going back to a level-less shortname for payment-request.

/cc @ianbjacobs 