### PR TITLE
Rename `permission-elements` to `geolocation-element`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -901,8 +901,11 @@
   "https://wicg.github.io/page-lifecycle/",
   "https://wicg.github.io/paymentlink/",
   {
-    "shortname": "permission-elements",
-    "url": "https://wicg.github.io/PEPC/permission-elements.html"
+    "shortname": "geolocation-element",
+    "url": "https://wicg.github.io/PEPC/geolocation-element.html",
+    "formerNames": [
+      "permission-elements"
+    ]
   },
   "https://wicg.github.io/performance-measure-memory/",
   "https://wicg.github.io/periodic-background-sync/",


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/2107#issuecomment-3968014473

The `<geolocation>` element is now defined in a separate spec. The `<permission>` element is no longer pursued. The attempt to get these elements under a single spec is no longer pursued either.