### PR TITLE
Don't fetch info from Specref for CSS and www.w3.org specs.

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -879,6 +879,7 @@
     "url": "https://www.w3.org/Graphics/GIF/spec-gif89a.txt",
     "shortname": "GIF",
     "shortTitle": "GIF",
+    "title": "Graphics Interchange Format",
     "organization": "CompuServe Incorporated",
     "groups": [
       {

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -236,7 +236,9 @@ async function fetchInfoFromSpecref(specs, options) {
   // these specs to avoid a catch-22 where the info in browser-specs gets stuck
   // to the that in Specref.
   const filteredSpecs = specs.filter(spec =>
-    !spec.url.match(/\/\/(wicg|w3c)\.github\.io\//));
+    !spec.url.match(/\/\/(wicg|w3c)\.github\.io\//) &&
+    !spec.url.match(/\/\/www\.w3\.org\//) &&
+    !spec.url.match(/\/\/drafts\.csswg\.org\//));
 
   const chunks = chunkArray(filteredSpecs, 50);
   const chunksRes = await Promise.all(chunks.map(async chunk => {
@@ -503,6 +505,15 @@ async function fetchInfoFromSpecs(specs, options) {
           return {
             title: isoTitle
           };
+        }
+      }
+      else if (spec.url.endsWith(".txt")) {
+        // Spec from another time (typically the GIF spec), published as plain
+        // text. Nothing we can usefully extract from the spec. Let's proceed
+        // and hope `specs.json` contains the appropriate info for the spec
+        // (no official status for the spec either, using "Editor's Draft")
+        return {
+          nightly: { url, status: "Editor's Draft" }
         }
       }
 


### PR DESCRIPTION
Browser-specs still fetched info from Specref for a few W3C specs, notably the `css-backgrounds-4` draft and a few policy documents. Info is now fetched directly from the spec for these specs. This will make it possible to properly retire `csswg.json` in Specref.

The GIF spec, published under `https://www.w3.org` is treated as an exception to the rule, because its URL ends with `.txt`, signaling a spec published in plain text.

Note: Browser-specs still leverages Specref, mainly for WHATWG specs, a few TC39 and ISO specs, and a couple of CG specs that use their own GitHub org.