### PR TITLE
Handle CSS2 series URLs as an exception to the rule

### DIFF
--- a/src/compute-series-urls.js
+++ b/src/compute-series-urls.js
@@ -17,9 +17,19 @@ function computeSeriesUrls(spec) {
 
   const res = {};
 
+  // We create a "CSS" series in browser-specs for CSS2 different from the
+  // "css" series for CSS snapshots but the W3C API mixes both, and the URL
+  // https://www.w3.org/TR/CSS/ that would logically be computed as series URL
+  // actually returns a CSS Snapshot. Let's use the spec URL instead
+  // (https://www.w3.org/TR/CSS2/).
+  if (spec.shortname === "CSS2") {
+    res.releaseUrl = spec.url;
+    res.nightlyUrl = spec.nightly.url;
+  }
+
   // If spec shortname and series shortname match, then series URLs match the
   // spec URLs.
-  if (spec.shortname === spec.series.shortname) {
+  else if (spec.shortname === spec.series.shortname) {
     if (spec.release?.url) {
       res.releaseUrl = spec.release.url;
     }

--- a/test/compute-series-urls.js
+++ b/test/compute-series-urls.js
@@ -66,6 +66,20 @@ describe("compute-series-urls module", () => {
   });
 
 
+  it("handles CSS2 correctly", () => {
+    const spec = {
+      url: "https://www.w3.org/TR/CSS2/",
+      shortname: "CSS2",
+      series: { shortname: "CSS" },
+      release: { url: "https://www.w3.org/TR/CSS2/" },
+      nightly: { url: "https://drafts.csswg.org/css2/" }
+    };
+    assert.deepStrictEqual(computeSeriesUrls(spec),
+      { releaseUrl: "https://www.w3.org/TR/CSS2/",
+        nightlyUrl: "https://drafts.csswg.org/css2/" });
+  });
+
+
   it("returns right nightly URL for series when spec's nightly has no level", () => {
     const spec = {
       url: "https://www.w3.org/TR/pointerlock-2/",


### PR DESCRIPTION
For CSS2, we create a "CSS" series in browser-specs different from the "css" series for CSS snapshots but the W3C API mixes both, and the URL https://www.w3.org/TR/CSS/ that would logically be computed as series URL for the CSS series actually returns a CSS Snapshot. The update makes the code use the CSS2 spec URLs instead.

An alternative would be to create a "CSS2" series instead, but that's less aligned with the current data in the W3C API.