### PR TITLE
Adjust URL and shortname of Source map spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -326,6 +326,16 @@
     }
   },
   {
+    "url": "https://tc39.es/ecma426/",
+    "shortname": "ecma-426",
+    "nightly": {
+      "sourcePath": "source-map.bs"
+    },
+    "formerNames": [
+      "sourcemap"
+    ]
+  },
+  {
     "url": "https://tc39.es/proposal-array-find-from-last/",
     "standing": "discontinued",
     "obsoletedBy": [
@@ -485,14 +495,6 @@
     ]
   },
   "https://tc39.es/proposal-temporal/",
-  {
-    "url": "https://tc39.es/source-map/",
-    "shortname": "sourcemap",
-    "nightly": {
-      "status": "Editor's Draft",
-      "sourcePath": "source-map.bs"
-    }
-  },
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",
   "https://urlpattern.spec.whatwg.org/",


### PR DESCRIPTION
Now published with an official spec ID. The former name is retained in the `formerNames` property.

Note the `-` in the shortname for consistency with the `ecma-402` entry.

The "Editor's Draft" status is no longer needed. It used to be needed because the spec claimed it was an unofficial draft.