### PR TITLE
Add former SDW Interest Group to non-browser group list

### DIFF
--- a/src/compute-categories.js
+++ b/src/compute-categories.js
@@ -36,6 +36,7 @@ const nonBrowserGroups = [
   "RDF & SPARQL Working Group",
   "RDF Dataset Canonicalization and Hash Working Group",
   "RDF-star Working Group",
+  "Spatial Data on the Web Interest Group",
   "Spatio-temporal Data on the Web Working Group",
   "Technical Architecture Group",
   "Verifiable Credentials Working Group",


### PR DESCRIPTION
The `vocab-ssn-ext` specification was last published in 2020 by the Spatial Data on the Web Interest Group. Code only knew about the more recent Spatio-temporal Data on the Web Working Group, and incorrectly categorized the spec as targeting browsers.