### PR TITLE
Drop digital-identities entry, now digital-credentials

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -669,9 +669,13 @@
   },
   "https://wicg.github.io/datacue/",
   "https://wicg.github.io/deprecation-reporting/",
-  "https://wicg.github.io/digital-credentials/",
+  {
+    "url": "https://wicg.github.io/digital-credentials/",
+    "formerNames": [
+      "digital-identities"
+    ]
+  },
   "https://wicg.github.io/digital-goods/",
-  "https://wicg.github.io/digital-identities/",
   "https://wicg.github.io/direct-sockets/",
   "https://wicg.github.io/document-picture-in-picture/",
   "https://wicg.github.io/document-policy/",


### PR DESCRIPTION
The digital-credentials repo was added to the monitor list back in January (#1174). The digital-identities spec was added shortly afterwards (#1204), but was using a different repository at the time.

Then digital-identities became digital-credentials, but we missed that. Instead we recently reviewed the list of monitored specs and decided to add digital-credentials (#1477).

That means we have twice the same spec in the list. This update drops the digital-identities entry and adds the name as a former name of digital-credentials, since that's the name under which the spec is now progressing.