### PR TITLE
Update wot-binding-registry url in specs.json

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -622,8 +622,8 @@
   "https://w3c.github.io/webrtc-ice/",
   "https://w3c.github.io/wot-binding-registry/",
   {
-    "shortTitle": "WoT Bindings Registry",
-    "url": "https://w3c.github.io/wot-bindings-registry/"
+    "shortTitle": "WoT Binding Registry",
+    "url": "https://w3c.github.io/wot-binding-registry/"
   },
   {
     "url": "https://webassembly.github.io/branch-hinting/core/bikeshed/",


### PR DESCRIPTION
wot-bindings-registry (plural bindings) doesn't seem to exist, which may have been a typo