### PR TITLE
Adjust series title test exception for TTML-IMSC

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -145,7 +145,7 @@ describe("The `index.json` list", () => {
       .filter(s => !s.title.includes(s.series.title))
       .filter(s => ![
           "webrtc", "css-backgrounds-4", "n-quads", "DOM-Level-2-Style",
-          "ttml2", "ttml-imsc1.3", "wcag-3.0"
+          "ttml2", "ttml-imsc1.2", "wcag-3.0"
         ].includes(s.shortname));
     assert.deepStrictEqual(wrong, []);
   });


### PR DESCRIPTION
The title of the spec got updated in v1.3. We used to have an exception to the rule for the test that checks alignment between the series title and the spec title. The series tile for the `ttml-imsc` series has now been updated to match that of v1.3, and the exception thus now needs to apply to v1.2 instead of 1.3.

Note: tests will fail given that index.json has not been updated yet. But this should actually fix the build.