### PR TITLE
Adjust URL of ARIA WG page in test

### DIFF
--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -156,7 +156,7 @@ describe("fetch-groups module (without API keys)", function () {
       assert.equal(res[1].organization, "W3C");
       assert.deepStrictEqual(res[1].groups, [{
         name: "Accessible Rich Internet Applications Working Group",
-        url: "https://www.w3.org/WAI/ARIA/"
+        url: "https://www.w3.org/WAI/about/groups/ariawg/"
       }]);
     });
 


### PR DESCRIPTION
The W3C API returns a new URL. Previous URL redirects to that one too.