### PR TITLE
TC39 Proposal: Add legacy RegExp features proposal URL to specs.json

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -172,6 +172,10 @@
       "sourcePath": "source"
     }
   },
+  {
+    "url": "https://github.com/tc39/proposal-regexp-legacy-features",
+    "shortTitle": "Legacy RegExp features in JavaScript"
+  },
   "https://immersive-web.github.io/anchors/",
   "https://immersive-web.github.io/body-tracking/",
   "https://immersive-web.github.io/model-element/",


### PR DESCRIPTION
The https://github.com/tc39/proposal-regexp-legacy-features proposal reached stage 3. I need to add it as a spec for Browser compatibility data https://github.com/mdn/browser-compat-data/pull/28999

Hope this is correct approach!