### PR TITLE
Update URL and shortname of privacy-preserving-attribution

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -525,12 +525,6 @@
   "https://w3c.github.io/mediacapture-surface-control/",
   "https://w3c.github.io/permissions-registry/",
   {
-    "nightly": {
-      "sourcePath": "api.bs"
-    },
-    "url": "https://w3c.github.io/ppa/"
-  },
-  {
     "url": "https://w3c.github.io/reporting/network-reporting.html",
     "shortname": "network-reporting",
     "nightly": {
@@ -1545,6 +1539,15 @@
   "https://www.w3.org/TR/pointerevents4/",
   "https://www.w3.org/TR/pointerlock-2/",
   "https://www.w3.org/TR/presentation-api/",
+  {
+    "nightly": {
+      "sourcePath": "api.bs"
+    },
+    "url": "https://www.w3.org/TR/privacy-preserving-attribution/",
+    "formerNames": [
+      "ppa"
+    ]
+  },
   "https://www.w3.org/TR/privacy-principles/",
   "https://www.w3.org/TR/proximity/",
   "https://www.w3.org/TR/pub-manifest/",


### PR DESCRIPTION
The `ppa` draft was published as First Public Working Draft under a different shortname `privacy-preserving-attribution`.