### PR TITLE
Retrieve WHATWG spec titles from WHATWG database

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -60,7 +60,7 @@
 
     "source": {
       "type": "string",
-      "enum": ["w3c", "specref", "spec", "ietf"]
+      "enum": ["w3c", "specref", "spec", "ietf", "whatwg"]
     },
 
     "nightly": {

--- a/src/fetch-json.js
+++ b/src/fetch-json.js
@@ -1,0 +1,33 @@
+import ThrottledQueue from "./throttled-queue.js";
+
+// Make sure we remain "friendly" with servers
+const fetchQueue = new ThrottledQueue({ maxParallel: 2 });
+
+// Maintain a cache of fetched JSON resources in memory to avoid sending the
+// same fetch request again and again
+const cache = {};
+
+/**
+ * Fetch a JSON URL
+ */
+export default async function (url, options) {
+  if (cache[url]) {
+    return JSON.parse(JSON.stringify(cache[url]));
+  }
+  const res = await fetchQueue.runThrottled(fetch, url, options);
+  if (res.status === 404) {
+    return null;
+  }
+  if (res.status !== 200) {
+    throw new Error(`Server returned an error for ${url}, status code is ${res.status}`);
+  }
+
+  try {
+    const body = await res.json();
+    cache[url] = body;
+    return JSON.parse(JSON.stringify(body));
+  }
+  catch (err) {
+    throw new Error(`Server returned invalid JSON for ${url}`);
+  }
+}

--- a/src/fetch-json.js
+++ b/src/fetch-json.js
@@ -25,7 +25,7 @@ export default async function (url, options) {
   try {
     const body = await res.json();
     cache[url] = body;
-    return JSON.parse(JSON.stringify(body));
+    return structuredClone(body);
   }
   catch (err) {
     throw new Error(`Server returned invalid JSON for ${url}`);

--- a/src/fetch-json.js
+++ b/src/fetch-json.js
@@ -12,7 +12,7 @@ const cache = {};
  */
 export default async function (url, options) {
   if (cache[url]) {
-    return JSON.parse(JSON.stringify(cache[url]));
+    return structuredClone(cache[url]);
   }
   const res = await fetchQueue.runThrottled(fetch, url, options);
   if (res.status === 404) {

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -20,7 +20,7 @@ describe("fetch-info module", function () {
     return spec;
   }
 
-  describe("fetch from Specref", () => {
+  describe("fetch from WHATWG", () => {
     it("works on a WHATWG spec", async () => {
       const spec = {
         url: "https://dom.spec.whatwg.org/",
@@ -28,10 +28,24 @@ describe("fetch-info module", function () {
       };
       const info = await fetchInfo([spec]);
       assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].source, "whatwg");
       assert.equal(info[spec.shortname].nightly.url, "https://dom.spec.whatwg.org/");
       assert.equal(info[spec.shortname].nightly.status, "Living Standard");
-      assert.equal(info[spec.shortname].title, "DOM Standard");
+      assert.equal(info[spec.shortname].title, "DOM");
+    });
+  });
+
+  describe("fetch from Specref", () => {
+    it("works on an ISO spec", async () => {
+      const spec = {
+        url: "https://www.iso.org/standard/85253.html",
+        shortname: "iso18181-2"
+      };
+      const info = await fetchInfo([spec]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "specref");
+      assert.equal(info[spec.shortname].title, "Information technology — JPEG XL image coding system — Part 2: File format");
+      assert.equal(info[spec.shortname].nightly, undefined);
     });
 
     it("can operate on multiple specs at once", async () => {
@@ -325,34 +339,6 @@ describe("fetch-info module", function () {
     });
   });
 
-  describe("fetch from Specref", () => {
-    it("works on a WHATWG spec", async () => {
-      const spec = {
-        url: "https://dom.spec.whatwg.org/",
-        shortname: "dom"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "specref");
-      assert.equal(info[spec.shortname].nightly.url, "https://dom.spec.whatwg.org/");
-      assert.equal(info[spec.shortname].nightly.status, "Living Standard");
-      assert.equal(info[spec.shortname].title, "DOM Standard");
-    });
-
-    it("works on an ISO spec", async () => {
-      const spec = {
-        url: "https://www.iso.org/standard/85253.html",
-        shortname: "iso18181-2"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "specref");
-      assert.equal(info[spec.shortname].title, "Information technology — JPEG XL image coding system — Part 2: File format");
-      assert.equal(info[spec.shortname].nightly, undefined);
-    })
-  });
-
-
   describe("fetch from all sources", () => {
     it("uses the last published info for discontinued specs", async () => {
       const spec = {
@@ -387,10 +373,10 @@ describe("fetch-info module", function () {
       assert.equal(info[w3c.shortname].title, "Presentation API");
 
       assert.ok(info[whatwg.shortname]);
-      assert.equal(info[whatwg.shortname].source, "specref");
+      assert.equal(info[whatwg.shortname].source, "whatwg");
       assert.equal(info[whatwg.shortname].nightly.url, whatwg.url);
       assert.equal(info[whatwg.shortname].nightly.status, "Living Standard");
-      assert.equal(info[whatwg.shortname].title, "HTML Standard");
+      assert.equal(info[whatwg.shortname].title, "HTML");
 
       assert.ok(info[other.shortname]);
       assert.equal(info[other.shortname].source, "spec");


### PR DESCRIPTION
Build code used to rely on Specref to get the title of WHATWG specifications. This update makes it fetch info for WHATWG specs from the WHATWG database directly. To save one request, the code leverages the workstreams database, also used by fetch-groups, instead of the biblio file.

On top of adding a new `whatwg` value to the `"source"` field, this update will also fix the titles of the WHATWG specs: they end with "Standard" in Specref but, while that matches the `<title>` tag, the actual spec title in the `<h1>` and the title in the WHATWG database don't end with "Standard". *#docallmeDOM*

The update turns the `fetchJSON` function into a utility function. This is going to save a few requests (not that many!) that are common between fetch-info and fetch-groups. Specific functions in fetch-info were also adjusted not to do anything when there are no specs of interest in the list (this speeds up tests a bit, but has no impact on a full build since, by definition, there are specs of interest in the full list...)