### PR TITLE
Stop fetching spec info from Specref

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The list is used in a variety of ways, which include:
   by tools such as [ReSpec](https://respec.org/docs/) and
   [Bikeshed](https://speced.github.io/bikeshed/) to create terminology
   and reference links between Web specifications.
+* [BCD](https://github.com/mdn/browser-compat-data) and
+  [web-features](https://github.com/web-platform-dx/web-features) to validate
+  specification URLs
+* [Specref](https://www.specref.org/) to complete the list of specifications
+  that can be referenced.
 * Analyzers of browser technologies to create reports on test coverage,
   WebIDL, and specification quality.
 
@@ -186,10 +191,11 @@ The `shortname` property is always set.
 
 ### `title`
 
-The title of the spec. The title is either retrieved from the
-[W3C API](https://w3c.github.io/w3c-api/) for W3C specs,
-[Specref](https://www.specref.org/) or from the spec itself. The
-[`source`](#source) property details the actual provenance.
+The title of the spec. The title is either retrieved from an official source
+(the [W3C API](https://w3c.github.io/w3c-api/) for W3C specs, the
+[workstreams database](https://github.com/whatwg/sg/blob/main/db.json) for
+WHATWG specs, etc.), or from the spec itself. The [`source`](#source) property
+details the actual provenance.
 
 The `title` property is always set.
 
@@ -485,11 +491,12 @@ available.
 
 The URL of the latest Editor's Draft or of the living standard.
 
-The URL is either retrieved from the [W3C API](https://w3c.github.io/w3c-api/)
-for W3C specs, or [Specref](https://www.specref.org/). The document at the
-versioned URL is considered to be the latest Editor's Draft if the spec does
-neither exist in the W3C API nor in Specref. The [`source`](#source) property
-details the actual provenance.
+The URL is either retrieved from an official source (the
+[W3C API](https://w3c.github.io/w3c-api/) for W3C specs, the
+[workstreams database](https://github.com/whatwg/sg/blob/main/db.json) for
+WHATWG specs, etc.) when possible. The document at the versioned URL is
+considered to be the latest Editor's Draft otherwise. The [`source`](#source)
+property details the actual provenance.
 
 The URL should be relatively stable but may still change over time. See
 [Spec identifiers](#spec-identifiers) for details.
@@ -552,8 +559,7 @@ The `pages` property is only set for specs identified as multipage specs.
 The URL of the repository that contains the source of the Editor's Draft or of
 the living standard.
 
-The URL is either retrieved from the [Specref](https://www.specref.org/) or
-computed from `nightly.url`.
+The URL is computed from `nightly.url`.
 
 The `repository` property is always set except for IETF specs where such a repo does not always exist.
 
@@ -621,7 +627,7 @@ The `excludePaths` property is seldom set.
 
 The provenance for the `title` and `nightly` property values. Can be one of:
 - `w3c`: information retrieved from the [W3C API](https://w3c.github.io/w3c-api/)
-- `specref`: information retrieved from [Specref](https://www.specref.org/)
+- `whatwg`: information retrieved from [WHATWG](https://spec.whatwg.org/)
 - `ietf`: information retrieved from the [IETF datatracker](https://datatracker.ietf.org)
 - `spec`: information retrieved from the spec itself
 

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -60,7 +60,7 @@
 
     "source": {
       "type": "string",
-      "enum": ["w3c", "specref", "spec", "ietf", "whatwg"]
+      "enum": ["w3c", "spec", "ietf", "whatwg"]
     },
 
     "nightly": {

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -35,45 +35,6 @@ describe("fetch-info module", function () {
     });
   });
 
-  describe("fetch from Specref", () => {
-    it("works on an ISO spec", async () => {
-      const spec = {
-        url: "https://www.iso.org/standard/85253.html",
-        shortname: "iso18181-2"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "specref");
-      assert.equal(info[spec.shortname].title, "Information technology — JPEG XL image coding system — Part 2: File format");
-      assert.equal(info[spec.shortname].nightly, undefined);
-    });
-
-    it("can operate on multiple specs at once", async () => {
-      const spec = getW3CSpec("presentation-api");
-      const other = getW3CSpec("hr-time-2");
-      const info = await fetchInfo([spec, other]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "w3c");
-      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
-      assert.equal(info[spec.shortname].title, "Presentation API");
-
-      assert.ok(info[other.shortname]);
-      assert.equal(info[other.shortname].source, "w3c");
-      assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/hr-time/");
-      assert.equal(info[other.shortname].title, "High Resolution Time Level 2");
-    });
-
-    it("does not retrieve info from a spec that got contributed to Specref", async () => {
-      const spec = {
-        url: "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
-        shortname: "ANGLE_instanced_arrays"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "spec");
-    });
-  });
-
   describe("fetch from IETF datatracker", () => {
     it("fetches info about RFCs from datatracker", async () => {
       const spec = {
@@ -336,6 +297,21 @@ describe("fetch-info module", function () {
       await assert.rejects(
         fetchInfo([spec]),
         /^Error: W3C API redirects "webaudio" to "webaudio-.*"/);
+    });
+
+    it("can operate on multiple specs at once", async () => {
+      const spec = getW3CSpec("presentation-api");
+      const other = getW3CSpec("hr-time-2");
+      const info = await fetchInfo([spec, other]);
+      assert.ok(info[spec.shortname]);
+      assert.equal(info[spec.shortname].source, "w3c");
+      assert.equal(info[spec.shortname].nightly.url, "https://w3c.github.io/presentation-api/");
+      assert.equal(info[spec.shortname].title, "Presentation API");
+
+      assert.ok(info[other.shortname]);
+      assert.equal(info[other.shortname].source, "w3c");
+      assert.equal(info[other.shortname].nightly.url, "https://w3c.github.io/hr-time/");
+      assert.equal(info[other.shortname].title, "High Resolution Time Level 2");
     });
   });
 


### PR DESCRIPTION
This completely drops the logic that used to fetch spec info from Specref. Motivation for the change is to avoid having a circular dependency between browser-specs and Specref that makes it cumbersome to make some updates.

In practice, there remained only 6 specs for which browser-specs was leveraging Specref: 3 from ISO, 2 from TC39 and the Web Bluetooth API.

One consequence is that the title of the TC39 specs will change because the actual specs include a registered mark and the year, which are now captured, leading to "ECMAScript® 2025 Language Specification". Maybe not ideal, but then that's per spec...

README and comments updated in the code to remove mentions of Specref.