### PR TITLE
Add FIDO CTAP v2.2 and adjust shortnames of FIDO specs

### DIFF
--- a/packages/web-specs/package.json
+++ b/packages/web-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-specs",
-  "version": "3.61.0",
+  "version": "3.61.1",
   "description": "Curated list of technical Web specifications",
   "repository": {
     "type": "git",

--- a/specs.json
+++ b/specs.json
@@ -131,7 +131,7 @@
   "https://fetch.spec.whatwg.org/",
   {
     "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
-    "shortname": "fido-ctap-v2.1",
+    "shortname": "fido-client-to-authenticator-protocol-v2.1",
     "organization": "FIDO Alliance",
     "groups": [
       {
@@ -145,7 +145,7 @@
   },
   {
     "url": "https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#idl-index",
-    "shortname": "fido-ctap-v2.2",
+    "shortname": "fido-client-to-authenticator-protocol-v2.2",
     "organization": "FIDO Alliance",
     "groups": [
       {

--- a/specs.json
+++ b/specs.json
@@ -131,7 +131,21 @@
   "https://fetch.spec.whatwg.org/",
   {
     "url": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
-    "shortname": "fido-v2.1",
+    "shortname": "fido-ctap-v2.1",
+    "organization": "FIDO Alliance",
+    "groups": [
+      {
+        "name": "FIDO2 Technical Working Group",
+        "url": "https://fidoalliance.org/members/working-groups/#fido2-technical-working-group"
+      }
+    ],
+    "formerNames": [
+      "fido-v2.1"
+    ]
+  },
+  {
+    "url": "https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#idl-index",
+    "shortname": "fido-ctap-v2.2",
     "organization": "FIDO Alliance",
     "groups": [
       {


### PR DESCRIPTION
The list already had v2.1. This adds latest version v2.2.

The shortname was `fido-v2.1` which seems too generic given that the FIDO Alliance publishes other specs that we might want to add in the future. Shortnames now have `ctap` to disambiguate.

Fixes #2122.