### PR TITLE
Make sure alternateUrls are unique

### DIFF
--- a/src/build-index.js
+++ b/src/build-index.js
@@ -290,6 +290,8 @@ async function runInfo(specs) {
 
     // If we're reusing last published discontinued info,
     // forget alternate URLs and rebuild them from scratch.
+    // Also note code may be reusing last published info when some
+    // network timeout occurred while fetching the spec.
     if (res.nightly) {
       if (res.__last?.standing === 'discontinued' &&
           (!res.standing || res.standing === 'discontinued')) {
@@ -298,7 +300,7 @@ async function runInfo(specs) {
       else if (!res.nightly.alternateUrls) {
         res.nightly.alternateUrls = [];
       }
-      res.nightly.alternateUrls = res.nightly.alternateUrls.concat(computeAlternateUrls(res));
+      computeAlternateUrls(res);
     }
 
     return res;

--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -6,15 +6,16 @@
 import computeShortname from "./compute-shortname.js";
 
 export default function (spec) {
-  if (!spec?.url) {
+  if (!spec?.url || !spec?.nightly) {
     throw "Invalid spec object passed as parameter";
   }
-  const alternate = [];
+  const alternate = new Set(spec.nightly.alternateUrls);
+
   // Document well-known patterns also used in other specs
   // datatracker and (now deprecated) tools.ietf.org
   if (spec.organization === "IETF" && spec.url.startsWith("https://www.rfc-editor.org/rfc/")) {
-    alternate.push(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://datatracker.ietf.org/doc/html/"));
-    alternate.push(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://tools.ietf.org/html/"));
+    alternate.add(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://datatracker.ietf.org/doc/html/"));
+    alternate.add(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://tools.ietf.org/html/"));
   }
 
   // Add alternate w3c.github.io URLs for CSS specs
@@ -24,12 +25,12 @@ export default function (spec) {
   // and not for the CSS 2.x series)
   if (spec?.nightly?.url.match(/\/drafts\.csswg\.org/)) {
     const draft = computeShortname(spec.nightly.url);
-    alternate.push(`https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
+    alternate.add(`https://w3c.github.io/csswg-drafts/${draft.shortname}/`);
     if ((spec.series.currentSpecification === spec.shortname) &&
         (draft.shortname !== draft.series.shortname) &&
         (draft.series.shortname !== 'css')) {
-      alternate.push(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
+      alternate.add(`https://w3c.github.io/csswg-drafts/${draft.series.shortname}/`);
     }
   }
-  return alternate;
+  spec.nightly.alternateUrls = Array.from(alternate);
 };


### PR DESCRIPTION
When a network error occurs, build logic reuses previously published information. Code that generates alternate URLs was not expecting that, and duplicated the previous URL as a result.

Code now uses a `Set` to avoid any duplicate. Note it also sets the `alternateUrls` directly for simplicity (and that behavior actually matches the advertized one at the top of the file).