### PR TITLE
Flag Direct Sockets API as pending

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -683,7 +683,10 @@
     ]
   },
   "https://wicg.github.io/digital-goods/",
-  "https://wicg.github.io/direct-sockets/",
+  {
+    "url": "https://wicg.github.io/direct-sockets/",
+    "standing": "pending"
+  },
   "https://wicg.github.io/document-picture-in-picture/",
   "https://wicg.github.io/document-policy/",
   "https://wicg.github.io/element-timing/",


### PR DESCRIPTION
The API used to have a "pending" standing because its status was "Unofficial Draft Proposal". That seems good (and the proposal has a negative standard position from Mozilla). The status of the spec changed to "Draft Community Group Report" recently, which was enough to make our code switch the standing to "good".

I missed that change when I reviewed the diff of web-specs and released a version of web-specs with that updated standing. This means Webref now tries to curate the IDL defined in the spec, and fails because the IDL references the `[IsolatedContext]` extended attribute that currently exists as a monkey patch in the Isolated Contexts spec.

We may of course update Strudy to accept `[IsolatedContext]` but I'm thinking that the right standing for the spec remains "pending" for now. This update forces the standing accordingly.