### PR TITLE
Throw when spec server returns a 404 response

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -59,7 +59,7 @@ async function useKnownInfoWhereAppropriate(specs) {
 function catchAndFallbackOnExistingData(fn) {
   return function(spec) {
     return fn(spec).catch(err => {
-      if (err.message.match(/ failed with HTTP code 404/)) {
+      if (err.name === 'HttpStatusError' && err.status === 404) {
         // If server returns a 404 status, the spec is no longer available at
         // the expected URL. Data needs to change. Throwing in the absence of
         // a better reporting mechanism so that the error does not end up

--- a/src/load-spec.js
+++ b/src/load-spec.js
@@ -4,6 +4,16 @@
  * cause timeout issues on CSS servers.
  */
 
+class HttpStatusError extends Error {
+  constructor(url, status, statusText) {
+    super(`Could not fetch ${url}, got HTTP status ${status} ${statusText}`);
+    this.name = 'HttpStatusError';
+    this.url = url;
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
 export default async function (url, page) {
   // Inner function that returns a network interception method for Puppeteer,
   // to avoid downloading images and getting stuck on streams.
@@ -48,7 +58,7 @@ export default async function (url, page) {
     const response = await page.goto(url, { timeout: 120000, waitUntil: 'networkidle0' });
 
     if (response.status() !== 200) {
-      throw new Error(`Fetching ${url} failed with HTTP code ${response.status()}`);
+      throw new HttpStatusError(url, response.status(), response.statusText());
     }
     // Wait until the generation of the spec is completely over
     // (same code as in Reffy, except Reffy forces the latest version of

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -230,8 +230,8 @@ describe("fetch-info module", function () {
       await assert.rejects(
         async () => fetchInfo([spec]),
         (err) => {
-          assert.strictEqual(err.name, 'Error');
-          assert.match(err.message, / failed with HTTP code 404/);
+          assert.strictEqual(err.name, 'HttpStatusError');
+          assert.match(err.message, / HTTP status 404/);
           return true;
         }
       );


### PR DESCRIPTION
This is meant to address cases such as #2134 and #2143 where a spec "disappears" following a rename. Build code detected the problem but since we don't have a good reporting mechanism in place, the code simply logged the problem and moved on.

The code now throws when it receives a 404 response from the server, on the grounds that data needs fixing.

The update disables the text on 429 errors. The problem is with the test itself: the spec is loaded in Puppeteer, setting up a mock agent in the test simply does not work. Test still passed because https://example.com/429 returns a 404 and we had the same logic for 404 and 429 errors, but we've just been lucky. Test now fails given that a 404 makes the code throw. To be fixed later on!