### PR TITLE
Update URL of `css-image-animations-1`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -115,7 +115,6 @@
     "seriesComposition": "delta",
     "shortTitle": "CSS GCPM 4"
   },
-  "https://drafts.csswg.org/css-image-animation-1/",
   "https://drafts.csswg.org/css-images-5/ delta",
   "https://drafts.csswg.org/css-link-params-1/",
   "https://drafts.csswg.org/css-navigation-1/",
@@ -1276,6 +1275,7 @@
   "https://www.w3.org/TR/css-grid-2/",
   "https://www.w3.org/TR/css-grid-3/ delta",
   "https://www.w3.org/TR/css-highlight-api-1/",
+  "https://www.w3.org/TR/css-image-animation-1/",
   {
     "url": "https://www.w3.org/TR/css-images-3/",
     "shortTitle": "CSS Images 3"


### PR DESCRIPTION
Spec was published as First Public Working Draft last week. Fix #2435.