### PR TITLE
Support "Statement" status

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -203,6 +203,7 @@
               "Note",
               "Proposed Recommendation",
               "Recommendation",
+              "Statement",
               "Working Draft"
             ]
           },


### PR DESCRIPTION
The Privacy Principles spec just got published as a W3C Statement. That's the first time we have an entry with that status in the list. The JSON schema needed to be adjusted accordingly.