### PR TITLE
Update URL of no-vary-search draft

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -78,6 +78,7 @@
       "sourcePath": "draft-davidben-http-client-hint-reliability.md"
     }
   },
+  "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-no-vary-search",
   "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
   "https://datatracker.ietf.org/doc/html/draft-zern-webp/",
   "https://dom.spec.whatwg.org/",
@@ -712,10 +713,6 @@
   "https://wicg.github.io/local-font-access/",
   "https://wicg.github.io/manifest-incubations/",
   "https://wicg.github.io/media-feeds/",
-  {
-    "url": "https://wicg.github.io/nav-speculation/no-vary-search.html",
-    "shortname": "no-vary-search"
-  },
   {
     "url": "https://wicg.github.io/nav-speculation/prefetch.html",
     "shortname": "prefetch"


### PR DESCRIPTION
Fixes #1544. The spec moved to the HTTP Working Group in IETF.

Note the new URL will produce the same shortname as before.

This will produce the following changes in `index.json`:

```json
{
  "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-no-vary-search",
  "seriesComposition": "full",
  "shortname": "no-vary-search",
  "series": {
    "shortname": "no-vary-search",
    "currentSpecification": "no-vary-search",
    "title": "No-Vary-Search",
    "shortTitle": "No-Vary-Search",
    "nightlyUrl": "https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html"
  },
  "organization": "IETF",
  "groups": [
    {
      "name": "HTTP Working Group",
      "url": "https://datatracker.ietf.org/wg/httpbis/"
    }
  ],
  "nightly": {
    "url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/httpwg/http-extensions",
    "sourcePath": "draft-ietf-httpbis-no-vary-search.md",
    "filename": "draft-ietf-httpbis-no-vary-search.html"
  },
  "title": "No-Vary-Search",
  "source": "ietf",
  "shortTitle": "No-Vary-Search",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```