### PR TITLE
Add level to canonical URL of css-color-hdr

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -93,7 +93,12 @@
   },
   "https://drafts.csswg.org/css-borders-4/",
   "https://drafts.csswg.org/css-color-6/ delta",
-  "https://drafts.csswg.org/css-color-hdr/",
+  {
+    "url": "https://drafts.csswg.org/css-color-hdr-1/",
+    "formerNames": [
+      "css-color-hdr"
+    ]
+  },
   "https://drafts.csswg.org/css-conditional-values-1/",
   "https://drafts.csswg.org/css-display-4/",
   "https://drafts.csswg.org/css-env-1/",


### PR DESCRIPTION
The draft used to be without a level but gained one recently, changing the actual shortname of the spec:
https://github.com/w3c/csswg-drafts/commit/2329ab24e2602ca41a6e9d127174ca251d9e03e1

(Build failed because it could no longer find the path to the source in the GitHub repository)