### PR TITLE
Adjust URLs of IETF RFCs to avoid redirects

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1018,78 +1018,78 @@
     "url": "https://www.iso.org/standard/87621.html",
     "shortTitle": "Open Font Format"
   },
-  "https://www.rfc-editor.org/rfc/rfc2397",
+  "https://www.rfc-editor.org/info/rfc2397",
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc4120",
+    "url": "https://www.rfc-editor.org/info/rfc4120",
     "shortTitle": "Kerberos"
   },
-  "https://www.rfc-editor.org/rfc/rfc5861",
-  "https://www.rfc-editor.org/rfc/rfc6265",
+  "https://www.rfc-editor.org/info/rfc5861",
+  "https://www.rfc-editor.org/info/rfc6265",
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc6266",
+    "url": "https://www.rfc-editor.org/info/rfc6266",
     "shortTitle": "Content-Disposition in HTTP"
   },
-  "https://www.rfc-editor.org/rfc/rfc6386",
-  "https://www.rfc-editor.org/rfc/rfc6454",
-  "https://www.rfc-editor.org/rfc/rfc6455",
-  "https://www.rfc-editor.org/rfc/rfc6797",
-  "https://www.rfc-editor.org/rfc/rfc7034",
-  "https://www.rfc-editor.org/rfc/rfc7230",
-  "https://www.rfc-editor.org/rfc/rfc7231",
-  "https://www.rfc-editor.org/rfc/rfc7232",
-  "https://www.rfc-editor.org/rfc/rfc7233",
-  "https://www.rfc-editor.org/rfc/rfc7234",
-  "https://www.rfc-editor.org/rfc/rfc7235",
-  "https://www.rfc-editor.org/rfc/rfc7239",
-  "https://www.rfc-editor.org/rfc/rfc7240",
-  "https://www.rfc-editor.org/rfc/rfc7469",
-  "https://www.rfc-editor.org/rfc/rfc7538",
-  "https://www.rfc-editor.org/rfc/rfc7540",
-  "https://www.rfc-editor.org/rfc/rfc7578",
-  "https://www.rfc-editor.org/rfc/rfc7616",
-  "https://www.rfc-editor.org/rfc/rfc7617",
-  "https://www.rfc-editor.org/rfc/rfc7725",
-  "https://www.rfc-editor.org/rfc/rfc7838",
-  "https://www.rfc-editor.org/rfc/rfc7932",
-  "https://www.rfc-editor.org/rfc/rfc8246",
-  "https://www.rfc-editor.org/rfc/rfc8288",
-  "https://www.rfc-editor.org/rfc/rfc8297",
-  "https://www.rfc-editor.org/rfc/rfc8470",
+  "https://www.rfc-editor.org/info/rfc6386",
+  "https://www.rfc-editor.org/info/rfc6454",
+  "https://www.rfc-editor.org/info/rfc6455",
+  "https://www.rfc-editor.org/info/rfc6797",
+  "https://www.rfc-editor.org/info/rfc7034",
+  "https://www.rfc-editor.org/info/rfc7230",
+  "https://www.rfc-editor.org/info/rfc7231",
+  "https://www.rfc-editor.org/info/rfc7232",
+  "https://www.rfc-editor.org/info/rfc7233",
+  "https://www.rfc-editor.org/info/rfc7234",
+  "https://www.rfc-editor.org/info/rfc7235",
+  "https://www.rfc-editor.org/info/rfc7239",
+  "https://www.rfc-editor.org/info/rfc7240",
+  "https://www.rfc-editor.org/info/rfc7469",
+  "https://www.rfc-editor.org/info/rfc7538",
+  "https://www.rfc-editor.org/info/rfc7540",
+  "https://www.rfc-editor.org/info/rfc7578",
+  "https://www.rfc-editor.org/info/rfc7616",
+  "https://www.rfc-editor.org/info/rfc7617",
+  "https://www.rfc-editor.org/info/rfc7725",
+  "https://www.rfc-editor.org/info/rfc7838",
+  "https://www.rfc-editor.org/info/rfc7932",
+  "https://www.rfc-editor.org/info/rfc8246",
+  "https://www.rfc-editor.org/info/rfc8288",
+  "https://www.rfc-editor.org/info/rfc8297",
+  "https://www.rfc-editor.org/info/rfc8470",
   {
     "shortTitle": "CDDL",
-    "url": "https://www.rfc-editor.org/rfc/rfc8610"
+    "url": "https://www.rfc-editor.org/info/rfc8610"
   },
