### PR TITLE
Add `specs.json` mechanism to drop computation of repository

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -63,43 +63,36 @@
       "enum": ["w3c", "spec", "ietf", "whatwg", "iso"]
     },
 
-    "nightly": {
-      "type": "object",
-      "properties": {
-        "url": { "$ref": "#/$defs/url" },
-        "status": {
-          "type": "string",
-          "enum": [
-            "A Collection of Interesting Ideas",
-            "Draft Community Group Report",
-            "Draft Deliverable",
-            "Draft Finding",
-            "Draft Registry",
-            "Editor's Draft",
-            "Experimental",
-            "Final Deliverable",
-            "Informational",
-            "Internet Standard",
-            "Living Standard",
-            "Proposed Standard",
-            "TAG Finding",
-            "Unofficial Proposal Draft",
-            "Working Group Approved Draft"
-          ]
-        },
-        "alternateUrls": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/url" }
-        },
-        "filename": { "$ref": "#/$defs/filename" },
-        "sourcePath": { "$ref": "#/$defs/relativePath" },
-        "pages": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/url" }
-        },
-        "repository": { "$ref": "#/$defs/url" }
-      },
-      "additionalProperties": false
+    "nightlyStatus": {
+      "type": "string",
+      "enum": [
+        "A Collection of Interesting Ideas",
+        "Draft Community Group Report",
+        "Draft Deliverable",
+        "Draft Finding",
+        "Draft Registry",
+        "Editor's Draft",
+        "Experimental",
+        "Final Deliverable",
+        "Informational",
+        "Internet Standard",
+        "Living Standard",
+        "Proposed Standard",
+        "TAG Finding",
+        "Unofficial Proposal Draft",
+        "Working Group Approved Draft"
+      ]
+    },
+
+    "shortnames": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/shortname" },
+      "minItems": 1
+    },
+
+    "urls": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/url" }
     },
 
     "tests": {
@@ -163,26 +156,9 @@
       ]
     },
 
-    "forks": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/shortname" }
-    },
-
     "standing": {
       "type": "string",
       "enum": ["good", "pending", "discontinued"]
-    },
-
-    "obsoletedBy": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/shortname" },
-      "minItems": 1
-    },
-
-    "formerNames": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/shortname" },
-      "minItems": 1
     },
 
     "specsfile": {
@@ -208,10 +184,7 @@
             ]
           },
           "filename": { "$ref": "#/$defs/filename" },
-          "pages": {
-            "type": "array",
-            "items": { "$ref": "#/$defs/url" }
-          }
+          "pages": { "$ref": "#/$defs/urls" }
         },
         "additionalProperties": false
       }

--- a/schema/index.json
+++ b/schema/index.json
@@ -9,13 +9,25 @@
       "url": { "$ref": "definitions.json#/$defs/url" },
       "shortname": { "$ref": "definitions.json#/$defs/shortname" },
       "forkOf": { "$ref": "definitions.json#/$defs/shortname" },
-      "forks": { "$ref": "definitions.json#/$defs/forks" },
+      "forks": { "$ref": "definitions.json#/$defs/shortnames" },
       "series": { "$ref": "definitions.json#/$defs/series" },
       "seriesVersion": { "$ref": "definitions.json#/$defs/seriesVersion" },
       "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },
       "seriesPrevious": { "$ref": "definitions.json#/$defs/shortname" },
       "seriesNext": { "$ref": "definitions.json#/$defs/shortname" },
-      "nightly": { "$ref": "definitions.json#/$defs/nightly" },
+      "nightly": {
+        "type": "object",
+        "properties": {
+          "url": { "$ref": "definitions.json#/$defs/url" },
+          "status": { "$ref": "definitions.json#/$defs/nightlyStatus" },
+          "alternateUrls": { "$ref": "definitions.json#/$defs/urls" },
+          "filename": { "$ref": "definitions.json#/$defs/filename" },
+          "sourcePath": { "$ref": "definitions.json#/$defs/relativePath" },
+          "pages": { "$ref": "definitions.json#/$defs/urls" },
+          "repository": { "$ref": "definitions.json#/$defs/url" }
+        },
+        "additionalProperties": false
+      },
       "tests": { "$ref": "definitions.json#/$defs/tests" },
       "release": { "$ref": "definitions.json#/$defs/indexfile/release" },
       "title": { "$ref": "definitions.json#/$defs/title" },
@@ -25,8 +37,8 @@
       "groups": { "$ref": "definitions.json#/$defs/groups" },
       "categories": { "$ref": "definitions.json#/$defs/categories" },
       "standing": { "$ref": "definitions.json#/$defs/standing" },
