### PR TITLE
Add `vc-data-model-2.1` and update nightly URL of 2.0

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1932,7 +1932,13 @@
   "https://www.w3.org/TR/vc-bitstring-status-list/",
   "https://www.w3.org/TR/vc-confidence-method/",
   "https://www.w3.org/TR/vc-data-integrity/",
-  "https://www.w3.org/TR/vc-data-model-2.0/",
+  {
+    "url": "https://www.w3.org/TR/vc-data-model-2.0/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/vc-data-model-2.0/"
+    }
+  },
+  "https://www.w3.org/TR/vc-data-model-2.1/",
   "https://www.w3.org/TR/vc-di-bbs/",
   "https://www.w3.org/TR/vc-di-ecdsa/",
   "https://www.w3.org/TR/vc-di-eddsa/",


### PR DESCRIPTION
Fixes #2436. As the Editor's Draft has now become the Editor's Draft of v2.1, this update also updates the v2.0 entry to use the /TR version as nightly URL, as was done for TTML IMSC 1.2 now that v1.3 is out.