### PR TITLE
Fix specs.json tests when run from the "build" CLI command

### DIFF
--- a/test/specs.js
+++ b/test/specs.js
@@ -20,7 +20,7 @@ const ajv = (new Ajv()).addSchema(dfnsSchema);
 addFormats(ajv);
 
 const scriptPath = path.dirname(fileURLToPath(import.meta.url));
-const specsFile = process.env.testIndex ?? path.resolve(scriptPath, "..", "specs.json");
+const specsFile = process.env.testSpecs ?? path.resolve(scriptPath, "..", "specs.json");
 const specs = await loadJSON(specsFile);
 
 // When an entry is invalid, the schema validator returns one error for each


### PR DESCRIPTION
When the tests are run as part of a "build" command run from the CLI, the tests on `specs.json` and `index.json` do not actually run on the files but on copies amended with would-be updates. The path to the copy is read in an environment variable. The `specs.json` tests were run against the `index.json` copy, likely due to a hasty copy-and-paste in a previous update. That explains the weird test failures reported in the latest spec suggestion issues.