### PR TITLE
update FedCM to W3C FPWD

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -138,7 +138,7 @@
   },
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://encoding.spec.whatwg.org/",
-  "https://fedidcg.github.io/FedCM/",
+  "https://www.w3.org/TR/fedcm/",
   "https://fetch.spec.whatwg.org/",
   {
     "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",


### PR DESCRIPTION
FedCM spec advanced from CG to WG, which published a First Public Working Draft.

related https://github.com/mdn/browser-compat-data/pull/24289