### PR TITLE
Fix detection of shortname change, update shortname of webaudio

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1715,7 +1715,12 @@
   "https://www.w3.org/TR/web-animations-2/ delta",
   "https://www.w3.org/TR/web-locks/",
   "https://www.w3.org/TR/web-share/",
-  "https://www.w3.org/TR/webaudio/",
+  {
+    "url": "https://www.w3.org/TR/webaudio-1.0/",
+    "formerNames": [
+      "webaudio"
+    ]
+  },
   {
     "url": "https://www.w3.org/TR/webauthn-3/",
     "shortTitle": "Web Authentication"

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -255,7 +255,7 @@ describe("fetch-info module", function () {
     });
   });
 
-    describe("fetch from W3C API", () => {
+  describe("fetch from W3C API", () => {
     it("works on a TR spec", async () => {
       const spec = getW3CSpec("hr-time-2", "hr-time");
       const info = await fetchInfo([spec]);
@@ -312,6 +312,16 @@ describe("fetch-info module", function () {
       assert.ok(info.__series["css"]);
       assert.equal(info.__series["CSS"].title, "Cascading Style Sheets");
       assert.equal(info.__series["css"].title, "CSS Snapshot");
+    });
+
+    it("detects redirects", async () => {
+      const spec = {
+        url: "https://www.w3.org/TR/webaudio/",
+        shortname: "webaudio"
+      };
+      await assert.rejects(
+        fetchInfo([spec]),
+        /^Error: W3C API redirects "webaudio" to "webaudio-.*"/);
     });
   });
 


### PR DESCRIPTION
For some reason, the code assumed that the fetch API would not follow permanent redirects.

The fetch API follows redirects by default and that's a good thing as requests on the `/specifications/[shortname]/versions/latest` API endpoint typically return a 302 to the actual version that is the current latest version.

This update rather relies on the `redirected` flag to detect redirects and checks the final URL to see whether the W3C API knows the spec under a different shortname. It throws when that happens, as before.

Build would typically fail on `webaudio` since it is now known as `webaudio-1.0` in the W3C API. This updates the shortname accordingly.