### PR TITLE
Move tests timeout to test level

### DIFF
--- a/test/determine-filename.js
+++ b/test/determine-filename.js
@@ -2,28 +2,31 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import determineFilename from "../src/determine-filename.js";
 
-describe("determine-filename module", {timeout: 30000}, function () {
+describe("determine-filename module", function () {
   // Long timeout since tests need to send network requests
+  const timeout = {
+    timeout: 30000
+  };
 
-  it("extracts filename from URL (.html)", async () => {
+  it("extracts filename from URL (.html)", timeout, async () => {
     const url = "https://example.org/spec/filename.html";
     const filename = await determineFilename(url);
     assert.equal(filename, "filename.html");
   });
 
-  it("extracts filename from URL (.pdf)", async () => {
+  it("extracts filename from URL (.pdf)", timeout, async () => {
     const url = "https://example.org/spec/filename.pdf";
     const filename = await determineFilename(url);
     assert.equal(filename, "filename.pdf");
   });
 
-  it("finds index.html filenames", async () => {
+  it("finds index.html filenames", timeout, async () => {
     const url = "https://w3c.github.io/presentation-api/";
     const filename = await determineFilename(url);
     assert.equal(filename, "index.html");
   });
 
-  it("finds Overview.html filenames", async () => {
+  it("finds Overview.html filenames", timeout, async () => {
     const url = "https://www.w3.org/TR/presentation-api/";
     const filename = await determineFilename(url);
     assert.equal(filename, "Overview.html");

--- a/test/extract-pages.js
+++ b/test/extract-pages.js
@@ -3,8 +3,12 @@ import assert from "node:assert";
 import puppeteer from "puppeteer";
 import extractPages from "../src/extract-pages.js";
 
-describe("extract-pages module", {timeout: 30000}, function () {
+describe("extract-pages module", function () {
   // Long timeout since tests need to send network requests
+  const timeout = {
+    timeout: 30000
+  };
+
   let browser;
 
   before(async () => {
@@ -15,37 +19,37 @@ describe("extract-pages module", {timeout: 30000}, function () {
     await browser.close();
   });
 
-  it("extracts pages from the SVG2 spec", async () => {
+  it("extracts pages from the SVG2 spec", timeout, async () => {
     const url = "https://svgwg.org/svg2-draft/";
     const pages = await extractPages(url, browser);
     assert.ok(pages.length > 20);
   });
 
-  it("extracts pages from the HTML spec", async () => {
+  it("extracts pages from the HTML spec", timeout, async () => {
     const url = "https://html.spec.whatwg.org/multipage/";
     const pages = await extractPages(url, browser);
     assert.ok(pages.length > 20);
   });
 
-  it("extracts pages from the CSS 2.1 spec", async () => {
+  it("extracts pages from the CSS 2.1 spec", timeout, async () => {
     const url = "https://www.w3.org/TR/CSS21/";
     const pages = await extractPages(url, browser);
     assert.ok(pages.length > 20);
   });
 
-  it("does not include the index page as first page", async () => {
+  it("does not include the index page as first page", timeout, async () => {
     const url = "https://svgwg.org/svg2-draft/"
     const pages = await extractPages(url, browser);
     assert.ok(!pages.find(page => page.url));
   });
 
-  it("does not get lost when given a single-page ReSpec spec", async () => {
+  it("does not get lost when given a single-page ReSpec spec", timeout, async () => {
     const url = "https://w3c.github.io/presentation-api/";
     const pages = await extractPages(url, browser);
     assert.deepStrictEqual(pages, []);
   });
 
-  it("does not get lost when given a single-page Bikeshed spec", async () => {
+  it("does not get lost when given a single-page Bikeshed spec", timeout, async () => {
     const url = "https://w3c.github.io/mediasession/";
     const pages = await extractPages(url, browser);
     assert.deepStrictEqual(pages, []);

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -11,8 +11,9 @@ const githubToken = (function () {
   }
 })() ?? process.env.GITHUB_TOKEN;
 
-describe("fetch-groups module (without API keys)", {timeout: 30000}, function () {
+describe("fetch-groups module (without API keys)", function () {
   // Long timeout since tests may need to send network requests
+  const timeout = { timeout: 30000 };
 
   async function fetchGroupsFor(url, options) {
     const spec = { url };
@@ -20,7 +21,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     return result[0];
   };
 
-  it("handles WHATWG URLs", async () => {
+  it("handles WHATWG URLs", timeout, async () => {
     const res = await fetchGroupsFor("https://url.spec.whatwg.org/");
     assert.equal(res.organization, "WHATWG");
     assert.deepStrictEqual(res.groups, [{
@@ -29,7 +30,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles TC39 URLs", async () => {
+  it("handles TC39 URLs", timeout, async () => {
     const res = await fetchGroupsFor("https://tc39.es/proposal-relative-indexing-method/");
     assert.equal(res.organization, "Ecma International");
     assert.deepStrictEqual(res.groups, [{
@@ -38,7 +39,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles W3C TAG URLs", async () => {
+  it("handles W3C TAG URLs", timeout, async () => {
     const res = await fetchGroupsFor("https://www.w3.org/2001/tag/doc/promises-guide");
     assert.equal(res.organization, "W3C");
     assert.deepStrictEqual(res.groups, [{
@@ -47,7 +48,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles WebGL URLs", async () => {
+  it("handles WebGL URLs", timeout, async () => {
     const res = await fetchGroupsFor("https://registry.khronos.org/webgl/extensions/EXT_clip_cull_distance/");
     assert.equal(res.organization, "Khronos Group");
     assert.deepStrictEqual(res.groups, [{
@@ -56,7 +57,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles IETF RFCs", async () => {
+  it("handles IETF RFCs", timeout, async () => {
     const res = await fetchGroupsFor("https://www.rfc-editor.org/rfc/rfc9110");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
@@ -65,7 +66,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles IETF group drafts", async () => {
+  it("handles IETF group drafts", timeout, async () => {
     const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
@@ -74,7 +75,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles IETF individual drafts", async () => {
+  it("handles IETF individual drafts", timeout, async () => {
     const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
@@ -83,7 +84,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles IETF area drafts", async () => {
+  it("handles IETF area drafts", timeout, async () => {
     const res = await fetchGroupsFor("https://datatracker.ietf.org/doc/html/draft-zern-webp");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
@@ -92,7 +93,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles AOM specs", async () => {
+  it("handles AOM specs", timeout, async () => {
     const res = await fetchGroupsFor("https://aomediacodec.github.io/afgs1-spec/");
     assert.equal(res.organization, "Alliance for Open Media");
     assert.deepStrictEqual(res.groups, [{
@@ -101,7 +102,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles simple ISO specs", async () => {
+  it("handles simple ISO specs", timeout, async () => {
     const res = await fetchGroupsFor("https://www.iso.org/standard/72482.html");
     assert.equal(res.organization, "ISO");
     assert.deepStrictEqual(res.groups, [{
@@ -110,7 +111,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("handles ISO/IEC specs", async () => {
+  it("handles ISO/IEC specs", timeout, async () => {
     const res = await fetchGroupsFor("https://www.iso.org/standard/85253.html");
     assert.equal(res.organization, "ISO/IEC");
     assert.deepStrictEqual(res.groups, [{
@@ -119,7 +120,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     }]);
   });
 
-  it("preserves provided info", async () => {
+  it("preserves provided info", timeout, async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",
       organization: "Acme Corporation",
@@ -133,7 +134,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
     assert.deepStrictEqual(res[0].groups, spec.groups);
   });
 
-  it("preserves provided info for Patent Policy", async () => {
+  it("preserves provided info for Patent Policy", timeout, async () => {
     const spec = {
       "url": "https://www.w3.org/Consortium/Patent-Policy/",
       "shortname": "w3c-patent-policy",
@@ -150,7 +151,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
   });
 
   describe("fetch from W3C API", () => {
-    it("handles /TR URLs", async () => {
+    it("handles /TR URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://www.w3.org/TR/gamepad/");
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -159,7 +160,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles multiple /TR URLs", async () => {
+    it("handles multiple /TR URLs", timeout, async () => {
       const specs = [
         { url: "https://www.w3.org/TR/gamepad/" },
         { url: "https://www.w3.org/TR/accname-1.2/" }
@@ -177,7 +178,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles w3c.github.io URLs", async () => {
+    it("handles w3c.github.io URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://w3c.github.io/web-nfc/", { githubToken });
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -186,7 +187,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles SVG URLs", async () => {
+    it("handles SVG URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://svgwg.org/specs/animations/");
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -195,7 +196,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles CSS WG URLs", async () => {
+    it("handles CSS WG URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://drafts.csswg.org/css-animations-2/");
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -204,7 +205,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles CSS Houdini TF URLs", async () => {
+    it("handles CSS Houdini TF URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://drafts.css-houdini.org/css-typed-om-2/");
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -213,7 +214,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("handles CSS FXTF URLs", async () => {
+    it("handles CSS FXTF URLs", timeout, async () => {
       const res = await fetchGroupsFor("https://drafts.fxtf.org/filter-effects-2/");
       assert.equal(res.organization, "W3C");
       assert.deepStrictEqual(res.groups, [{
@@ -222,7 +223,7 @@ describe("fetch-groups module (without API keys)", {timeout: 30000}, function ()
       }]);
     });
 
-    it("uses last published info for discontinued specs", async () => {
+    it("uses last published info for discontinued specs", timeout, async () => {
       const spec = {
         url: "https://wicg.github.io/close-watcher/",
         shortname: "close-watcher",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -8,8 +8,11 @@ import fetchInfo from "../src/fetch-info.js";
 
 import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
 
-describe("fetch-info module", {timeout: 60000}, function () {
+describe("fetch-info module", function () {
   // Long time out since tests need to send network requests
+  const timeout = {
+    timeout: 60000
+  };
 
   function getW3CSpec(shortname, series) {
     const spec = { shortname, url: `https://www.w3.org/TR/${shortname}/` };
@@ -20,7 +23,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
   }
 
   describe("fetch from WHATWG", () => {
-    it("works on a WHATWG spec", async () => {
+    it("works on a WHATWG spec", timeout, async () => {
       const spec = {
         url: "https://dom.spec.whatwg.org/",
         shortname: "dom"
@@ -35,7 +38,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
   });
 
   describe("fetch from IETF datatracker", () => {
-    it("fetches info about RFCs from datatracker", async () => {
+    it("fetches info about RFCs from datatracker", timeout, async () => {
       const spec = {
         url: "https://www.rfc-editor.org/rfc/rfc7578",
         shortname: "rfc7578"
@@ -47,7 +50,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].nightly.url, "https://www.rfc-editor.org/rfc/rfc7578");
     });
 
-    it("fetches info about HTTP WG RFCs from datatracker", async () => {
+    it("fetches info about HTTP WG RFCs from datatracker", timeout, async () => {
       const spec = {
         url: "https://www.rfc-editor.org/rfc/rfc9110",
         shortname: "rfc9110"
@@ -59,7 +62,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].nightly.url, "https://httpwg.org/specs/rfc9110.html");
     });
 
-    it("extracts a suitable nightly URL from an IETF draft", async () => {
+    it("extracts a suitable nightly URL from an IETF draft", timeout, async () => {
       const spec = {
         url: "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
         shortname: "client-hint-reliability"
@@ -70,7 +73,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.match(info[spec.shortname].nightly.url, /^https:\/\/www\.ietf\.org\/archive\/id\/draft-davidben-http-client-hint-reliability-\d+\.html/);
     });
 
-    it("extracts a suitable nightly URL from an IETF HTTP WG draft", async () => {
+    it("extracts a suitable nightly URL from an IETF HTTP WG draft", timeout, async () => {
       const spec = {
         url: "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
         shortname: "partitioned-cookies"
@@ -81,7 +84,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.match(info[spec.shortname].nightly.url, /^https:\/\/www\.ietf\.org\/archive\/id\/draft-cutler-httpbis-partitioned-cookies-\d+\.html/);
     });
 
-    it("extracts a suitable nightly URL from an IETF HTTP State Management Mechanism WG RFC", async () => {
+    it("extracts a suitable nightly URL from an IETF HTTP State Management Mechanism WG RFC", timeout, async () => {
       const spec = {
         url: "https://www.rfc-editor.org/rfc/rfc6265",
         shortname: "rfc6265"
@@ -92,7 +95,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].nightly.url, "https://httpwg.org/specs/rfc6265.html");
     });
 
-    it("uses the rfc-editor URL as nightly for an IETF HTTP WG RFC not published under httpwg.org", async () => {
+    it("uses the rfc-editor URL as nightly for an IETF HTTP WG RFC not published under httpwg.org", timeout, async () => {
       const spec = {
         url: "https://www.rfc-editor.org/rfc/rfc9163",
         shortname: "rfc9163"
@@ -103,7 +106,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].nightly.url, spec.url);
     });
 
-    it("identifies discontinued IETF specs", async () => {
+    it("identifies discontinued IETF specs", timeout, async () => {
       const info = await fetchInfo([
         { url: "https://www.rfc-editor.org/rfc/rfc7230", shortname: "rfc7230" },
         { url: "https://www.rfc-editor.org/rfc/rfc9110", shortname: "rfc9110" },
@@ -114,7 +117,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.deepStrictEqual(info["rfc7230"].obsoletedBy, ["rfc9110", "rfc9112"]);
     });
 
-    it("throws when a discontinued IETF spec is obsoleted by an unknown spec", async () => {
+    it("throws when a discontinued IETF spec is obsoleted by an unknown spec", timeout, async () => {
       const spec = {
         url: "https://www.rfc-editor.org/rfc/rfc7230",
         shortname: "rfc7230"
@@ -124,7 +127,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
         /^Error: IETF spec at (.*)rfc7230 is obsoleted by rfc9110 which is not in the list.$/);
     });
 
-    it("throws when an IETF URL needs to be updated", async () => {
+    it("throws when an IETF URL needs to be updated", timeout, async () => {
       const spec = {
         url: "https://datatracker.ietf.org/doc/html/draft-ietf-websec-strict-transport-sec",
         shortname: "strict-transport-sec"
@@ -136,7 +139,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
   });
 
   describe("fetch from spec", () => {
-    it("extracts spec info from a Bikeshed spec when needed", async () => {
+    it("extracts spec info from a Bikeshed spec when needed", timeout, async () => {
       const spec = {
         url: "https://speced.github.io/bikeshed/",
         shortname: "bikeshed"
@@ -149,7 +152,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].title, "Bikeshed Documentation");
     });
 
-    it("extracts spec info from a Respec spec when needed", async () => {
+    it("extracts spec info from a Respec spec when needed", timeout, async () => {
       const spec = {
         url: "https://screen-share.github.io/element-capture/",
         shortname: "respec"
@@ -162,7 +165,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].title, "Element Capture");
     });
 
-    it("extracts right title from an ECMAScript proposal spec", async () => {
+    it("extracts right title from an ECMAScript proposal spec", timeout, async () => {
       const spec = {
         url: "https://tc39.es/proposal-intl-segmenter/",
         shortname: "tc39-intl-segmenter"
@@ -175,7 +178,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].title, "Intl.Segmenter Proposal");
     });
 
-    it("creates a release for final AOM deliverables published as PDF", async () => {
+    it("creates a release for final AOM deliverables published as PDF", timeout, async () => {
       const spec = {
         organization: "Alliance for Open Media",
         url: "https://aomediacodec.github.io/av1-spec/av1-spec.pdf",
@@ -193,7 +196,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].release.status, "Final Deliverable");
     });
 
-    it("extracts spec info from an ISO spec page", async () => {
+    it("extracts spec info from an ISO spec page", timeout, async () => {
       const spec = {
         url: "https://www.iso.org/standard/61292.html",
         shortname: "iso18074-2015"
@@ -205,7 +208,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].nightly, undefined);
     });
 
-    it("uses the last published info when hitting an error fetching the spec", async () => {
+    it("uses the last published info when hitting an error fetching the spec", timeout, async () => {
       const defaultDispatcher = getGlobalDispatcher();
       const mockAgent = new MockAgent();
       setGlobalDispatcher(mockAgent);
@@ -230,7 +233,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
   });
 
   describe("fetch from W3C API", () => {
-    it("works on a TR spec", async () => {
+    it("works on a TR spec", timeout, async () => {
       const spec = getW3CSpec("hr-time-2", "hr-time");
       const info = await fetchInfo([spec]);
       assert.ok(info[spec.shortname]);
@@ -247,7 +250,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info.__series["hr-time"].title, "High Resolution Time");
     });
 
-    it("can operate on multiple specs at once", async () => {
+    it("can operate on multiple specs at once", timeout, async () => {
       const spec = getW3CSpec("hr-time-2", "hr-time");
       const other = getW3CSpec("tracking-dnt", "tracking-dnt");
       const info = await fetchInfo([spec, other]);
@@ -274,7 +277,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info.__series["tracking-dnt"].currentSpecification, "tracking-dnt");
     });
 
-    it("does not get confused by CSS snapshots", async () => {
+    it("does not get confused by CSS snapshots", timeout, async () => {
       const css = getW3CSpec("CSS2", "CSS");
       const snapshot = getW3CSpec("css-2023", "css");
       const info = await fetchInfo([css, snapshot]);
@@ -288,7 +291,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info.__series["css"].title, "CSS Snapshot");
     });
 
-    it("detects redirects", async () => {
+    it("detects redirects", timeout, async () => {
       const spec = {
         url: "https://www.w3.org/TR/webaudio/",
         shortname: "webaudio"
@@ -298,7 +301,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
         /^Error: W3C API redirects "webaudio" to "webaudio-.*"/);
     });
 
-    it("can operate on multiple specs at once", async () => {
+    it("can operate on multiple specs at once", timeout, async () => {
       const spec = getW3CSpec("presentation-api");
       const other = getW3CSpec("hr-time-2");
       const info = await fetchInfo([spec, other]);
@@ -315,7 +318,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
   });
 
   describe("fetch from all sources", () => {
-    it("uses the last published info for discontinued specs", async () => {
+    it("uses the last published info for discontinued specs", timeout, async () => {
       const spec = {
         url: "https://wicg.github.io/close-watcher/",
         shortname: "close-watcher",
@@ -329,7 +332,7 @@ describe("fetch-info module", {timeout: 60000}, function () {
       assert.equal(info[spec.shortname].organization, spec.__last.organization);
     });
 
-    it("merges info from sources", async () => {
+    it("merges info from sources", timeout, async () => {
       const w3c = getW3CSpec("presentation-api");
       const whatwg = {
         url: "https://html.spec.whatwg.org/multipage/",


### PR DESCRIPTION
Same update as done in Reffy for the same reason. Timeouts set at the suite level in Node.js apply to the suite as well, see:
https://github.com/w3c/reffy/pull/1846 (and I ran into timeout issues locally in practice)