### PR TITLE
Stop fetching info from Specref for WICG specs and W3C ED

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -231,7 +231,14 @@ async function fetchInfoFromSpecref(specs, options) {
   const browserSpecs = await browserSpecsResponse.json();
   specs = specs.filter(spec => !browserSpecs[spec.shortname.toUpperCase()]);
 
-  const chunks = chunkArray(specs, 50);
+  // Browser-specs now acts as source for Specref for the WICG specs and W3C
+  // Editor's Drafts that have not yet been published to /TR. Let's filter out
+  // these specs to avoid a catch-22 where the info in browser-specs gets stuck
+  // to the that in Specref.
+  const specsWithoutWICG = specs.filter(spec =>
+    !spec.url.match(/\/\/(wicg|w3c)\.github\.io\//));
+
+  const chunks = chunkArray(specsWithoutWICG, 50);
   const chunksRes = await Promise.all(chunks.map(async chunk => {
     let specrefUrl = "https://api.specref.org/bibrefs?refs=" +
       chunk.map(spec => spec.shortname).join(',');

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -235,10 +235,10 @@ async function fetchInfoFromSpecref(specs, options) {
   // Editor's Drafts that have not yet been published to /TR. Let's filter out
   // these specs to avoid a catch-22 where the info in browser-specs gets stuck
   // to the that in Specref.
-  const specsWithoutWICG = specs.filter(spec =>
+  const filteredSpecs = specs.filter(spec =>
     !spec.url.match(/\/\/(wicg|w3c)\.github\.io\//));
 
-  const chunks = chunkArray(specsWithoutWICG, 50);
+  const chunks = chunkArray(filteredSpecs, 50);
   const chunksRes = await Promise.all(chunks.map(async chunk => {
     let specrefUrl = "https://api.specref.org/bibrefs?refs=" +
       chunk.map(spec => spec.shortname).join(',');


### PR DESCRIPTION
This provides a more generic solution to #1606.

Browser-specs has become the main source for Specref for WICG specs and W3C Editor's Drafts. The code no longer attempts to fetch info for these specs from Specref as a result.

Tested locally, this will adjust a handful of spec titles (to match the actual spec title, which seems good)... and the URL of element-timing! Interestingly, it will also adjust a few WICG entries for which the spec says the status is "Unofficial Draft", which will also switch the standing of these specs to "pending". That seems good as well although we may want to review these changes before we release a new version. I propose to do that separately in any case. Specs in that category include: Web Share Target API, preferCurrentTab, the CSS Parser API.

Note: Specref is still being used as source, mainly for WHATWG specs.