### PR TITLE
Mark Open Screen Protocol as obsoleted by App and Network protocols

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1472,7 +1472,13 @@
   "https://www.w3.org/TR/network-error-logging/",
   "https://www.w3.org/TR/openscreen-application/",
   "https://www.w3.org/TR/openscreen-network/",
-  "https://www.w3.org/TR/openscreenprotocol/",
+  {
+    "url": "https://www.w3.org/TR/openscreenprotocol/",
+    "obsoletedBy": [
+      "openscreen-application",
+      "openscreen-network"
+    ]
+  },
   "https://www.w3.org/TR/orientation-event/",
   "https://www.w3.org/TR/orientation-sensor/",
   "https://www.w3.org/TR/paint-timing/",


### PR DESCRIPTION
Need to be done explicitly until #1604 gets addressed.