### PR TITLE
Drop dependency on Mocha in CLI

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,19 @@
+/**
+ * Make sure that the browser-specs CLI runs as intended.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { exec as execCb } from 'node:child_process';
+import util from "node:util";
+const exec = util.promisify(execCb);
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const cwd = path.join(scriptPath, '..', 'src');
+
+describe("The browser-specs CLI", () => {
+  it("runs without errors", async () => {
+    await exec("node cli.js --help", { cwd });
+  });
+});


### PR DESCRIPTION
This replaces the CLI logic that was based on Mocha for running tests against the index that a proposed change would create, with logic based on Node's test module.

Note: I added a simple test on the CLI to make sure that it's at least possible to run it, so that we don't miss that next time. More tests would of course be better...

Fixes #1899.