### PR TITLE
Add new versions of published VC specs

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1936,7 +1936,13 @@
   },
   "https://www.w3.org/TR/vc-bitstring-status-list/",
   "https://www.w3.org/TR/vc-confidence-method/",
-  "https://www.w3.org/TR/vc-data-integrity/",
+  "https://www.w3.org/TR/vc-data-integrity-1.1/",
+  {
+    "url": "https://www.w3.org/TR/vc-data-integrity/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/vc-data-integrity/"
+    }
+  },
   {
     "url": "https://www.w3.org/TR/vc-data-model-2.0/",
     "nightly": {
@@ -1945,8 +1951,20 @@
   },
   "https://www.w3.org/TR/vc-data-model-2.1/",
   "https://www.w3.org/TR/vc-di-bbs/",
-  "https://www.w3.org/TR/vc-di-ecdsa/",
-  "https://www.w3.org/TR/vc-di-eddsa/",
+  "https://www.w3.org/TR/vc-di-ecdsa-1.1/",
+  {
+    "url": "https://www.w3.org/TR/vc-di-ecdsa/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/vc-di-ecdsa/"
+    }
+  },
+  "https://www.w3.org/TR/vc-di-eddsa-1.1/",
+  {
+    "url": "https://www.w3.org/TR/vc-di-eddsa/",
+    "nightly": {
+      "url": "https://www.w3.org/TR/vc-di-eddsa/"
+    }
+  },
   "https://www.w3.org/TR/vc-jose-cose/",
   "https://www.w3.org/TR/vc-json-schema/",
   "https://www.w3.org/TR/vc-render-method/",


### PR DESCRIPTION
This adds versions 1.1 of `vc-data-integrity`, `vc-ecdsa`, `vc-eddsa`. Nightly URLs of previous versions 1.0 also get updated to target the /TR URLs directly because the nightly specs are the same for v1.0 and v1.1.

Fixes #2445, #2446, #2447.