### PR TITLE
Support shortnames of the form nameX.Y

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -20,7 +20,7 @@
 
     "shortname": {
       "type": "string",
-      "pattern": "^[\\w\\-]+((?<=-v?\\d+)\\.\\d+)?$"
+      "pattern": "^[\\w\\-]+((?<=v?\\d+)\\.\\d+)?$"
     },
 
     "series": {

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -146,7 +146,7 @@ function computeShortname(url) {
   // Latin characters (a-z letters, digits, underscore and "-"), and that it
   // only contains a dot for fractional levels at the end of the name
   // (e.g. "blah-1.2" is good but "blah.blah" and "blah-3.1-blah" are not)
-  if (!name.match(/^[\w\-]+((?<=\-v?\d+)\.\d+)?$/)) {
+  if (!name.match(/^[\w\-]+((?<=v?\d+)\.\d+)?$/)) {
     throw `Specification name contains unexpected characters: ${name} (extracted from ${url})`;
   }
 
@@ -200,9 +200,10 @@ function completeWithSeriesAndLevel(shortname, url, forkOf) {
     };
   }
 
-  // Extract X and X.Y levels with form "nameX" or "nameXY" (but not "nameXXY")
+  // Extract X and X.Y levels with form "nameX", "nameXY" or "nameX.Y"
+  // (but not "nameXXY")
   // (e.g. 2.1 for "CSS21", 1.1 for "SVG11", 4 for "selectors4")
-  match = seriesBasename.match(/^(.*?)(?<!\d)(\d)(\d?)$/);
+  match = seriesBasename.match(/^(.*?)(?<!\d)(\d)\.?(\d?)$/);
   if (match) {
     return {
       shortname: specShortname,

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -121,10 +121,8 @@ describe("compute-shortname module", () => {
         /^Specification name contains unexpected characters/);
     });
 
-    it("throws when name contains a non separated fractional level", () => {
-      assert.throws(
-        () => computeInfo("https://w3c.github.io/spec4.2/"),
-        /^Specification name contains unexpected characters/);
+    it("handles non separated fractional level", () => {
+      assertName("https://www.w3.org/TR/level4.2/", "level4.2");
     });
 
     it("handles forks", () => {
@@ -157,6 +155,10 @@ describe("compute-shortname module", () => {
 
     it("parses form 'shortnameXY'", () => {
       assertSeries("answer42", "answer");
+    });
+
+    it("parses form 'shortnameX.Y'", () => {
+      assertSeries("answer4.2", "answer");
     });
 
     it("parses form 'rdfXY-something'", () => {


### PR DESCRIPTION
Code supports a restricted set of formats for shortnames that contain a version number because there are also specifications that have digits in their names that are not version numbers.

Code supported `nameXY` but not `nameX.Y`. The latter is needed to add `ttml-imsc1.2`.