### PR TITLE
Update URL of WebCryptoAPI

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1697,7 +1697,12 @@
   "https://www.w3.org/TR/webcodecs-vp8-codec-registration/",
   "https://www.w3.org/TR/webcodecs-vp9-codec-registration/",
   "https://www.w3.org/TR/webcodecs/",
-  "https://www.w3.org/TR/WebCryptoAPI/",
+  {
+    "url": "https://www.w3.org/TR/webcrypto-2/",
+    "formerNames": [
+      "WebCryptoAPI"
+    ]
+  },
   "https://www.w3.org/TR/webdriver-bidi/",
   "https://www.w3.org/TR/webdriver2/",
   {


### PR DESCRIPTION
Same story as with Subresource Integrity (#1805), Level 2 of the Web Crypto API was published as FPWD yesterday, and the `WebCryptoAPI` shortname is now no longer a true spec shortname.

This updates the entry to use `webcrypto-2` as shortname and records the former shortname.