### PR TITLE
Further extend support for `shacl12-*` specs

### DIFF
--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -96,6 +96,9 @@ export default async function (specs, options) {
       `${spec.series.shortname}/Overview.bs`,
       `${spec.series.shortname}/Overview.src.html`,
 
+      // Used for SHACL specs
+      `${spec.shortname}/index.html`,
+
       // Used for ARIA specs
       `${spec.series.shortname}/index.html`,
 

--- a/test/index.js
+++ b/test/index.js
@@ -137,12 +137,13 @@ describe("The `index.json` list", () => {
   it("has series titles that look consistent with spec titles", () => {
     // The test is useful in that it allows to trap cases where the information
     // returned by the W3C API about a series is not up-to-date, but there are
-    // a few exceptions to the rule.
-    const wrong = specs.filter(s => !s.title.includes(s.series.title))
-      .filter(s => !s.title.startsWith("RDF ") && !s.title.startsWith("SPARQL "))
+    // a few exceptions to the rule, notably specs whose shortname follow the
+    // "fooXY-bar" pattern
+    const wrong = specs
+      .filter(s => !s.shortname.match(/^[^\d]+\d\d-.+$/))
+      .filter(s => !s.title.includes(s.series.title))
       .filter(s => ![
-          "webrtc", "json-ld11-api", "json-ld11-framing",
-          "css-backgrounds-4", "n-quads", "DOM-Level-2-Style"
+          "webrtc", "css-backgrounds-4", "n-quads", "DOM-Level-2-Style"
         ].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
The specs belong to a common repository that uses a slightly different pattern that wasn't yet supported. Also, as for other specs following the `fooXY-bar` pattern, the series title does not completely look like the spec's title. The test now considers the `fooXY-bar` case as an exception to the rule.