### PR TITLE
Update URLs of W3C Patent Policy and Process document

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -874,6 +874,18 @@
   },
   "https://www.w3.org/2001/tag/doc/promises-guide",
   {
+    "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
+    "shortname": "GIF",
+    "shortTitle": "GIF",
+    "organization": "CompuServe Incorporated",
+    "groups": [
+      {
+        "name": "CompuServe Incorporated",
+        "url": "https://www.compuserve.com/"
+      }
+    ]
+  },
+  {
     "url": "https://www.w3.org/policies/patent-policy/",
     "shortname": "w3c-patent-policy",
     "organization": "W3C",
@@ -900,18 +912,6 @@
     "nightly": {
       "repository": "https://github.com/w3c/w3process/"
     }
-  },
-  {
-    "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
-    "shortname": "GIF",
-    "shortTitle": "GIF",
-    "organization": "CompuServe Incorporated",
-    "groups": [
-      {
-        "name": "CompuServe Incorporated",
-        "url": "https://www.compuserve.com/"
-      }
-    ]
   },
   "https://www.w3.org/TR/accelerometer/",
   {

--- a/specs.json
+++ b/specs.json
@@ -874,7 +874,7 @@
   },
   "https://www.w3.org/2001/tag/doc/promises-guide",
   {
-    "url": "https://www.w3.org/Consortium/Patent-Policy/",
+    "url": "https://www.w3.org/policies/patent-policy/",
     "shortname": "w3c-patent-policy",
     "organization": "W3C",
     "groups": [
@@ -885,7 +885,7 @@
     ]
   },
   {
-    "url": "https://www.w3.org/Consortium/Process/",
+    "url": "https://www.w3.org/policies/process/",
     "shortname": "w3c-process",
     "groups": [
       {


### PR DESCRIPTION
Via https://github.com/w3c/process/issues/962

(depended on Specref being updated)