### PR TITLE
Add new RDF/SPARQL WG to list of "non-browser" groups

### DIFF
--- a/src/compute-categories.js
+++ b/src/compute-categories.js
@@ -33,6 +33,7 @@ const nonBrowserGroups = [
   "MiniApps Working Group",
   "Patents and Standards Interest Group",
   "Publishing Maintenance Working Group",
+  "RDF & SPARQL Working Group",
   "RDF Dataset Canonicalization and Hash Working Group",
   "RDF-star Working Group",
   "Spatio-temporal Data on the Web Working Group",


### PR DESCRIPTION
The group used to be known as the "RDF-star" working group. New name needed to be added to the list of non-browser groups to avoid categorizing the group's deliverables as "browser" specs.

Note: the list still contains the previous name in case some data remains that still references that name.

Via https://github.com/w3c/browser-specs/pull/1828#pullrequestreview-2820568835