### PR TITLE
Force Private Aggregation API standing to good

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -176,7 +176,8 @@
         "url": "https://www.w3.org/community/patcg/"
       }
     ],
-    "url": "https://patcg-individual-drafts.github.io/private-aggregation-api/"
+    "url": "https://patcg-individual-drafts.github.io/private-aggregation-api/",
+    "standing": "good"
   },
   {
     "url": "https://patcg-individual-drafts.github.io/topics/",


### PR DESCRIPTION
Our build code is smart: it detects that the spec says it is an unofficial proposal draft and determines that standing should be "pending" as a result.

This forces the standing to "good" since that's the intent of previous commit.