### PR TITLE
Flag Web Preferences API as discontinued

### DIFF
--- a/index.json
+++ b/index.json
@@ -10497,8 +10497,8 @@
     "series": {
       "shortname": "web-preferences-api",
       "currentSpecification": "web-preferences-api",
-      "title": "Media Queries",
-      "shortTitle": "Media Queries",
+      "title": "Web Preferences API",
+      "shortTitle": "Web Preferences API",
       "nightlyUrl": "https://wicg.github.io/web-preferences-api/"
     },
     "organization": "W3C",
@@ -10510,19 +10510,22 @@
     ],
     "nightly": {
       "url": "https://wicg.github.io/web-preferences-api/",
-      "status": "Editor's Draft",
+      "status": "Unofficial Proposal Draft",
       "alternateUrls": [],
       "repository": "https://github.com/WICG/web-preferences-api",
-      "sourcePath": "index.html",
+      "sourcePath": "index.bs",
       "filename": "index.html"
     },
-    "title": "Media Queries Level 5",
+    "title": "Web Preferences API",
     "source": "spec",
-    "shortTitle": "Media Queries 5",
+    "shortTitle": "Web Preferences API",
     "categories": [
       "browser"
     ],
-    "standing": "good"
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "mediaqueries-5"
+    ]
   },
   {
     "url": "https://wicg.github.io/web-smart-card/",

--- a/specs.json
+++ b/specs.json
@@ -788,7 +788,13 @@
   "https://wicg.github.io/video-rvfc/",
   "https://wicg.github.io/web-app-launch/",
   "https://wicg.github.io/web-otp/",
-  "https://wicg.github.io/web-preferences-api/",
+  {
+    "url": "https://wicg.github.io/web-preferences-api/",
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "mediaqueries-5"
+    ]
+  },
   "https://wicg.github.io/web-smart-card/",
   {
     "shortname": "device-attributes",


### PR DESCRIPTION
... and integrated in Media Queries Level 5.

The previous URL now redirects to a section in Media Queries. This update also makes the update in `index.json` and rolls back the information there to the latest published info because build will otherwise update the title to "Media Queries".

(Note: once merged, a new package needs to be published right away, as we need a release with the "discontinued" status, otherwise the code will keep looking at the spec and update the entry with the *wrong* info).