### PR TITLE
Fix monitor/ignore bot commands

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -171,7 +171,7 @@ function getMonitorOrIgnoreHandler(action) {
       issueNumber = what;
       let issueStr = null;
       try {
-        issueStr = execSync(`gh issue view ${what} --json body,state,title,comments`, execParams);
+        issueStr = execSync(`gh issue view ${what} --json body,state,title,comments,url`, execParams);
       }
       catch (err) {
         console.log(`Could not retrieve issue ${issueNumber}.`);
@@ -186,14 +186,17 @@ function getMonitorOrIgnoreHandler(action) {
       }
       what = urlSection.value;
 
-      if (comment.match(/^IC_[a-zA-Z0-9]+$/)) {
-        const issueComment = issue.comments.find(c => c.id === comment);
+      const commentUrl = comment.match(/^\d+$/) ?
+        `${issue.url}#issuecomment-${comment}` :
+        null;
+      if (commentUrl) {
+        const issueComment = issue.comments.find(c => c.url === commentUrl);
         if (!issueComment) {
           console.log(`Comment ${comment} not found in issue #${issueNumber}.`);
           process.exit(1);
         }
         const match = issueComment.body.match(
-          /@browser-specs-bot (?:monitor|ignore)(?:\s+as|because|for|since)?\s+(.*)/is);
+          /@browser-specs-bot (?:monitor|ignore)(?:\s+(?:as|because|for|since))?\s+(.*)/is);
         if (!match) {
           console.log(`Comment ${comment} in issue #${issueNumber} does not contain the expected command.`);
           process.exit(1);


### PR DESCRIPTION
The monitor/ignore bot commands expected to receive as comment ID the same ID as the one returned by the `gh` CLI. That would have been way too easy! The comment ID in a workflow is an integer while the ID returned by the `gh` CLI is a string (probably an encoding of the number?). The code now computes the URL of the comment from the comment ID and uses that instead to find the comment in the list returned by `gh`.

The update also fixes a bug in the regular expression used to extract the actual comment (extracted string included the "because" prefix).

Closes #1496.