### PR TITLE
Force release URL of CSS2 spec to /TR/CSS2/

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1194,6 +1194,9 @@
       "url": "https://drafts.csswg.org/css2/",
       "sourcePath": "css2/Overview.bs"
     },
+    "release": {
+      "url": "https://www.w3.org/TR/CSS2/"
+    },
     "title": "Cascading Style Sheets Level 2",
     "shortTitle": "CSS 2"
   },


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/1496.

The W3C API still reports that the shortlink URL for CSS2 is https://www.w3.org/TR/CSS21/ whereas that URL now redirects to https://www.w3.org/TR/CSS2/

Will work with @deniak to update the URL in the W3C API. In the meantime, this update forces the release URL to https://www.w3.org/TR/CSS2/.