### PR TITLE
Add "review" label to newly proposed specs

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-spec.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-spec.yml
@@ -1,6 +1,6 @@
 name: New spec
 description: Use this issue template to suggest that a new spec be added to the list.
-labels: ["new spec"]
+labels: ["new spec", "review"]
 title: "Add new spec: <title>"
 body:
   - type: markdown


### PR DESCRIPTION
Issue template added the "new spec" label already to signal that the issue contains a new spec proposal but did not set the "review" label which, with the new system, translates into "Pending proposal, no need to review yet".