-      "obsoletedBy": { "$ref": "definitions.json#/$defs/obsoletedBy" },
-      "formerNames": { "$ref": "definitions.json#/$defs/formerNames" }
+      "obsoletedBy": { "$ref": "definitions.json#/$defs/shortnames" },
+      "formerNames": { "$ref": "definitions.json#/$defs/shortnames" }
     },
     "required": [
       "url", "shortname", "series", "seriesComposition",

--- a/schema/specs.json
+++ b/schema/specs.json
@@ -18,7 +18,26 @@
           "series": { "$ref": "definitions.json#/$defs/series" },
           "seriesVersion": { "$ref": "definitions.json#/$defs/seriesVersion" },
           "seriesComposition": { "$ref": "definitions.json#/$defs/seriesComposition" },
-          "nightly": { "$ref": "definitions.json#/$defs/nightly" },
+          "nightly": {
+            "type": "object",
+            "properties": {
+              "url": { "$ref": "definitions.json#/$defs/url" },
+              "status": { "$ref": "definitions.json#/$defs/nightlyStatus" },
+              "alternateUrls": {
+                "type": "array",
+                "items": { "$ref": "definitions.json#/$defs/url" }
+              },
+              "filename": { "$ref": "definitions.json#/$defs/filename" },
+              "sourcePath": { "$ref": "definitions.json#/$defs/relativePath" },
+              "repository": {
+                "oneOf": [
+                  { "$ref": "definitions.json#/$defs/url" },
+                  { "type": "null" }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
           "release": { "$ref": "definitions.json#/$defs/specsfile/release" },
           "tests": { "$ref": "definitions.json#/$defs/tests" },
           "title": { "$ref": "definitions.json#/$defs/title" },
@@ -27,8 +46,8 @@
           "groups": { "$ref": "definitions.json#/$defs/groups" },
           "categories": { "$ref": "definitions.json#/$defs/categories-specs" },
           "standing": { "$ref": "definitions.json#/$defs/standing" },
-          "obsoletedBy": { "$ref": "definitions.json#/$defs/obsoletedBy" },
-          "formerNames": { "$ref": "definitions.json#/$defs/formerNames" },
+          "obsoletedBy": { "$ref": "definitions.json#/$defs/shortnames" },
+          "formerNames": { "$ref": "definitions.json#/$defs/shortnames" },
           "forceCurrent": { "type": "boolean" },
           "multipage": {
             "type": "string",

--- a/specs.json
+++ b/specs.json
@@ -1955,7 +1955,8 @@
   {
     "url": "https://www.w3.org/TR/vc-data-integrity/",
     "nightly": {
-      "url": "https://www.w3.org/TR/vc-data-integrity/"
+      "url": "https://www.w3.org/TR/vc-data-integrity/",
+      "repository": null
     }
   },
   {
@@ -1970,14 +1971,16 @@
   {
     "url": "https://www.w3.org/TR/vc-di-ecdsa/",
     "nightly": {
-      "url": "https://www.w3.org/TR/vc-di-ecdsa/"
+      "url": "https://www.w3.org/TR/vc-di-ecdsa/",
+      "repository": null
     }
   },
   "https://www.w3.org/TR/vc-di-eddsa-1.1/",
   {
     "url": "https://www.w3.org/TR/vc-di-eddsa/",
     "nightly": {
-      "url": "https://www.w3.org/TR/vc-di-eddsa/"
+      "url": "https://www.w3.org/TR/vc-di-eddsa/",
+      "repository": null
     }
   },
   "https://www.w3.org/TR/vc-jose-cose/",

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -183,7 +183,7 @@ export default async function (specs, options) {
   }
 
   // Compute GitHub repositories with lowercase owner names
-  const repos = specs.map(spec => spec.nightly ?
+  const repos = specs.map(spec => spec.nightly && (spec.nightly.repository !== null) ?
     parseSpecUrl(spec.nightly.repository ?? spec.nightly.url) :
     null);
 
@@ -199,7 +199,7 @@ export default async function (specs, options) {
   // Compute final repo URL and add source file if possible
   for (const spec of specs) {
     const repo = repos.shift();
-    if (repo && repo.type !== 'tr' && await isRealRepo(repo)) {
+    if (repo && await isRealRepo(repo)) {
       spec.nightly.repository = `https://github.com/${repo.owner}/${repo.name}`;
 
       if (options.githubToken && !spec.nightly.sourcePath) {
@@ -213,6 +213,14 @@ export default async function (specs, options) {
       const draftName = spec.nightly.url.match(/\/(draft-ietf-(.+))\.html$/);
       spec.nightly.repository = 'https://github.com/httpwg/http-extensions';
       spec.nightly.sourcePath = `${draftName[1]}.md`;
+    }
+
+    // The `null` value is used in `specs.json` to drop a repository that
+    // happens to have the same name as the spec's shortname but that does not
+    // contain the nightly version of that spec. Let's get rid of the
+    // instruction now that we've computed the repository
+    if (spec.nightly?.repository === null) {
+      delete spec.nightly.repository;
     }
   }
 

--- a/test/compute-repository.js
+++ b/test/compute-repository.js
@@ -87,11 +87,12 @@ describe("compute-repository module", async () => {
     assert.equal(result[0].nightly, undefined);
   });
 
-  it("returns null when nightly URL is the release URL", async () => {
+  it("returns no repository when instructed to do so", async () => {
     const spec = {
       url: "https://www.w3.org/TR/vc-data-integrity/",
       nightly: {
-        url: "https://www.w3.org/TR/vc-data-integrity/"
+        url: "https://www.w3.org/TR/vc-data-integrity/",
+        repository: null
       }
     };
     const result = await computeRepo([spec]);


### PR DESCRIPTION
This reverts #2457 because there are /TR specs that use auto-publish and do not have any Editor's Draft on purpose, but still have a repository that we want to keep track of. One example is `device-memory-1`:
 https://www.w3.org/TR/device-memory-1/

This update adds a mechanism that allows setting `repository` to `null` in the `specs.json` file, to prevent the computation of the repository for the entry.

@dontcallmedom I'm actually wondering whether it wouldn't be preferable to just relax the test "there can be no two entries with the same repository + sourcePath" as the data isn't really incorrect.