### PR TITLE
Ignore CSS 2.2

### DIFF
--- a/src/data/ignore.json
+++ b/src/data/ignore.json
@@ -420,6 +420,9 @@
     },
     "https://w3c.github.io/math-aam/": {
       "comment": "no longer worked on and community group closed"
+    },
+    "https://www.w3.org/TR/CSS22/": {
+      "comment": "Published as a separate revision but to be folded into CSS2 down the line"
     }
   }
 }


### PR DESCRIPTION
CSS 2.1 and CSS 2.2 remain separated from a /TR perspective, but should end up being folded into a single CSS 2 entry, with a `CSS2` shortname. We already force this view in browser-specs (done in #1696), to avoid introducing duplicated definitions.