### PR TITLE
Add RFC 6455: The WebSocket Protocol

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -820,6 +820,10 @@
     "url": "https://www.rfc-editor.org/rfc/rfc6266",
     "shortTitle": "Content-Disposition in HTTP"
   },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc6455",
+    "shortTitle": "The WebSocket Protocol"
+  },
   "https://www.rfc-editor.org/rfc/rfc6386",
   "https://www.rfc-editor.org/rfc/rfc6454",
   "https://www.rfc-editor.org/rfc/rfc6797",


### PR DESCRIPTION
This PR adds [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455), including a `shortTitle` for convenience.

This is required for adding MDN browser compat data for the `Sec-WebSocket-*` HTTP headers.

__Related issues and pull requests:__

- [ ] https://github.com/mdn/browser-compat-data/pull/25115