### PR TITLE
Adjust URLs for WebXR plane detection specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -173,15 +173,16 @@
   "https://immersive-web.github.io/body-tracking/",
   "https://immersive-web.github.io/model-element/",
   {
-    "url": "https://immersive-web.github.io/plane-detection/plane-detection.html",
+    "url": "https://immersive-web.github.io/plane-detection/",
     "shortname": "webxr-plane-detection"
   },
-  {
-    "url": "https://immersive-web.github.io/plane-detection/webxrmeshing-1.html",
-    "shortname": "webxr-meshing"
-  },
   "https://immersive-web.github.io/raw-camera-access/",
-  "https://immersive-web.github.io/real-world-meshing/",
+  {
+    "url": "https://immersive-web.github.io/real-world-meshing/",
+    "formerNames": [
+      "webxr-meshing"
+    ]
+  },
   "https://infra.spec.whatwg.org/",
   "https://mimesniff.spec.whatwg.org/",
   "https://notifications.spec.whatwg.org/",


### PR DESCRIPTION
Spec files got further renamed and the `webxr-meshing` spec was removed from the `plane-detection` repository. The commit message notes that the spec was the precursor for the `real-world-meshing` spec:
https://github.com/immersive-web/plane-detection/commit/50ef17fd22b4bf9839f390cfc58740dbf4a30392

This update adjusts the URL of the `webxr-plane-detection` spec and removes `webxr-meshing`, making it a former name of `real-world-meshing`.