### PR TITLE
Add Accessibility Object Model

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -631,6 +631,7 @@
   "https://webidl.spec.whatwg.org/",
   "https://websockets.spec.whatwg.org/",
   "https://wicg.github.io/anonymous-iframe/",
+  "https://wicg.github.io/aom/spec/",
   "https://wicg.github.io/attribution-reporting-api/",
   "https://wicg.github.io/background-fetch/",
   {

--- a/src/data/monitor.json
+++ b/src/data/monitor.json
@@ -40,10 +40,6 @@
       "comment": "Early exploration phase; spec at https://webmonetization.org/specification/",
       "lastreviewed": "2025-01-01"
     },
-    "WICG/aom": {
-      "comment": "Specs at https://wicg.github.io/aom/spec/computed-accessibility-tree.html https://wicg.github.io/aom/spec/virtual-accessibility-nodes.html https://wicg.github.io/aom/spec/input-events.html in their very early stage of definition",
-      "lastreviewed": "2025-01-01"
-    },
     "WICG/container-queries": {
       "comment": "Likely candidate for ignoring - see archival discussion at https://github.com/WICG/container-queries/issues/14",
       "lastreviewed": "2025-01-01"


### PR DESCRIPTION
Close #1654, adding the suggested spec to the list.

### Changes to `index.json`
This update would trigger the following changes in `index.json`:

<details><summary>Add spec (1)</summary>

```json
{
  "url": "https://wicg.github.io/aom/spec/",
  "seriesComposition": "full",
  "shortname": "aom",
  "series": {
    "shortname": "aom",
    "currentSpecification": "aom",
    "title": "Accessibility Object Model",
    "shortTitle": "Accessibility Object Model",
    "nightlyUrl": "https://wicg.github.io/aom/spec/"
  },
  "organization": "W3C",
  "groups": [
    {
      "name": "Web Platform Incubator Community Group",
      "url": "https://www.w3.org/community/wicg/"
    }
  ],
  "nightly": {
    "url": "https://wicg.github.io/aom/spec/",
    "status": "Unofficial Proposal Draft",
    "alternateUrls": [],
    "repository": "https://github.com/WICG/aom",
    "sourcePath": "spec/index.html",
    "filename": "index.html"
  },
  "title": "Accessibility Object Model",
  "source": "spec",
  "shortTitle": "Accessibility Object Model",
  "categories": [
    "browser"
  ],
  "standing": "pending"
}
```
</details>

### Tests
These changes look good! 😎