### PR TITLE
Add `css-shadow`, replacing `css-scoping` and `css-shadow-parts`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -117,6 +117,13 @@
   "https://drafts.csswg.org/css-link-params-1/",
   "https://drafts.csswg.org/css-navigation-1/",
   "https://drafts.csswg.org/css-page-4/ delta",
+  {
+    "url": "https://drafts.csswg.org/css-shadow-1/",
+    "formerNames": [
+      "css-scoping-1",
+      "css-shadow-parts-1"
+    ]
+  },
   "https://drafts.csswg.org/css-shapes-2/ delta",
   {
     "url": "https://drafts.csswg.org/css-size-adjust-1/",
@@ -1258,12 +1265,10 @@
   "https://www.w3.org/TR/css-rhythm-1/",
   "https://www.w3.org/TR/css-round-display-1/",
   "https://www.w3.org/TR/css-ruby-1/",
-  "https://www.w3.org/TR/css-scoping-1/",
   "https://www.w3.org/TR/css-scroll-anchoring-1/",
   "https://www.w3.org/TR/css-scroll-snap-1/",
   "https://www.w3.org/TR/css-scroll-snap-2/ delta",
   "https://www.w3.org/TR/css-scrollbars-1/",
-  "https://www.w3.org/TR/css-shadow-parts-1/",
   "https://www.w3.org/TR/css-shapes-1/",
   {
     "url": "https://www.w3.org/TR/css-sizing-3/",


### PR DESCRIPTION
The CSS WG has enacted an old resolution to move the work on `@scope` to `css-cascade-6` and merge remaining parts of `css-scoping-1` and `css-shadow-parts-1` into a new `css-shadow-1` spec: https://github.com/w3c/csswg-drafts/issues/5809#issuecomment-910896765

The Editor's Drafts of the older specs no longer exist and need to be dropped from browser-specs (they should be republished as discontinued specs).