### PR TITLE
Add svgwg.org as alternate URL for SVG2, adjust test matching

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1855,7 +1855,15 @@
   "https://www.w3.org/TR/svg-paths/",
   "https://www.w3.org/TR/svg-strokes/",
   "https://www.w3.org/TR/SVG11/ multipage",
-  "https://www.w3.org/TR/SVG2/ multipage",
+  {
+    "url": "https://www.w3.org/TR/SVG2/",
+    "multipage": "all",
+    "nightly": {
+      "alternateUrls": [
+        "https://svgwg.org/svg2-draft/"
+      ]
+    }
+  },
   {
     "url": "https://www.w3.org/TR/test-methodology/",
     "categories": [

--- a/src/determine-testpath.js
+++ b/src/determine-testpath.js
@@ -163,10 +163,16 @@ export default async function (specs, options) {
     // Note the use of startsWith below, needed to cover cases where a META.yml
     // file targets a specific page in a multipage spec (for HTML, typically),
     // or a fragment within a spec.
+    function matchSpecUrl(metaUrl, specUrl) {
+      return metaUrl.startsWith(specUrl) ||
+        metaUrl.startsWith(specUrl.replace(/-\d+\/$/, "/"));
+    }
+    function matchSpec(metaFile, spec) {
+      return matchSpecUrl(metaFile.spec, spec.nightly.url) ||
+        spec.nightly.alternateUrls.find(url => matchSpecUrl(metaFile.spec, url));
+    }
     const folders = wptFolders
-      .filter(item =>
-        item.spec.startsWith(spec.nightly.url) ||
-        item.spec.startsWith(spec.nightly.url.replace(/-\d+\/$/, "/")))
+      .filter(item => matchSpec(item, spec))
       .map(item => item.folder);
     if (folders.length > 0) {
       // Don't list subfolders when parent folder is already in the list


### PR DESCRIPTION
The SVG WG has started to use `w3c.github.io` for the Editor's Draft but the URL is not yet fully official (and the /TR document does not yet reflect that in particular). It may also still be that we end up being able to use `svgwg.org` again. In order to allow Reffy and Webref to crawl the latest version while still allowing other sources to stick to the `svgwg.org` URL for now, this adds the `svgwg.org` URL to the `alternateUrls` field, and adjusts the logic that matches WPT folders to URLs to also consider that field.