### PR TITLE
Add Concise Data Definition Language (CDDL): A Notational Convention …

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -842,6 +842,10 @@
   "https://www.rfc-editor.org/rfc/rfc8288",
   "https://www.rfc-editor.org/rfc/rfc8297",
   "https://www.rfc-editor.org/rfc/rfc8470",
+  {
+    "shortTitle": "CDDL",
+    "url": "https://www.rfc-editor.org/rfc/rfc8610"
+  },
   "https://www.rfc-editor.org/rfc/rfc8878",
   "https://www.rfc-editor.org/rfc/rfc8942",
   "https://www.rfc-editor.org/rfc/rfc9110",


### PR DESCRIPTION
…to Express Concise Binary Object Representation (CBOR) and JSON Data Structures

Close #1651, adding the suggested spec to the list.

### Changes to `index.json`
This update would trigger the following changes in `index.json`:

<details><summary>Add spec (1)</summary>

```json
{
  "url": "https://www.rfc-editor.org/rfc/rfc8610",
  "seriesComposition": "full",
  "shortname": "rfc8610",
  "series": {
    "shortname": "rfc8610",
    "currentSpecification": "rfc8610",
    "title": "Concise Data Definition Language (CDDL): A Notational Convention to Express Concise Binary Object Representation (CBOR) and JSON Data Structures",
    "shortTitle": "CDDL",
    "nightlyUrl": "https://www.rfc-editor.org/rfc/rfc8610"
  },
  "shortTitle": "CDDL",
  "organization": "IETF",
  "groups": [
    {
      "name": "Concise Binary Object Representation Maintenance and Extensions Working Group",
      "url": "https://datatracker.ietf.org/wg/cbor/"
    }
  ],
  "nightly": {
    "url": "https://www.rfc-editor.org/rfc/rfc8610",
    "status": "Proposed Standard",
    "alternateUrls": [
      "https://datatracker.ietf.org/doc/html/rfc8610",
      "https://tools.ietf.org/html/rfc8610"
    ],
    "filename": "rfc8610.html"
  },
  "title": "Concise Data Definition Language (CDDL): A Notational Convention to Express Concise Binary Object Representation (CBOR) and JSON Data Structures",
  "source": "ietf",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```
</details>

### Tests
These changes look good! 😎

(PR created manually from branch created by the bot; I think the action is failing because of https://github.com/cli/cli/issues/10188 - strudy has this problem at least; it may be the error reporting needs improvement if so)