### PR TITLE
Drop release URL for CSS2 (URL was fixed in the W3C API)

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1196,9 +1196,6 @@
       "url": "https://drafts.csswg.org/css2/",
       "sourcePath": "css2/Overview.bs"
     },
-    "release": {
-      "url": "https://www.w3.org/TR/CSS2/"
-    },
     "title": "Cascading Style Sheets Level 2",
     "shortTitle": "CSS 2"
   },


### PR DESCRIPTION
The W3C API now returns the /TR/CSS2/ URL for CSS2, the URL no longer needs to be specified in `specs.json`.

Note: this is the expected follow-up to #1726