### PR TITLE
Add `w3c/sdw-ssn-sosa` to multi-spec repos list

### DIFF
--- a/src/data/multispecs-repos.json
+++ b/src/data/multispecs-repos.json
@@ -73,6 +73,16 @@
       "subsetting"
     ]
   },
+  "w3c/sdw-sosa-ssn": {
+    "url": "https://w3c.github.io/sdw-sosa-ssn/$path/",
+    "shortname": {
+      "pattern": "w3c\\.github\\.io/sdw-sosa-ssn/([^/]+)/",
+      "prefix": "sdw-"
+    },
+    "exclude": [
+      "ogcapi-sosa"
+    ]
+  },
   "w3c/svgwg": {
     "url": "https://svgwg.org/$path/",
     "shortname": {


### PR DESCRIPTION
The repository contains the current ED of the SSN and SSN Extensions ontologies.