### PR TITLE
Private Aggregation API: switch to good standing

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -176,7 +176,6 @@
         "url": "https://www.w3.org/community/patcg/"
       }
     ],
-    "standing": "pending",
     "url": "https://patcg-individual-drafts.github.io/private-aggregation-api/"
   },
   {


### PR DESCRIPTION
The spec remains an unofficial individual draft in the PAT CG for now, but:
1. It ships in Chromium, where it's enabled by default. So could be useful for the MDN BCD collector.
2. The Shared Storage API, which is in good standing, has started to normatively reference IDL terms and concepts from the Private Aggregation API. If standings of both specs are different, we end up with IDL inconsistency in Webref's curated data.