### PR TITLE
Add RFC5861 HTTP Cache-Control Extensions for Stale Content

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -828,6 +828,7 @@
     "url": "https://www.rfc-editor.org/rfc/rfc4120",
     "shortTitle": "Kerberos"
   },
+  "https://httpwg.org/specs/rfc5861.html",
   "https://www.rfc-editor.org/rfc/rfc6265",
   {
     "url": "https://www.rfc-editor.org/rfc/rfc6266",


### PR DESCRIPTION
This is required for https://github.com/mdn/browser-compat-data/pull/26895

