### PR TITLE
Update URL of css-anchor-position-2

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -93,7 +93,6 @@
     "url": "https://drafts.css-houdini.org/font-metrics-api-1/",
     "standing": "good"
   },
-  "https://drafts.csswg.org/css-anchor-position-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-backgrounds-4/",
     "seriesComposition": "delta",
@@ -1102,6 +1101,7 @@
   "https://www.w3.org/TR/css-2025/",
   "https://www.w3.org/TR/css-align-3/",
   "https://www.w3.org/TR/css-anchor-position-1/",
+  "https://www.w3.org/TR/css-anchor-position-2/ delta",
   "https://www.w3.org/TR/css-animation-worklet-1/",
   "https://www.w3.org/TR/css-animations-1/",
   "https://www.w3.org/TR/css-animations-2/ delta",


### PR DESCRIPTION
Spec was published as FPWD. Fixes #2198.