### PR TITLE
Flag `private-network-access` as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -817,7 +817,13 @@
     "url": "https://wicg.github.io/prefer-current-tab/",
     "standing": "good"
   },
-  "https://wicg.github.io/private-network-access/",
+  {
+    "url": "https://wicg.github.io/private-network-access/",
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "local-network-access"
+    ]
+  },
   "https://wicg.github.io/responsive-image-client-hints/",
   "https://wicg.github.io/sanitizer-api/",
   "https://wicg.github.io/savedata/",


### PR DESCRIPTION
Via #1953.

As explained in https://github.com/WICG/private-network-access/issues/148 and https://developer.chrome.com/blog/local-network-access, the `local-network-access` proposal replaces `private-network-access`, and both specs define (roughly) the same Web IDL in practice.

This update flags the `private-network-access` as being discontinued and obsoleted by `local-network-access`.