### PR TITLE
Add RFC9842, replacing `compression-dictionary`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -84,7 +84,6 @@
       "sourcePath": "draft-davidben-http-client-hint-reliability.md"
     }
   },
-  "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary",
   "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-no-vary-search",
   "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
   "https://dom.spec.whatwg.org/",
@@ -990,6 +989,12 @@
     "url": "https://www.rfc-editor.org/rfc/rfc9649",
     "formerNames": [
       "webp"
+    ]
+  },
+  {
+    "url": "https://www.rfc-editor.org/rfc/rfc9842",
+    "formerNames": [
+      "compression-dictionary"
     ]
   },
   "https://www.w3.org/2001/tag/doc/promises-guide",


### PR DESCRIPTION
Draft IETF spec has now been published as an RFC. Close #2171.

This would add the following entry (no repository but there aren't any anymore as https://github.com/httpwg/http-extensions/ now merely contains the "previous" draft:

```json
{
  "url": "https://www.rfc-editor.org/rfc/rfc9842",
  "seriesComposition": "full",
  "shortname": "rfc9842",
  "series": {
    "shortname": "rfc9842",
    "currentSpecification": "rfc9842",
    "title": "Compression Dictionary Transport",
    "shortTitle": "Compression Dictionary Transport",
    "nightlyUrl": "https://www.rfc-editor.org/rfc/rfc9842"
  },
  "formerNames": [
    "compression-dictionary"
  ],
  "organization": "IETF",
  "groups": [
    {
      "name": "HTTP Working Group",
      "url": "https://datatracker.ietf.org/wg/httpbis/"
    }
  ],
  "nightly": {
    "url": "https://www.rfc-editor.org/rfc/rfc9842",
    "status": "Proposed Standard",
    "alternateUrls": [
      "https://datatracker.ietf.org/doc/html/rfc9842",
      "https://tools.ietf.org/html/rfc9842"
    ],
    "filename": "rfc9842.html"
  },
  "title": "Compression Dictionary Transport",
  "source": "ietf",
  "shortTitle": "Compression Dictionary Transport",
  "categories": [
    "browser"
  ],
  "standing": "good"
}
```