### PR TITLE
Force standing of `tc39-json-parse-with-source` proposal

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -539,7 +539,10 @@
       "ecmascript"
     ]
   },
-  "https://tc39.es/proposal-json-parse-with-source/",
+  {
+    "url": "https://tc39.es/proposal-json-parse-with-source/",
+    "standing": "good"
+  },
   {
     "url": "https://tc39.es/proposal-math-sum/",
     "standing": "discontinued",


### PR DESCRIPTION
We flagged the entry as "discontinued" by mistake and released a version of web-specs with that status. The build code now takes that released information as granted. This is a good mechanism in general as discontinued specs tend to disappear over time. This does not help however when we make a mistake and need to change the standing again.

This update makes the "good" standing explicit for the spec to prevent the build from using the discontinued info. We can rollback that change once we publish a new version of web-specs where the spec is no longer discontinued.

Via https://github.com/w3c/browser-specs/pull/2323#issuecomment-3811845860