### PR TITLE
Update URL of Cookie Store API following move to WHATWG

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -65,6 +65,12 @@
   "https://compression.spec.whatwg.org/",
   "https://console.spec.whatwg.org/",
   {
+    "url": "https://cookiestore.spec.whatwg.org/",
+    "formerNames": [
+      "cookie-store"
+    ]
+  },
+  {
     "url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
     "nightly": {
       "repository": "https://github.com/privacycg/CHIPS",
@@ -715,7 +721,6 @@
     ]
   },
   "https://wicg.github.io/content-index/spec/",
-  "https://wicg.github.io/cookie-store/",
   "https://wicg.github.io/crash-reporting/",
   {
     "url": "https://wicg.github.io/csp-next/scripting-policy.html",


### PR DESCRIPTION
Via https://github.com/web-platform-tests/wpt/pull/54005#issuecomment-3127534609

The spec's shortname will also change from `cookie-store` to `cookiestore`. Recording the former name in `formerNames`.