### PR TITLE
Drop ":" before "Level" to compute short and series titles

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -256,7 +256,7 @@ async function runInfo(specs) {
     else if (!res.series.title) {
       res.series.title = res.title
         .replace(/ \d+(\.\d+)?$/, '')           // Drop level number
-        .replace(/( -)? Level$/, '')            // Drop "Level"
+        .replace(/(:| -)? Level$/, '')          // Drop "Level"
         .replace(/ Module$/, '')                // Drop "Module"
         .replace(/^(RDF|SPARQL) \d\.\d/, '$1'); // Handle RDF/SPARQL titles
     }

--- a/src/compute-shorttitle.js
+++ b/src/compute-shorttitle.js
@@ -31,7 +31,7 @@ export default function (title) {
     .trim()
     .replace(/\s/g, ' ')                  // Replace non-breaking spaces
     .replace(/ \d+(\.\d+)?$/, '')         // Drop level number for now
-    .replace(/( -)? Level$/i, '')         // Drop "Level"
+    .replace(/(:| -)? Level$/i, '')       // Drop "Level"
     .replace(/ \(\v\d+(\.\d+)?\)/i, '')   // Drop "(vx.y)"
     .replace(/\(Draft\)/i, '')            // Drop "(Draft)" indication
     .replace(/ Module$/i, '')             // Drop "Module" (now followed by level)

--- a/test/compute-shorttitle.js
+++ b/test/compute-shorttitle.js
@@ -49,6 +49,12 @@ describe("compute-shorttitle module", () => {
       "Foo 2");
   });
 
+  it("drops ': Level' from title", () => {
+    assertTitle(
+      "Foo: Level 7",
+      "Foo 7");
+  });
+
   it("drops 'Module - Level' from title", () => {
     assertTitle(
       "Foo Module - Level 3",


### PR DESCRIPTION
Via #1676. The "Privacy-Preserving Attribution" spec separates the main title and the level with a `:`, which wasn't handled as part of the logic used to shorten the title.