### PR TITLE
Find new specs: strip XSSI prefix when fetching JSON

### DIFF
--- a/src/fetch-json.js
+++ b/src/fetch-json.js
@@ -13,6 +13,11 @@ const fetchQueue = new ThrottledQueue({
 // same fetch request again and again
 const cache = {};
 
+// Chrome status prefixes JSON responses with an XSSI prefix for extra
+// security.
+const reXSSIPrefix = /^\)\]\}'\n/;
+
+
 /**
  * Fetch a JSON URL
  */
@@ -29,9 +34,10 @@ export default async function (url, options) {
   }
 
   try {
-    const body = await res.json();
-    cache[url] = body;
-    return structuredClone(body);
+    const body = await res.text();
+    const json = JSON.parse(body.replace(reXSSIPrefix, ''));
+    cache[url] = json;
+    return structuredClone(json);
   }
   catch (err) {
     throw new Error(`Server returned invalid JSON for ${url}`);


### PR DESCRIPTION
Chrome Status added an XSSI prefix to all JSON requests a couple of weeks ago, see: https://github.com/GoogleChrome/chromium-dashboard/pull/6371

This makes the JSON invalid on purpose. That prefix needs to be dropped before the response may be parsed as JSON.