### PR TITLE
Update URL of wot-binding-registry

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -655,13 +655,6 @@
   },
   "https://w3c.github.io/webrtc-ice/",
   {
-    "url": "https://w3c.github.io/wot-binding-registry/",
-    "shortTitle": "WoT Bindings Registry",
-    "formerNames": [
-      "wot-bindings-registry"
-    ]
-  },
-  {
     "url": "https://webassembly.github.io/branch-hinting/core/bikeshed/",
     "forkOf": "wasm-core-2",
     "title": "WebAssembly Core: Branch Hinting"
@@ -2077,6 +2070,13 @@
   {
     "shortTitle": "WoT Architecture 1.1",
     "url": "https://www.w3.org/TR/wot-architecture11/"
+  },
+  {
+    "url": "https://www.w3.org/TR/wot-binding-registry/",
+    "shortTitle": "WoT Bindings Registry",
+    "formerNames": [
+      "wot-bindings-registry"
+    ]
   },
   {
     "shortTitle": "WoT Discovery",


### PR DESCRIPTION
Spec got published as FPWD. Via #2223