### PR TITLE
Fix lookup of series for diff building

### DIFF
--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -256,7 +256,7 @@ async function buildDiff(diff, baseSpecs, baseIndex, { diffType = "diff", log = 
     .map(spec => [spec].concat(baseSpecs.filter(s => areDistinctSpecsInSameSeries(s, spec))))
     .concat(diff.delete.map(spec => baseSpecs.filter(s => areDistinctSpecsInSameSeries(s, spec))))
     .flat()
-    .filter((spec, idx, arr) => arr.findIndex(s => s.url === spec.url) === idx);
+    .filter((spec, idx, arr) => arr.findIndex(s => haveSameUrl(s, spec)) === idx);
   const built = (needBuild.length === 0) ? [] :
     await generateIndex(needBuild, {
       previousIndex: newIndex,


### PR DESCRIPTION
When diff building a spec, other specs in the same series need to be re-built as well. The code correctly picked up the other specs in the same series but forgot that entries in `specs.json` may either be a string or an object with a `url` property when it removed duplicates, leading to an incomplete list in the end.

Fixes #1713