### PR TITLE
Add CSS Easing Level 2

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -96,7 +96,6 @@
   "https://drafts.csswg.org/css-color-hdr/",
   "https://drafts.csswg.org/css-conditional-values-1/",
   "https://drafts.csswg.org/css-display-4/",
-  "https://drafts.csswg.org/css-easing-2/",
   "https://drafts.csswg.org/css-env-1/",
   "https://drafts.csswg.org/css-extensions-1/",
   "https://drafts.csswg.org/css-forms-1/",
@@ -999,6 +998,7 @@
   "https://www.w3.org/TR/css-counter-styles-3/",
   "https://www.w3.org/TR/css-display-3/",
   "https://www.w3.org/TR/css-easing-1/",
+  "https://www.w3.org/TR/css-easing-2/",
   {
     "url": "https://www.w3.org/TR/css-flexbox-1/",
     "shortTitle": "CSS Flexbox 1"


### PR DESCRIPTION
Spec was published as a First Public Working Draft.

Fixes #1478 (manual because the logic does not properly handle the case when a spec transitions to /TR yet)