### PR TITLE
Add WCAG 2.2 (current spec) and WCAG 3.0

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1855,6 +1855,13 @@
   },
   "https://www.w3.org/TR/wasm-js-api-2/",
   "https://www.w3.org/TR/wasm-web-api-2/",
+  {
+    "url": "https://www.w3.org/TR/WCAG22/",
+    "series": {
+      "shortname": "wcag"
+    }
+  },
+  "https://www.w3.org/TR/wcag-3.0/",
   "https://www.w3.org/TR/web-animations-1/",
   "https://www.w3.org/TR/web-animations-2/ delta",
   "https://www.w3.org/TR/web-locks/",

--- a/specs.json
+++ b/specs.json
@@ -1856,12 +1856,17 @@
   "https://www.w3.org/TR/wasm-js-api-2/",
   "https://www.w3.org/TR/wasm-web-api-2/",
   {
+    "url": "https://www.w3.org/TR/wcag-3.0/",
+    "nightly": {
+      "sourcePath": "src/pages/guidelines/index.astro"
+    }
+  },
+  {
     "url": "https://www.w3.org/TR/WCAG22/",
     "series": {
       "shortname": "wcag"
     }
   },
-  "https://www.w3.org/TR/wcag-3.0/",
   "https://www.w3.org/TR/web-animations-1/",
   "https://www.w3.org/TR/web-animations-2/ delta",
   "https://www.w3.org/TR/web-locks/",


### PR DESCRIPTION
Close #2066, adding also WCAG 2.2 because it is the current specification in the series. Note the need to override the series shortname for WCAG 2.2, as the series shortname is now lower-case, and the need to skip a couple of tests as WCAG 3.0 title is different, and as there is no obvious source file for the spec (it gets generated from a mix of files, the entry point is code, not content).

This update would trigger the following changes in `index.json`:

<details><summary>Add spec (2)</summary>

```json
{
  "url": "https://www.w3.org/TR/WCAG22/",
  "seriesComposition": "full",
  "shortname": "WCAG22",
  "series": {
    "shortname": "wcag",
    "currentSpecification": "WCAG22",
    "title": "Web Content Accessibility Guidelines (WCAG)",
    "shortTitle": "WCAG",
    "releaseUrl": "https://www.w3.org/TR/wcag/",
    "nightlyUrl": "https://w3c.github.io/wcag/guidelines/22/"
  },
  "seriesVersion": "2.2",
  "seriesNext": "wcag-3.0",
  "organization": "W3C",
  "groups": [
    {
      "name": "Accessibility Guidelines Working Group",
      "url": "https://www.w3.org/WAI/about/groups/agwg/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/WCAG22/",
    "status": "Recommendation",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/wcag/guidelines/22/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/w3c/wcag",
    "sourcePath": "index.html",
    "filename": "index.html"
  },
  "title": "Web Content Accessibility Guidelines (WCAG) 2.2",
  "source": "w3c",
  "shortTitle": "WCAG 2.2",
  "categories": [],
  "standing": "good"
}
```
```json
{
  "url": "https://www.w3.org/TR/wcag-3.0/",
  "seriesComposition": "full",
  "shortname": "wcag-3.0",
  "series": {
    "shortname": "wcag",
    "currentSpecification": "WCAG22",
    "title": "Web Content Accessibility Guidelines (WCAG)",
    "shortTitle": "WCAG",
    "releaseUrl": "https://www.w3.org/TR/wcag/",
    "nightlyUrl": "https://w3c.github.io/wcag/guidelines/22/"
  },
  "seriesVersion": "3.0",
  "seriesPrevious": "WCAG22",
  "organization": "W3C",
  "groups": [
    {
      "name": "Accessibility Guidelines Working Group",
      "url": "https://www.w3.org/WAI/about/groups/agwg/"
    }
  ],
  "release": {
    "url": "https://www.w3.org/TR/wcag-3.0/",
    "status": "Working Draft",
    "filename": "Overview.html"
  },
  "nightly": {
    "url": "https://w3c.github.io/wcag3/guidelines/",
    "status": "Editor's Draft",
    "alternateUrls": [],
    "repository": "https://github.com/w3c/wcag3",
    "filename": "index.html"
  },
  "title": "W3C Accessibility Guidelines (WCAG) 3.0",
  "source": "w3c",
  "shortTitle": "WCAG 3.0",
  "categories": [],
  "standing": "good"
}
```
</details>