### PR TITLE
Drop "delta" status for css-view-transitions-2

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1253,7 +1253,7 @@
     "shortTitle": "CSS Variables 1"
   },
   "https://www.w3.org/TR/css-view-transitions-1/",
-  "https://www.w3.org/TR/css-view-transitions-2/ delta",
+  "https://www.w3.org/TR/css-view-transitions-2/",
   {
     "url": "https://www.w3.org/TR/css-viewport-1/",
     "nightly": {


### PR DESCRIPTION
The Editor's Draft now contains the previous level, and the Web IDL interfaces of Level 1 in particular. Curation in Webref fails accordingly.

Note: the /TR version hasn't been updated yet and is still to be viewed as a delta spec over Level 1. We don't have a way to capture "delta in /TR, non-delta in ED" though in the current data model though. This gives priority to the `nightly` status because that's the reference one for data.