### PR TITLE
Update URL of digital-credentials spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -494,6 +494,12 @@
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",
   "https://urlpattern.spec.whatwg.org/",
+  {
+    "url": "https://w3c-fedid.github.io/digital-credentials/",
+    "formerNames": [
+      "digital-identities"
+    ]
+  },
   "https://w3c-fedid.github.io/login-status/",
   "https://w3c.github.io/at-driver/",
   {
@@ -682,12 +688,6 @@
   },
   "https://wicg.github.io/datacue/",
   "https://wicg.github.io/deprecation-reporting/",
-  {
-    "url": "https://w3c-fedid.github.io/digital-credentials/",
-    "formerNames": [
-      "digital-identities"
-    ]
-  },
   "https://wicg.github.io/digital-goods/",
   {
     "url": "https://wicg.github.io/direct-sockets/",

--- a/specs.json
+++ b/specs.json
@@ -683,7 +683,7 @@
   "https://wicg.github.io/datacue/",
   "https://wicg.github.io/deprecation-reporting/",
   {
-    "url": "https://wicg.github.io/digital-credentials/",
+    "url": "https://w3c-fedid.github.io/digital-credentials/",
     "formerNames": [
       "digital-identities"
     ]


### PR DESCRIPTION
The spec moved to the FedID WG.

Fix #1848