-  "https://www.rfc-editor.org/rfc/rfc8878",
-  "https://www.rfc-editor.org/rfc/rfc8942",
-  "https://www.rfc-editor.org/rfc/rfc9110",
-  "https://www.rfc-editor.org/rfc/rfc9111",
-  "https://www.rfc-editor.org/rfc/rfc9112",
-  "https://www.rfc-editor.org/rfc/rfc9113",
-  "https://www.rfc-editor.org/rfc/rfc9114",
+  "https://www.rfc-editor.org/info/rfc8878",
+  "https://www.rfc-editor.org/info/rfc8942",
+  "https://www.rfc-editor.org/info/rfc9110",
+  "https://www.rfc-editor.org/info/rfc9111",
+  "https://www.rfc-editor.org/info/rfc9112",
+  "https://www.rfc-editor.org/info/rfc9113",
+  "https://www.rfc-editor.org/info/rfc9114",
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc9163",
+    "url": "https://www.rfc-editor.org/info/rfc9163",
     "nightly": {
       "repository": "https://github.com/httpwg/http-extensions",
       "sourcePath": "archive/draft-ietf-httpbis-expect-ct.md"
     }
   },
-  "https://www.rfc-editor.org/rfc/rfc9218",
-  "https://www.rfc-editor.org/rfc/rfc9421",
+  "https://www.rfc-editor.org/info/rfc9218",
+  "https://www.rfc-editor.org/info/rfc9421",
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc9530",
+    "url": "https://www.rfc-editor.org/info/rfc9530",
     "formerNames": [
       "digest-headers"
     ]
   },
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc9649",
+    "url": "https://www.rfc-editor.org/info/rfc9649",
     "formerNames": [
       "webp"
     ]
   },
