### PR TITLE
Force a "good" standing for the Web Share Target API

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -535,7 +535,10 @@
     }
   },
   "https://w3c.github.io/web-nfc/",
-  "https://w3c.github.io/web-share-target/",
+  {
+    "url": "https://w3c.github.io/web-share-target/",
+    "standing": "good"
+  },
   {
     "nightly": {
       "sourcePath": "passkey-endpoints.bs"


### PR DESCRIPTION
The spec is documented on MDN already, so the switch to "pending" is not fantastic for BCD and web-features. See context in: https://github.com/w3c/browser-specs/issues/1645
https://github.com/w3c/browser-specs/pull/1628#issuecomment-2589699597