### PR TITLE
Add new version of vocab-ssn, rename old one

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1881,7 +1881,17 @@
     "nightly": {
       "sourcePath": "ssn/index.html"
     },
-    "url": "https://www.w3.org/TR/vocab-ssn/"
+    "url": "https://www.w3.org/TR/vocab-ssn-2017/",
+    "formerNames": [
+      "vocab-ssn"
+    ]
+  },
+  {
+    "organization": "W3C/OGC",
+    "nightly": {
+      "sourcePath": "ssn/index.html"
+    },
+    "url": "https://www.w3.org/TR/vocab-ssn-2023/"
   },
   {
     "url": "https://www.w3.org/TR/wai-aria-1.2/",


### PR DESCRIPTION
The `vocab-ssn` shortname now is an alias to `vocab-ssn-2017`, and series has a new `vocab-ssn-2023` working draft.