### PR TITLE
Use ISO Open Data datasets to process ISO specs

### DIFF
--- a/.github/workflows/build-skip-iso.yml
+++ b/.github/workflows/build-skip-iso.yml
@@ -1,10 +1,10 @@
-name: Update spec info (full build)
+name: Update spec info (skip ISO specs)
 
 on:
   schedule:
-    # At 6:10PM on Saturday and Sunday
-    # (see build-skip-iso.yml workflow for rest of the week)
-    - cron: '10 18 * * SAT-SUN'
+    # Every 6 hours from Monday to Friday
+    # (see build.yml workflow for Saturday and Sunday)
+    - cron: '10 */6 * * MON-SAT'
   workflow_dispatch:
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
     - name: Build new index file
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run build
+      run: npm run build-skip-iso
 
     - name: Test new index file
       env:

--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ The provenance for the `title` and `nightly` property values. Can be one of:
 - `w3c`: information retrieved from the [W3C API](https://w3c.github.io/w3c-api/)
 - `whatwg`: information retrieved from [WHATWG](https://spec.whatwg.org/)
 - `ietf`: information retrieved from the [IETF datatracker](https://datatracker.ietf.org)
+- `iso`: information retrieved from the [ISO Open Data](https://www.iso.org/open-data.html) datasets [iso_deliverables_metadata](https://www.iso.org/open-data.html#iso_deliverables_metadata) and [iso_technical_committees](https://www.iso.org/open-data.html#iso_technical_committees), licensed under the [ODC Attribution License](https://opendatacommons.org/licenses/by/1-0/)
 - `spec`: information retrieved from the spec itself
 
 The `source` property is always set.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "index.json",
   "scripts": {
     "build": "node src/build-index.js",
+    "build-skip-iso": "node src/build-index.js --skip-fetch=iso",
     "lint": "node src/lint.js",
     "lint-fix": "node src/lint.js --fix",
     "test": "node --test --test-reporter=spec",

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -60,7 +60,7 @@
 
     "source": {
       "type": "string",
-      "enum": ["w3c", "spec", "ietf", "whatwg"]
+      "enum": ["w3c", "spec", "ietf", "whatwg", "iso"]
     },
 
     "nightly": {

--- a/specs.json
+++ b/specs.json
@@ -867,17 +867,14 @@
   "https://wicg.github.io/window-controls-overlay/",
   {
     "url": "https://www.iso.org/standard/54989.html",
-    "shortname": "iso10918-5",
     "shortTitle": "JPEG"
   },
   {
     "url": "https://www.iso.org/standard/85253.html",
-    "shortname": "iso18181-2",
     "shortTitle": "JPEG XL: File Format"
   },
   {
     "url": "https://www.iso.org/standard/87621.html",
-    "shortname": "iso14496-22",
     "shortTitle": "Open Font Format"
   },
   "https://www.rfc-editor.org/rfc/rfc2397",

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -131,6 +131,15 @@ function computeShortname(url) {
       return tag[1];
     }
 
+    // Handle ISO specs
+    // (Note: the computed shortname uses the internal ID. This will be updated
+    // by fetch-iso-info to return a better shortname based on the spec's
+    // official ISO codification)
+    const iso = url.match(/\/www\.iso\.org\/standard\/(\d+)\.html$/);
+    if (iso) {
+      return `iso-id-${iso[1]}`;
+    }
+
     // Return name when one was given
     if (!url.match(/\//)) {
       return url;

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -19,62 +19,6 @@ let w3cGroups = null;
 
 
 /**
- * Retrieve the information about the exact organization and the group that
- * develops an ISO specification from the description page on the ISO web site.
- *
- * The group's name and URL appear in the page under the General Information
- * heading.
- *
- * Note: It would be better to use Puppeteer to parse the HTML, but that seems
- * a bit overkill (and would not be future proof either since the HTML page
- * does not contain good non-text anchors to extract the info we need.
- */
-async function setISOGroupFromPage(spec, options) {
-  const res = await fetch(spec.url, options);
-  if (res.status !== 200) {
-    throw new Error(`Could not retrieve ISO page ${spec.url}, status code is ${res.status}`);
-  }
-  const html = await res.text();
-  let startPos = html.indexOf('<h3>General information</h3>');
-  if (startPos === -1) {
-    throw new Error(`Cannot find General information heading in ISO page ${spec.url}`);
-  }
-  startPos = html.indexOf('Technical Committee&nbsp;:', startPos);
-  if (startPos === -1) {
-    throw new Error(`Cannot find technical committee information in ISO page ${spec.url}`);
-  }
-  startPos = html.indexOf('<a ', startPos);
-  if (startPos === -1) {
-    throw new Error(`Cannot find technical committee anchor in ISO page ${spec.url}`);
-  }
-  startPos = html.indexOf('href="', startPos);
-  let endPos = html.indexOf('"', startPos + 'href="'.length);
-  if (startPos === -1 || endPos === -1) {
-    throw new Error(`Cannot find technical committee href in ISO page ${spec.url}`);
-  }
-  const groupUrl = html.substring(startPos + 'href="'.length, endPos);
-  startPos = html.indexOf('>', endPos);
-  endPos = html.indexOf('<', startPos);
-  if (startPos === -1 || endPos === -1) {
-    throw new Error(`Cannot find technical committee name in ISO page ${spec.url}`);
-  }
-  const groupName = html.substring(startPos + 1, endPos).trim();
-
-  if (groupName.startsWith('ISO/IEC')) {
-    spec.organization = 'ISO/IEC';
-  }
-  else {
-    spec.organization = 'ISO';
-  }
-
-  spec.groups = [{
-    name: groupName,
-    url: (new URL(groupUrl, 'https://www.iso.org')).href
-  }];
-}
-
-
-/**
  * Exports main function that takes a list of specs (with a url property)
  * as input, completes entries with an "organization" property that contains the
  * name of the organization such as W3C, WHATWG, IETF, Khronos Group,
@@ -132,13 +76,6 @@ export default async function (specs, options) {
           throw new Error(`Could not derive IETF group for ${spec.url}.
             Unknown group type found in https://datatracker.ietf.org/doc/${ietfName[1]}/doc.json`);
         }
-      }
-
-      // For ISO documents, retrieve the group info from the HTML page
-      // (NB: it would be cleaner to use Puppeteer here)
-      const isoName = spec.url.match(/https:\/\/www\.iso\.org\//);
-      if (isoName) {
-        await setISOGroupFromPage(spec, options);
       }
 
       if (!spec.groups) {

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -102,24 +102,6 @@ describe("fetch-groups module (without API keys)", function () {
     }]);
   });
 
-  it("handles simple ISO specs", timeout, async () => {
-    const res = await fetchGroupsFor("https://www.iso.org/standard/72482.html");
-    assert.equal(res.organization, "ISO");
-    assert.deepStrictEqual(res.groups, [{
-      name: "ISO/TC 46",
-      url: "https://www.iso.org/committee/48750.html"
-    }]);
-  });
-
-  it("handles ISO/IEC specs", timeout, async () => {
-    const res = await fetchGroupsFor("https://www.iso.org/standard/85253.html");
-    assert.equal(res.organization, "ISO/IEC");
-    assert.deepStrictEqual(res.groups, [{
-      name: "ISO/IEC JTC 1/SC 29",
-      url: "https://www.iso.org/committee/45316.html"
-    }]);
-  });
-
   it("preserves provided info", timeout, async () => {
     const spec = {
       url: "https://url.spec.whatwg.org/",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -196,26 +196,14 @@ describe("fetch-info module", function () {
       assert.equal(info[spec.shortname].release.status, "Final Deliverable");
     });
 
-    it("extracts spec info from an ISO spec page", timeout, async () => {
-      const spec = {
-        url: "https://www.iso.org/standard/61292.html",
-        shortname: "iso18074-2015"
-      };
-      const info = await fetchInfo([spec]);
-      assert.ok(info[spec.shortname]);
-      assert.equal(info[spec.shortname].source, "spec");
-      assert.equal(info[spec.shortname].title, "Textiles — Identification of some animal fibres by DNA analysis method — Cashmere, wool, yak and their blends");
-      assert.equal(info[spec.shortname].nightly, undefined);
-    });
-
     it("uses the last published info when hitting an error fetching the spec", timeout, async () => {
       const defaultDispatcher = getGlobalDispatcher();
       const mockAgent = new MockAgent();
       setGlobalDispatcher(mockAgent);
 
       mockAgent.get("https://example.com")
-	.intercept({ method: "GET", path: "/429" })
-	.reply(429);
+        .intercept({ method: "GET", path: "/429" })
+        .reply(429);
 
       const spec = {
         url: "https://example.com/429",

--- a/test/fetch-iso-info.js
+++ b/test/fetch-iso-info.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for the fetch-info module
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fetchInfoFromISO from "../src/fetch-iso-info.js";
+
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+
+const tcResponse = `
+{"id":48148,"reference":"ISO/TC 38"}
+{"id":45316,"reference":"ISO/IEC JTC 1/SC 29"}
+`;
+
+const catalogResponse = `
+{"id":54989,"deliverableType":"IS","supplementType":null,"reference":"ISO/IEC 10918-5:2013","title":{"en":"Information technology — Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF) — Part 5:","fr":"Technologies de l'information — Compression numérique et codage des images fixes à modelé continu: Format d'échange de fichiers JPEG (JFIF) — Partie 5:"},"publicationDate":"2013-04-26","edition":1,"icsCode":["35.040.30"],"ownerCommittee":"ISO/IEC JTC 1/SC 29","currentStage":9060,"replaces":null,"replacedBy":null,"languages":["en"],"pages":{"en":9},"scope":{"en":"<p>ISO/IEC 10918-5:2013 specifies the JPEG File Interchange Format (JFIF).</p>\\n"}}
+{"id":61292,"deliverableType":"IS","supplementType":null,"reference":"ISO 18074:2015","title":{"en":"Textiles — Identification of some animal fibres by DNA analysis method — Cashmere, wool, yak and their blends","fr":"Textiles — Identification de certaines fibres animales par la méthode d'analyse de l'ADN — Cachemire, laine, yack et leurs mélanges"},"publicationDate":"2015-11-19","edition":1,"icsCode":["59.080.01"],"ownerCommittee":"ISO/TC 38","currentStage":9093,"replaces":null,"replacedBy":null,"languages":["en","fr"],"pages":{"en":22},"scope":{"en":"<p>ISO 18074:2015 specifies a testing method for DNA analysis of some animal fibres to identify cashmere, wool, yak, and their blends by using extraction, amplification by the polymerase chain reaction (PCR) method and DNA detection processes.</p>\\n<p>ISO 18084:2015 is applicable to cashmere, yak, and wool and their blends as a qualitative method.</p>\\n\\n"}}
+`;
+
+describe("The ISO catalog module", async function () {
+  // Long time out since tests need to send network requests
+  const timeout = {
+    timeout: 60000
+  };
+
+  let defaultDispatcher = getGlobalDispatcher();
+  let mockAgent = new MockAgent();
+
+  function initIntercepts() {
+    const mockPool = mockAgent
+      .get("https://isopublicstorageprod.blob.core.windows.net");
+    mockPool
+      .intercept({ path: "/opendata/_latest/iso_technical_committees/json/iso_technical_committees.jsonl" })
+      .reply(200, tcResponse);
+    mockPool
+      .intercept({ path: "/opendata/_latest/iso_deliverables_metadata/json/iso_deliverables_metadata.jsonl" })
+      .reply(200, catalogResponse);
+  }
+
+  before(() => {
+    setGlobalDispatcher(mockAgent);
+    mockAgent.disableNetConnect();
+  });
+
+  after(() => {
+    setGlobalDispatcher(defaultDispatcher);
+  })
+
+  it("extracts spec info for an ISO spec", timeout, async () => {
+    initIntercepts();
+    const spec = { url: "https://www.iso.org/standard/61292.html" };
+    const specs = await fetchInfoFromISO([spec]);
+    assert.ok(specs[0]);
+    assert.equal(specs[0].shortname, "iso18074");
+    assert.equal(specs[0].series?.shortname, "iso18074");
+    assert.equal(specs[0].source, "iso");
+    assert.equal(specs[0].title, "Textiles — Identification of some animal fibres by DNA analysis method — Cashmere, wool, yak and their blends");
+    assert.equal(specs[0].organization, "ISO");
+    assert.equal(specs[0].groups[0].url, "https://www.iso.org/committee/48148.html");
+    assert.equal(specs[0].groups[0].name, "ISO/TC 38");
+    assert.equal(specs[0].nightly, undefined);
+  });
+
+  it("extracts spec info for an ISO/IEC spec", timeout, async () => {
+    initIntercepts();
+    const spec = { url: "https://www.iso.org/standard/54989.html" };
+    const specs = await fetchInfoFromISO([spec]);
+    assert.ok(specs[0]);
+    assert.equal(specs[0].shortname, "iso10918-5");
+    assert.equal(specs[0].series?.shortname, "iso10918-5");
+    assert.equal(specs[0].source, "iso");
+    assert.equal(specs[0].title, "Information technology — Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF) — Part 5:");
+    assert.equal(specs[0].organization, "ISO/IEC");
+    assert.equal(specs[0].groups[0].url, "https://www.iso.org/committee/45316.html");
+    assert.equal(specs[0].groups[0].name, "ISO/IEC JTC 1/SC 29");
+    assert.equal(specs[0].nightly, undefined);
+  });
+
+  it("skips fetch in the absence of specs from ISO", timeout, async () => {
+    // Note: as we don't call initIntercepts(), mock agent will throw if
+    // code attempts to fetch something from the network
+    const spec = { url: "https://www.w3.org/TR/from-w3c-with-love/" };
+    const specs = await fetchInfoFromISO([spec]);
+    assert.ok(specs[0]);
+  });
+
+  it("skips fetch when asked", timeout, async () => {
+    // Note: as we don't call initIntercepts(), mock agent will throw if
+    // code attempts to fetch something from the network.
+    const spec = { url: "https://www.iso.org/standard/54989.html" };
+    const specs = await fetchInfoFromISO([spec], { skipFetch: 'iso' });
+    assert.ok(specs[0]);
+  });
+});


### PR DESCRIPTION
Logic to process specs from ISO was to "browse" the ISO web site to extract the spec title and group name. That approach fails more and more, essentially because bots are not welcome on the web site.

This update drops custom logic to browse the ISO web site and leverages machine-readable datasets provided through the ISO Open data project instead: https://www.iso.org/open-data.html

Now, the thing is, browser-specs only contains 3 specs from ISO for now, and their information is unlikely ever going to change. And the datasets are huge (~70MB for the main catalog). To avoid wasting resources for nothing, a new build command gets introduced:

```
npm run build-skip-iso
```

The command skips fetching the ISO catalog and reuses previous info about the ISO specs.

That new command is used for all automated builds from Monday to Friday. On Saturday and Sunday, a full build gets made, only once per day (running multiple builds during the week-end is not very useful in any case as we're unlikely ever going to act on them).

Under the hoods, the new command uses a `--skip-fetch` CLI option, which could perhaps be extended afterwards to skip additional network fetches.

The `source` of ISO entries changes from `spec` to `iso`.

Note: A full build will be needed when we add a new ISO spec to the list.