### PR TITLE
Update URL of css-values-5, fix duplicates in diff build

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -122,11 +122,6 @@
     "shortTitle": "CSS Size Adjustment 1"
   },
   {
-    "url": "https://drafts.csswg.org/css-values-5/",
-    "shortTitle": "CSS Values 5",
-    "seriesComposition": "delta"
-  },
-  {
     "url": "https://drafts.csswg.org/css-variables-2/",
     "shortTitle": "CSS Variables 2"
   },
@@ -1104,6 +1099,11 @@
   {
     "url": "https://www.w3.org/TR/css-values-4/",
     "shortTitle": "CSS Values 4"
+  },
+  {
+    "url": "https://www.w3.org/TR/css-values-5/",
+    "shortTitle": "CSS Values 5",
+    "seriesComposition": "delta"
   },
   {
     "url": "https://www.w3.org/TR/css-variables-1/",

--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -255,7 +255,8 @@ async function buildDiff(diff, baseSpecs, baseIndex, { diffType = "diff", log = 
     .concat(diff.update)
     .map(spec => [spec].concat(baseSpecs.filter(s => areDistinctSpecsInSameSeries(s, spec))))
     .concat(diff.delete.map(spec => baseSpecs.filter(s => areDistinctSpecsInSameSeries(s, spec))))
-    .flat();
+    .flat()
+    .filter((spec, idx, arr) => arr.findIndex(s => s.url === spec.url) === idx);
   const built = (needBuild.length === 0) ? [] :
     await generateIndex(needBuild, {
       previousIndex: newIndex,


### PR DESCRIPTION
The CSS Values 5 spec was publised as First Public Working Draft last week.

There are 3 specs in the series (Levels 3, 4 and 5). The diff build script tried to build the other specs in the series twice, one time for the "add" operation and one time for the "delete" operation, which made tests fail. The code now adds specs in the same series only once.

Build test locally, no errors reported.

Fixes #1489 (need to be done manually because automation script cannot delete the previous URL on its own).