### PR TITLE
Adjust URL of `web-nfc`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -616,6 +616,7 @@
   "https://testutils.spec.whatwg.org/",
   "https://url.spec.whatwg.org/",
   "https://urlpattern.spec.whatwg.org/",
+  "https://w3c-cg.github.io/web-nfc/",
   "https://w3c-fedid.github.io/login-status/",
   "https://w3c.github.io/at-driver/",
   {
@@ -675,7 +676,6 @@
   "https://w3c.github.io/tracestate-ids-registry/",
   "https://w3c.github.io/vc-barcodes/",
   "https://w3c.github.io/vc-recognition/",
-  "https://w3c.github.io/web-nfc/",
   {
     "url": "https://w3c.github.io/web-share-target/",
     "standing": "good"


### PR DESCRIPTION
The spec was moved to the `w3c-cg` repository, and is now served under a `w3c-cg.github.io` URL.