### PR TITLE
Update URL of FedCM and record former shortname

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -138,7 +138,6 @@
   },
   "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://encoding.spec.whatwg.org/",
-  "https://fedidcg.github.io/FedCM/",
   "https://fetch.spec.whatwg.org/",
   {
     "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
@@ -1256,6 +1255,12 @@
     ]
   },
   "https://www.w3.org/TR/event-timing/",
+  {
+    "url": "https://www.w3.org/TR/fedcm-1/",
+    "formerNames": [
+      "fedCM"
+    ]
+  },
   {
     "url": "https://www.w3.org/TR/fetch-metadata/",
     "shortTitle": "Fetch Metadata"


### PR DESCRIPTION
First Public Working Draft published under the `fedcm-1` shortname.

Replaces #1486. Changes tested locally.