### PR TITLE
Update shortnames of CSS 2.1 and RDF 1.1 N-Quads

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1140,7 +1140,7 @@
   "https://www.w3.org/TR/css-writing-modes-4/",
   {
     "url": "https://www.w3.org/TR/CSS21/",
-    "shortname": "CSS2",
+    "shortname": "CSS21",
     "seriesVersion": "2.1",
     "multipage": "all",
     "nightly": {
@@ -1441,6 +1441,10 @@
   "https://www.w3.org/TR/mst-content-hint/",
   {
     "url": "https://www.w3.org/TR/n-quads/",
+    "shortname": "rdf11-n-quads",
+    "formerNames": [
+      "n-quads"
+    ],
     "nightly": {
       "url": "https://www.w3.org/TR/n-quads/"
     },


### PR DESCRIPTION
Build now traps the fact that the shortname for CSS 2.1 and RDF 1.1 N-Quads do not match those used in the W3C API. This update aligns the shortnames accordingly.

For CSS 2.1, shortname was `CSS2` instead of `CSS21`, probably because we used `/TR/CSS2/` at some point. Note: Reffy will need a short update as it uses the shortname to run dedicated pre-processing on the spec to extract definitions. I cannot think of other consequences that we need to worry about.

For RDF 1.1 N-Quads, the canonical /TR URL returned by the W3C API ends with `/TR/n-quads/`, but the shortname is `rdf11-n-quads`. The longer shortname is inconsistent with the URL but consistent with the `rdf12-n-quads` shortname and allows the code to put both n-quads entries in the same series, as done in the W3C API: https://api.w3.org/specification-series/rdf-n-quads/specifications