### PR TITLE
Add WCAG 3.0 to list of exceptions for series title check

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -145,7 +145,7 @@ describe("The `index.json` list", () => {
       .filter(s => !s.title.includes(s.series.title))
       .filter(s => ![
           "webrtc", "css-backgrounds-4", "n-quads", "DOM-Level-2-Style",
-          "ttml2", "ttml-imsc1.3"
+          "ttml2", "ttml-imsc1.3", "wcag-3.0"
         ].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
Forgot to include that update in PR #2094... As said there, the series title matches the title of the current specification (WCAG 2.2) but WCAG 3.0 introduces a new title.