### PR TITLE
Update URL of digital-credentials spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -548,12 +548,6 @@
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",
   "https://urlpattern.spec.whatwg.org/",
-  {
-    "url": "https://w3c-fedid.github.io/digital-credentials/",
-    "formerNames": [
-      "digital-identities"
-    ]
-  },
   "https://w3c-fedid.github.io/login-status/",
   "https://w3c.github.io/at-driver/",
   {
@@ -1280,6 +1274,12 @@
   "https://www.w3.org/TR/device-posture/",
   "https://www.w3.org/TR/did-1.1/",
   "https://www.w3.org/TR/did-resolution/",
+  {
+    "url": "https://www.w3.org/TR/digital-credentials/",
+    "formerNames": [
+      "digital-identities"
+    ]
+  },
   {
     "url": "https://www.w3.org/TR/DOM-Level-2-Style/",
     "series": {


### PR DESCRIPTION
Following publication of FPWD. Close #1991.