### PR TITLE
Force a good standing for CSS Parser API and preferCurrentTab

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -653,7 +653,10 @@
       "sourcePath": "scripting-policy.bs"
     }
   },
-  "https://wicg.github.io/css-parser-api/",
+  {
+    "url": "https://wicg.github.io/css-parser-api/",
+    "standing": "good"
+  },
   {
     "url": "https://wicg.github.io/custom-state-pseudo-class/",
     "standing": "discontinued",
@@ -724,7 +727,10 @@
   "https://wicg.github.io/permissions-request/",
   "https://wicg.github.io/permissions-revoke/",
   "https://wicg.github.io/portals/",
-  "https://wicg.github.io/prefer-current-tab/",
+  {
+    "url": "https://wicg.github.io/prefer-current-tab/",
+    "standing": "good"
+  },
   "https://wicg.github.io/private-network-access/",
   "https://wicg.github.io/responsive-image-client-hints/",
   "https://wicg.github.io/sanitizer-api/",


### PR DESCRIPTION
See discussion in:
https://github.com/w3c/browser-specs/pull/1628#issuecomment-2586337351

Specs used to come with a "good" standing in browser-specs because data came from Specref. The specs themselves continue to say they are unofficial drafts, and so build code now considers that these specs should have a "pending" standing.

That standing seems correct, but WPT already has actual tests for the CSS Parser API (on top of IDL tests), and already integrated the preferCurrentTab IDL as well (just a partial dictionary definition in practice). This update forces the standing to "good" for continuity.