### PR TITLE
Leverage validate-repos and throttle requests on w3c.json files

### DIFF
--- a/src/fetch-json.js
+++ b/src/fetch-json.js
@@ -1,7 +1,13 @@
 import ThrottledQueue from "./throttled-queue.js";
 
 // Make sure we remain "friendly" with servers
-const fetchQueue = new ThrottledQueue({ maxParallel: 2 });
+// In particular, we're going to have to fetch a number of w3c.json files from
+// https://raw.githubusercontent.com which seems to restrict the total number
+// of allowed requests to ~5000 per hour and per IP address.
+const fetchQueue = new ThrottledQueue({
+  maxParallel: 4,
+  sleepInterval: 1000
+});
 
 // Maintain a cache of fetched JSON resources in memory to avoid sending the
 // same fetch request again and again
@@ -14,7 +20,7 @@ export default async function (url, options) {
   if (cache[url]) {
     return structuredClone(cache[url]);
   }
-  const res = await fetchQueue.runThrottled(fetch, url, options);
+  const res = await fetchQueue.runThrottledPerOrigin(url, fetch, url, options);
   if (res.status === 404) {
     return null;
   }


### PR DESCRIPTION
The validate-repos project collects all known `w3c.json` file, and contains
the information we need to map repo names to groups for a good chunk of specs.

This still does not work well for /TR specs because we guess the name of the
repository from the spec's shortname, but that's still better than what we used
to have!

Also, the `fetchJSON` function was only applying loose throttling, but
https://raw.githubusercontent.com/ is starting to return 429 responses after a
while. Documentation does not say much, but it would seem the limit is around
~5000 requests per hour. This update makes the function sleep 1000ms in
between requests to a given origin.