### PR TITLE
Add former name of content-editable

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -965,7 +965,12 @@
   },
   "https://www.w3.org/TR/compute-pressure/",
   "https://www.w3.org/TR/contact-picker/",
-  "https://www.w3.org/TR/content-editable/",
+  {
+    "url": "https://www.w3.org/TR/content-editable/",
+    "formerNames": [
+      "contentEditable"
+    ]
+  },
   "https://www.w3.org/TR/core-aam-1.2/",
   "https://www.w3.org/TR/credential-management-1/",
   "https://www.w3.org/TR/csp-embedded-enforcement/",


### PR DESCRIPTION
The `content-editable` spec used to be known as `contentEditable`.

Not sure yet why the test on shortname continuity did not capture that...