### PR TITLE
Rename `vc-recognition` to `vc-recognized-entities`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -673,7 +673,12 @@
   "https://w3c.github.io/trace-context-binary/",
   "https://w3c.github.io/trace-context-mqtt/",
   "https://w3c.github.io/tracestate-ids-registry/",
-  "https://w3c.github.io/vc-recognition/",
+  {
+    "url": "https://w3c.github.io/vc-recognized-entities/",
+    "formerNames": [
+      "vc-recognition"
+    ]
+  },
   {
     "url": "https://w3c.github.io/web-share-target/",
     "standing": "good"


### PR DESCRIPTION
The repository and spec got a new name.