### PR TITLE
Skip series title test on ttml-imsc1.3

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -145,7 +145,7 @@ describe("The `index.json` list", () => {
       .filter(s => !s.title.includes(s.series.title))
       .filter(s => ![
           "webrtc", "css-backgrounds-4", "n-quads", "DOM-Level-2-Style",
-          "ttml2"
+          "ttml2", "ttml-imsc1.3"
         ].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
Version 1.3 has a different title because it only contains a text profile. Adding it to the list of exceptions.