### PR TITLE
Support ED to FPWD transition

### DIFF
--- a/src/build-diff.js
+++ b/src/build-diff.js
@@ -231,10 +231,15 @@ async function buildSpec(spec, { diffType = "diff", log = console.log }) {
   log(`Prepare diff...`);
   const isNew = !baseSpecs.find(s => haveSameUrl(s, spec));
   log(isNew ? `- spec is new` : `- spec is already in specs.json`);
+  const knownUrl = spec.knownUrl;
+  if (knownUrl) {
+    log('- but ED was already in specs.json');
+    delete spec.knownUrl;
+  }
   const diff = {
     add: isNew ? [spec] : [],
     update: isNew ? [] : [spec],
-    delete: []
+    delete: baseSpecs.filter(s => haveSameUrl(s, knownUrl))
   };
   log(`Prepare diff... done`);
 


### PR DESCRIPTION
When it finds a candidate /TR URL for a spec that was already in the list through its ED URL, the find-specs script now also adds a link to the ED in the rationale section of the issue.

When it finds a candidate /TR URL for a spec for which there is a pending issue for the ED URL, the find-specs script now creates a new issue for the /TR URL that links to the ED URL issue in the rationale section. The script also closes the ED URL issue with a "Superseded by #xxxx" comment.

The build logic leverages the ED link to also propose the deletion of the ED entry from the list at the same time as the /TR URL is added.

The update also introduces improvements to the comparison logic in the find-specs script, and skips the check on open issues before creating a new one (that's no longer needed since, by definition, we look at open issues before we suggest candidate specs).

Note: We still need tests for find-specs, I wouldn't be surprised if this update introduces bugs, but then they should be easy to spot and fix. Yay for tests in production! ;)