### PR TITLE
[Issues monitoring] Fix last reviewed time collection

### DIFF
--- a/src/monitor-specs.js
+++ b/src/monitor-specs.js
@@ -90,7 +90,7 @@ async function fetchIssuesToReview() {
                   name
                 }
               }
-              timelineItems(last: 5, itemTypes: UNLABELED_EVENT) {
+              timelineItems(last: 1, itemTypes: UNLABELED_EVENT) {
                 nodes {
                   ... on UnlabeledEvent {
                     label {


### PR DESCRIPTION
The code assumed that the GraphQL API would sort events by descending date. That does not seem to be the case. Now, the API request returned the last 5 such events, but we only need the last one in practice. This update reduces the `last` query parameter to 1 accordingly.