### PR TITLE
Generalize code to compute series name for `fooXY-bar`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1373,18 +1373,12 @@
   "https://www.w3.org/TR/intersection-observer/",
   {
     "url": "https://www.w3.org/TR/json-ld11-api/",
-    "series": {
-      "shortname": "json-ld-api"
-    },
     "categories": [
       "-browser"
     ]
   },
   {
     "url": "https://www.w3.org/TR/json-ld11-framing/",
-    "series": {
-      "shortname": "json-ld-framing"
-    },
     "categories": [
       "-browser"
     ]

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -210,8 +210,10 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
   }
 
   // Extract X and X.Y levels with form "rdfXY-something" or "sparqlXY-something"
-  // (e.g. 1.2 for "rdf12-concepts")
-  match = seriesBasename.match(/^(rdf|sparql)(\d)(\d)-(.+)$/);
+  // or "shaclXY-something" (e.g. 1.2 for "rdf12-concepts").
+  // Note matching would catch `tc39-*` in theory but that case has already
+  // been handled.
+  match = seriesBasename.match(/^([^\d]+)(\d)(\d)-(.+)$/);
   if (match) {
     return {
       shortname: specShortname,

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -162,6 +162,10 @@ describe("compute-shortname module", () => {
       assertSeries("sparql12-something", "sparql-something");
     });
 
+    it("parses form 'shaclXY-something'", () => {
+      assertSeries("shacl12-something", "shacl-something");
+    });
+
     it("includes final digits when they do not seem to be a level", () => {
       assertSeries("cors-rfc1918", "cors-rfc1918");
     });


### PR DESCRIPTION
Via #1739 and #1740.

The new `shacl12-*` specs follow the same pattern as `sparql12-*`, `rdf12-*` but the code only supported the latter. Also, the `json-ld11-*` entries needed to specify their series shortnames explicitly whereas they, too, follow the same pattern.

This update generalizes handling of shortnames `fooXY-bar` to compute series names. The only other occurrences in the list would be for `tc39-*` specs, where a generic rule would not be correct, but these get handled separately in any case.