### PR TITLE
Fix matching of ISO specs when attaching previous info

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -208,7 +208,11 @@ async function runFetchLastPublished(index) {
   const lastIndexStr = await fs.readFile(lastIndexFile, 'utf8');
   const lastIndex = JSON.parse(lastIndexStr);
   const decoratedIndex = index.map(spec => {
-    const last = lastIndex.find(s => s.shortname === spec.shortname);
+    // Match on shortname first (transition from ED to FPWD changes the URL)
+    // and then on the URL (computed shortname of ISO specs is an internal ID
+    // at this step)
+    const last = lastIndex.find(s => s.shortname === spec.shortname) ??
+      lastIndex.find(s => s.url === spec.url);
     if (last) {
       spec.__last = last;
     }


### PR DESCRIPTION
I *almost* got it right yesterday ;)

Builds that do not fetch the ISO catalog use previous info. The code that associated previous info with the actual list of specs to process was only matching on the spec's *computed* shortname. That computed shortname is a temporary one for ISO specs, it gets changed right after that step when ISO specs get processed. Code now also matches on the spec's URL if match on shortname did not work.