### PR TITLE
Adjust URL of filter-effects-2 draft spec

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -126,9 +126,9 @@
     "url": "https://drafts.csswg.org/css-variables-2/",
     "shortTitle": "CSS Variables 2"
   },
+  "https://drafts.csswg.org/filter-effects-2/ delta",
   "https://drafts.csswg.org/pointer-animations-1/",
   "https://drafts.csswg.org/selectors-5/ delta",
-  "https://drafts.fxtf.org/filter-effects-2/ delta",
   "https://encoding.spec.whatwg.org/",
   "https://fetch.spec.whatwg.org/",
   {


### PR DESCRIPTION
The spec was moved to the CSSWG repository.

Note: that's the only remaining FXTF URL that we had in browser-specs. Build will not work right away as W3C API still returns a couple of other FXTF URLs. Should get updated soon!
