### PR TITLE
Monitoring: loop through the right set of issues

### DIFF
--- a/src/monitor-specs.js
+++ b/src/monitor-specs.js
@@ -254,7 +254,7 @@ fetchIssuesToReview().then(async issues => {
   }
 
   console.log('Mark GitHub issues as needing a review...');
-  for (const issue of issues) {
+  for (const issue of issuesToReview) {
     const comment = `The specification was updated on **${issue.lastRevised}** (last reviewed on ${issue.lastReviewed}).`;
     await flagIssueForReview(issue, comment);
   }


### PR DESCRIPTION
The monitor job correctly determines the set of issues that need reviewing, but then incorrectly looped over the entire set of open issues when updating GitHub...