### PR TITLE
Never set the repository when nightly draft is the /TR URL

### DIFF
--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -199,7 +199,7 @@ export default async function (specs, options) {
   // Compute final repo URL and add source file if possible
   for (const spec of specs) {
     const repo = repos.shift();
-    if (repo && await isRealRepo(repo)) {
+    if (repo && repo.type !== 'tr' && await isRealRepo(repo)) {
       spec.nightly.repository = `https://github.com/${repo.owner}/${repo.name}`;
 
       if (options.githubToken && !spec.nightly.sourcePath) {

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -87,6 +87,17 @@ describe("compute-repository module", async () => {
     assert.equal(result[0].nightly, undefined);
   });
 
+  it("returns null when nightly URL is the release URL", async () => {
+    const spec = {
+      url: "https://www.w3.org/TR/vc-data-integrity/",
+      nightly: {
+        url: "https://www.w3.org/TR/vc-data-integrity/"
+      }
+    };
+    const result = await computeRepo([spec]);
+    assert.equal(result[0].nightly.repository, undefined);
+  });
+
   it("returns null when repository cannot be derived from URL", async () => {
     assert.equal(
       await computeSingleRepo("https://example.net/repoless"),


### PR DESCRIPTION
When a Working Group starts working on a new version of a spec and reuses the same Editor's Draft for the new version, we set the nightly URL of the previous version to the /TR URL as a way to avoid associating extracts from the new version with the former one.

When the shortname of the previous version happens to match the name of an existing repository under the W3C organization in GitHub, the code still managed to set a repository for the former version. That's not completely wrong but means that we end up with the same `sourcePath` for the previous version and the new version. A practical example here is `vc-data-integrity`, with a new 1.1 version now being developed.

This update makes sure that the entry for a former version of a spec that shares its nightly draft with a newer version does not get associated with a repository.