### PR TITLE
Rename `shacl12-inf-rules` to `schacl12-rules`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -573,13 +573,13 @@
   "https://w3c-fedid.github.io/login-status/",
   "https://w3c.github.io/at-driver/",
   "https://w3c.github.io/data-shapes/shacl12-compact-syntax/",
+  "https://w3c.github.io/data-shapes/shacl12-node-expr/",
   {
     "url": "https://w3c.github.io/data-shapes/shacl12-rules/",
     "formerNames": [
       "shacl12-inf-rules"
     ]
   },
-  "https://w3c.github.io/data-shapes/shacl12-node-expr/",
   {
     "shortname": "execCommand",
     "standing": "pending",


### PR DESCRIPTION
Group renamed the spec in https://github.com/w3c/data-shapes/issues/567