-  "https://www.rfc-editor.org/rfc/rfc9659",
+  "https://www.rfc-editor.org/info/rfc9659",
   {
-    "url": "https://www.rfc-editor.org/rfc/rfc9842",
+    "url": "https://www.rfc-editor.org/info/rfc9842",
     "formerNames": [
       "compression-dictionary"
     ]

--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -13,9 +13,9 @@ export default function (spec) {
 
   // Document well-known patterns also used in other specs
   // datatracker and (now deprecated) tools.ietf.org
-  if (spec.organization === "IETF" && spec.url.startsWith("https://www.rfc-editor.org/rfc/")) {
-    alternate.add(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://datatracker.ietf.org/doc/html/"));
-    alternate.add(spec.url.replace("https://www.rfc-editor.org/rfc/", "https://tools.ietf.org/html/"));
+  if (spec.organization === "IETF" && spec.url.startsWith("https://www.rfc-editor.org/info/")) {
+    alternate.add(spec.url.replace("https://www.rfc-editor.org/info/", "https://datatracker.ietf.org/doc/html/"));
+    alternate.add(spec.url.replace("https://www.rfc-editor.org/info/", "https://tools.ietf.org/html/"));
   }
 
   // Add alternate w3c.github.io URLs for CSS specs

--- a/src/compute-shortname.js
+++ b/src/compute-shortname.js
@@ -99,7 +99,7 @@ function computeShortname(url) {
     }
 
     // Handle IETF RFCs
-    const rfcs = url.match(/\/www.rfc-editor\.org\/rfc\/(rfc[0-9]+)/);
+    const rfcs = url.match(/\/www\.rfc-editor\.org\/info\/(rfc[0-9]+)/);
     if (rfcs) {
       return rfcs[1];
     }

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -47,7 +47,7 @@ export default async function (specs, options) {
     if (!info) {
       // For IETF documents, retrieve the group info from datatracker
       const ietfName =
-        spec.url.match(/rfc-editor\.org\/rfc\/([^\/]+)/) ??
+        spec.url.match(/rfc-editor\.org\/info\/([^\/]+)/) ??
         spec.url.match(/datatracker\.ietf\.org\/doc\/html\/([^\/]+)/);
       if (ietfName) {
         spec.organization = spec.organization ?? "IETF";

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -269,7 +269,7 @@ async function fetchInfoFromIETF(specs, options) {
 
     // Retrieve information about the spec
     const draftName =
-      spec.url.match(/rfc-editor\.org\/rfc\/([^\/]+)/) ??
+      spec.url.match(/rfc-editor\.org\/info\/([^\/]+)/) ??
       spec.url.match(/datatracker\.ietf\.org\/doc\/html\/([^\/]+)/);
     if (!draftName) {
       throw new Error(`IETF document follows an unexpected URL pattern: ${spec.url}`);
@@ -290,7 +290,7 @@ async function fetchInfoFromIETF(specs, options) {
         nightly = `https://httpwg.org/specs/${lastRevision.name}.html`
       }
       else {
-        nightly = `https://www.rfc-editor.org/rfc/${lastRevision.name}`;
+        nightly = `https://www.rfc-editor.org/info/${lastRevision.name}`;
       }
     }
     else if (jsonDoc.group?.acronym === 'httpbis' || jsonDoc.group?.acronym === 'httpstate') {

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -54,7 +54,7 @@ describe("compute-shortname module", () => {
     });
 
     it("handles IETF RFCs", () => {
-      assertName("https://www.rfc-editor.org/rfc/rfc2397", "rfc2397");
+      assertName("https://www.rfc-editor.org/info/rfc2397", "rfc2397");
     });
 
     it("handles IETF group drafts", () => {

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -58,7 +58,7 @@ describe("fetch-groups module (without API keys)", function () {
   });
 
   it("handles IETF RFCs", timeout, async () => {
-    const res = await fetchGroupsFor("https://www.rfc-editor.org/rfc/rfc9110");
+    const res = await fetchGroupsFor("https://www.rfc-editor.org/info/rfc9110");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
       name: "HTTP Working Group",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -46,19 +46,19 @@ describe("fetch-info module", function () {
   describe("fetch from IETF datatracker", () => {
     it("fetches info about RFCs from datatracker", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/rfc/rfc7578",
+        url: "https://www.rfc-editor.org/info/rfc7578",
         shortname: "rfc7578"
       };
       const info = await fetchInfo([spec]);
       assert.ok(info[spec.shortname]);
       assert.equal(info[spec.shortname].title, "Returning Values from Forms: multipart/form-data");
       assert.equal(info[spec.shortname].source, "ietf");
-      assert.equal(info[spec.shortname].nightly.url, "https://www.rfc-editor.org/rfc/rfc7578");
+      assert.equal(info[spec.shortname].nightly.url, "https://www.rfc-editor.org/info/rfc7578");
     });
 
     it("fetches info about HTTP WG RFCs from datatracker", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/rfc/rfc9110",
+        url: "https://www.rfc-editor.org/info/rfc9110",
         shortname: "rfc9110"
       };
       const info = await fetchInfo([spec]);
@@ -92,7 +92,7 @@ describe("fetch-info module", function () {
 
     it("extracts a suitable nightly URL from an IETF HTTP State Management Mechanism WG RFC", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/rfc/rfc6265",
+        url: "https://www.rfc-editor.org/info/rfc6265",
         shortname: "rfc6265"
       };
       const info = await fetchInfo([spec]);
@@ -103,7 +103,7 @@ describe("fetch-info module", function () {
 
     it("uses the rfc-editor URL as nightly for an IETF HTTP WG RFC not published under httpwg.org", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/rfc/rfc9163",
+        url: "https://www.rfc-editor.org/info/rfc9163",
         shortname: "rfc9163"
       };
       const info = await fetchInfo([spec]);
@@ -114,9 +114,9 @@ describe("fetch-info module", function () {
 
     it("identifies discontinued IETF specs", timeout, async () => {
       const info = await fetchInfo([
-        { url: "https://www.rfc-editor.org/rfc/rfc7230", shortname: "rfc7230" },
-        { url: "https://www.rfc-editor.org/rfc/rfc9110", shortname: "rfc9110" },
-        { url: "https://www.rfc-editor.org/rfc/rfc9112", shortname: "rfc9112" }
+        { url: "https://www.rfc-editor.org/info/rfc7230", shortname: "rfc7230" },
+        { url: "https://www.rfc-editor.org/info/rfc9110", shortname: "rfc9110" },
+        { url: "https://www.rfc-editor.org/info/rfc9112", shortname: "rfc9112" }
       ]);
       assert.ok(info["rfc7230"]);
       assert.equal(info["rfc7230"].standing, "discontinued");
@@ -125,7 +125,7 @@ describe("fetch-info module", function () {
 
     it("throws when a discontinued IETF spec is obsoleted by an unknown spec", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/rfc/rfc7230",
+        url: "https://www.rfc-editor.org/info/rfc7230",
         shortname: "rfc7230"
       };
       await assert.rejects(

--- a/test/index.js
+++ b/test/index.js
@@ -230,7 +230,7 @@ describe("The `index.json` list", () => {
 
   it("has a datatracker alternate URL for IETF RFCS", () => {
     const wrong = specs
-      .filter(s => s.url.match(/\/www.rfc-editor\.org\/rfc/))
+      .filter(s => s.url.match(/\/www.rfc-editor\.org\/info/))
       .filter(s => {
         const draft = computeShortname(s.url);
         return !s.nightly.alternateUrls.includes(


### PR DESCRIPTION
IETF RFCs had URLs that started with `https://www.rfc-editor.org/rfc/rfcXXXX`. These URLs now redirect to `https://www.rfc-editor.org/info/rfcXXXX` following the release of the new RFC Editor site.

This commit updates all URLs in browser-specs accordingly to avoid redirects, and adjusts the logic used to parse IETF URLs in the different modules.