### PR TITLE
Force currentSpecification for ISO specs

### DIFF
--- a/src/fetch-iso-info.js
+++ b/src/fetch-iso-info.js
@@ -64,7 +64,6 @@ async function fetchInfoFromISO(specs, options) {
 
       spec.__iso = {
         shortname,
-        series: { shortname },
         organization: json.ownerCommittee.startsWith('ISO/IEC') ? 'ISO/IEC' : 'ISO',
         groups: [{
           name: group.reference,
@@ -90,7 +89,8 @@ async function fetchInfoFromISO(specs, options) {
       if (!copy.series) {
         copy.series = {};
       }
-      copy.series.shortname = isoInfo?.series.shortname ?? spec.__last?.series.shortname;
+      copy.series.shortname = isoInfo?.shortname ?? spec.__last?.series.shortname;
+      copy.series.currentSpecification = isoInfo?.shortname ?? spec.__last?.series.currentSpecification;
       return copy;
     }
     else {

--- a/test/fetch-iso-info.js
+++ b/test/fetch-iso-info.js
@@ -54,6 +54,7 @@ describe("The ISO catalog module", async function () {
     assert.ok(specs[0]);
     assert.equal(specs[0].shortname, "iso18074");
     assert.equal(specs[0].series?.shortname, "iso18074");
+    assert.equal(specs[0].series?.currentSpecification, "iso18074");
     assert.equal(specs[0].source, "iso");
     assert.equal(specs[0].title, "Textiles — Identification of some animal fibres by DNA analysis method — Cashmere, wool, yak and their blends");
     assert.equal(specs[0].organization, "ISO");
@@ -69,6 +70,7 @@ describe("The ISO catalog module", async function () {
     assert.ok(specs[0]);
     assert.equal(specs[0].shortname, "iso10918-5");
     assert.equal(specs[0].series?.shortname, "iso10918-5");
+    assert.equal(specs[0].series?.currentSpecification, "iso10918-5");
     assert.equal(specs[0].source, "iso");
     assert.equal(specs[0].title, "Information technology — Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF) — Part 5:");
     assert.equal(specs[0].organization, "ISO/IEC");


### PR DESCRIPTION
Missed another hiccup, should be the last one! ;)

The `series.currentSpecification` property is set before the code that processes ISO specs is run, and thus relies on the *computed* shortname, which isn't the final one for ISO specs.

Code that processes ISO specs now overrides that property with the actual spec shortname (note: we don't have a notion of levels for ISO specs today)