### PR TITLE
Update URL of Subresource Integrity

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1575,11 +1575,14 @@
   "https://www.w3.org/TR/sparql12-service-description/",
   "https://www.w3.org/TR/sparql12-update/",
   {
-    "url": "https://www.w3.org/TR/SRI/",
+    "url": "https://www.w3.org/TR/sri-2/",
     "shortTitle": "SRI",
     "release": {
       "filename": "index.html"
-    }
+    },
+    "formerNames": [
+      "SRI"
+    ]
   },
   "https://www.w3.org/TR/svg-aam-1.0/",
   "https://www.w3.org/TR/svg-integration/",


### PR DESCRIPTION
There used to be one Recommendation for Subresource Integrity, whose shortname was `SRI`. A new level 2 was published as First Public Working Draft today. Shortnames got updated accordingly: `sri-2` for the new level, and `sri-1` for the previous Recommendation, and `SRI` now returns that new level. Our build code detects the redirection and does not like it.

This updates the URL in the list to use `sri-2` (recording `SRI` as a former name). We could keep an entry for `sri-1` but we usually only do that when the current spec is not the latest level.