### PR TITLE
Revert marking JSON Parse with Source as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -539,13 +539,7 @@
       "ecmascript"
     ]
   },
-  {
-    "url": "https://tc39.es/proposal-json-parse-with-source/",
-    "standing": "discontinued",
-    "obsoletedBy": [
-      "ecmascript"
-    ]
-  },
+  "https://tc39.es/proposal-json-parse-with-source/",
   {
     "url": "https://tc39.es/proposal-math-sum/",
     "standing": "discontinued",


### PR DESCRIPTION
Not yet merged in main spec, see also https://github.com/w3c/browser-specs/pull/2319#issuecomment-3807920724