### PR TITLE
Mark speculation-rules as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -816,7 +816,13 @@
   },
   {
     "url": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-    "shortname": "speculation-rules"
+    "title": "Speculation Rules",
+    "shortname": "speculation-rules",
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "html",
+      "prerendering-revamped"
+    ]
   },
   "https://wicg.github.io/netinfo/",
   "https://wicg.github.io/observable/",


### PR DESCRIPTION
The spec moved mainly to HTML (although still as a pending PR) with some parts moved to `prerendering-revamped`.

Note the need to force the title as the previous spec now has a "Moved to the HTML Standard" title.