### PR TITLE
Fold CSS 2.1 and CSS 2.2 into a CSS 2 entry

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1178,23 +1178,17 @@
   "https://www.w3.org/TR/css-writing-modes-3/",
   "https://www.w3.org/TR/css-writing-modes-4/",
   {
-    "url": "https://www.w3.org/TR/CSS21/",
-    "shortname": "CSS21",
+    "url": "https://www.w3.org/TR/CSS2/",
     "formerNames": [
-      "CSS2"
+      "CSS21",
+      "CSS22"
     ],
-    "seriesVersion": "2.1",
-    "multipage": "all",
-    "nightly": {
-      "url": "https://www.w3.org/TR/CSS21/"
-    }
-  },
-  {
-    "url": "https://www.w3.org/TR/CSS22/",
     "multipage": "release",
     "nightly": {
-      "sourcePath": "css2/Overview.bs"
-    }
+      "url": "https://drafts.csswg.org/css2/"
+    },
+    "title": "Cascading Style Sheets Level 2",
+    "shortTitle": "CSS 2"
   },
   {
     "url": "https://www.w3.org/TR/css3-exclusions/",

--- a/specs.json
+++ b/specs.json
@@ -1185,7 +1185,8 @@
     ],
     "multipage": "release",
     "nightly": {
-      "url": "https://drafts.csswg.org/css2/"
+      "url": "https://drafts.csswg.org/css2/",
+      "sourcePath": "css2/Overview.bs"
     },
     "title": "Cascading Style Sheets Level 2",
     "shortTitle": "CSS 2"

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -276,7 +276,7 @@ describe("fetch-info module", function () {
     });
 
     it("does not get confused by CSS snapshots", async () => {
-      const css = getW3CSpec("CSS21", "CSS");
+      const css = getW3CSpec("CSS2", "CSS");
       const snapshot = getW3CSpec("css-2023", "css");
       const info = await fetchInfo([css, snapshot]);
       assert.equal(info[css.shortname].source, "w3c");


### PR DESCRIPTION
The W3C API was updated to make `CSS2` the actual spec and to have `CSS21` redirect to `CSS2`. This follows from discussions with @fantasai, @tabatkins and @deniak to clarify that revision 1 and revision 2 of CSS Level 2 should be viewed as just CSS Level 2.

This update folds the CSS 2.1 and CSS 2.2 entries into one CSS 2 entry accordingly:
- Shortname is `CSS2`. That used to be the shortname we had for CSS 2.1, until we updated it to `CSS21` to be consistent with the W3C API a few months ago (through #1560)
- Published version is at https://www.w3.org/TR/CSS2/
- Editor's Draft is at https://drafts.csswg.org/css2/

A side benefit is that there will no longer be duplicated definitions in Webref for CSS 2.1 and CSS 2.2. That should remove one of the de-duplication rules.

Note the W3C API continues to have two entries because CSS 2.2 got published as a separate spec in 2016. Hopefully, the specs will eventually get folded there as well.