### PR TITLE
[Breaking] Relax `filename` constraint for RFCs, adjust RFC URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,8 @@ For instance, the filename for `https://www.w3.org/TR/presentation-api/` is
 `https://www.w3.org/TR/presentation-api/Overview.html`. The filename may be
 useful to distinguish links to self in a spec.
 
-The `filename` property is always set.
+The `filename` property is always set, except for IETF specifications
+([`organization`](#organization) is set to `"IETF"` for them).
 
 
 #### `release.pages`
@@ -544,7 +545,8 @@ For instance, the filename for `https://w3c.github.io/presentation-api/` is
 `https://w3c.github.io/presentation-api/index.html`. The filename may be
 useful to distinguish links to self in a spec.
 
-The `filename` property is always set.
+The `filename` property is always set, except for IETF specifications
+([`organization`](#organization) is set to `"IETF"` for them).
 
 
 #### `nightly.pages`

--- a/specs.json
+++ b/specs.json
@@ -1018,78 +1018,78 @@
     "url": "https://www.iso.org/standard/87621.html",
     "shortTitle": "Open Font Format"
   },
-  "https://www.rfc-editor.org/info/rfc2397",
+  "https://www.rfc-editor.org/info/rfc2397/",
   {
-    "url": "https://www.rfc-editor.org/info/rfc4120",
+    "url": "https://www.rfc-editor.org/info/rfc4120/",
     "shortTitle": "Kerberos"
   },
-  "https://www.rfc-editor.org/info/rfc5861",
-  "https://www.rfc-editor.org/info/rfc6265",
+  "https://www.rfc-editor.org/info/rfc5861/",
+  "https://www.rfc-editor.org/info/rfc6265/",
   {
-    "url": "https://www.rfc-editor.org/info/rfc6266",
+    "url": "https://www.rfc-editor.org/info/rfc6266/",
     "shortTitle": "Content-Disposition in HTTP"
   },
-  "https://www.rfc-editor.org/info/rfc6386",
-  "https://www.rfc-editor.org/info/rfc6454",
-  "https://www.rfc-editor.org/info/rfc6455",
-  "https://www.rfc-editor.org/info/rfc6797",
-  "https://www.rfc-editor.org/info/rfc7034",
-  "https://www.rfc-editor.org/info/rfc7230",
-  "https://www.rfc-editor.org/info/rfc7231",
-  "https://www.rfc-editor.org/info/rfc7232",
-  "https://www.rfc-editor.org/info/rfc7233",
-  "https://www.rfc-editor.org/info/rfc7234",
-  "https://www.rfc-editor.org/info/rfc7235",
-  "https://www.rfc-editor.org/info/rfc7239",
-  "https://www.rfc-editor.org/info/rfc7240",
-  "https://www.rfc-editor.org/info/rfc7469",
-  "https://www.rfc-editor.org/info/rfc7538",
-  "https://www.rfc-editor.org/info/rfc7540",
-  "https://www.rfc-editor.org/info/rfc7578",
-  "https://www.rfc-editor.org/info/rfc7616",
-  "https://www.rfc-editor.org/info/rfc7617",
-  "https://www.rfc-editor.org/info/rfc7725",
-  "https://www.rfc-editor.org/info/rfc7838",
-  "https://www.rfc-editor.org/info/rfc7932",
-  "https://www.rfc-editor.org/info/rfc8246",
-  "https://www.rfc-editor.org/info/rfc8288",
-  "https://www.rfc-editor.org/info/rfc8297",
-  "https://www.rfc-editor.org/info/rfc8470",
+  "https://www.rfc-editor.org/info/rfc6386/",
+  "https://www.rfc-editor.org/info/rfc6454/",
+  "https://www.rfc-editor.org/info/rfc6455/",
+  "https://www.rfc-editor.org/info/rfc6797/",
+  "https://www.rfc-editor.org/info/rfc7034/",
+  "https://www.rfc-editor.org/info/rfc7230/",
+  "https://www.rfc-editor.org/info/rfc7231/",
+  "https://www.rfc-editor.org/info/rfc7232/",
+  "https://www.rfc-editor.org/info/rfc7233/",
+  "https://www.rfc-editor.org/info/rfc7234/",
+  "https://www.rfc-editor.org/info/rfc7235/",
+  "https://www.rfc-editor.org/info/rfc7239/",
+  "https://www.rfc-editor.org/info/rfc7240/",
+  "https://www.rfc-editor.org/info/rfc7469/",
+  "https://www.rfc-editor.org/info/rfc7538/",
+  "https://www.rfc-editor.org/info/rfc7540/",
+  "https://www.rfc-editor.org/info/rfc7578/",
+  "https://www.rfc-editor.org/info/rfc7616/",
+  "https://www.rfc-editor.org/info/rfc7617/",
+  "https://www.rfc-editor.org/info/rfc7725/",
+  "https://www.rfc-editor.org/info/rfc7838/",
+  "https://www.rfc-editor.org/info/rfc7932/",
+  "https://www.rfc-editor.org/info/rfc8246/",
+  "https://www.rfc-editor.org/info/rfc8288/",
+  "https://www.rfc-editor.org/info/rfc8297/",
+  "https://www.rfc-editor.org/info/rfc8470/",
   {
     "shortTitle": "CDDL",
-    "url": "https://www.rfc-editor.org/info/rfc8610"
+    "url": "https://www.rfc-editor.org/info/rfc8610/"
   },
-  "https://www.rfc-editor.org/info/rfc8878",
-  "https://www.rfc-editor.org/info/rfc8942",
-  "https://www.rfc-editor.org/info/rfc9110",
-  "https://www.rfc-editor.org/info/rfc9111",
-  "https://www.rfc-editor.org/info/rfc9112",
-  "https://www.rfc-editor.org/info/rfc9113",
-  "https://www.rfc-editor.org/info/rfc9114",
+  "https://www.rfc-editor.org/info/rfc8878/",
+  "https://www.rfc-editor.org/info/rfc8942/",
+  "https://www.rfc-editor.org/info/rfc9110/",
+  "https://www.rfc-editor.org/info/rfc9111/",
+  "https://www.rfc-editor.org/info/rfc9112/",
+  "https://www.rfc-editor.org/info/rfc9113/",
+  "https://www.rfc-editor.org/info/rfc9114/",
   {
-    "url": "https://www.rfc-editor.org/info/rfc9163",
+    "url": "https://www.rfc-editor.org/info/rfc9163/",
     "nightly": {
       "repository": "https://github.com/httpwg/http-extensions",
       "sourcePath": "archive/draft-ietf-httpbis-expect-ct.md"
     }
   },
-  "https://www.rfc-editor.org/info/rfc9218",
-  "https://www.rfc-editor.org/info/rfc9421",
+  "https://www.rfc-editor.org/info/rfc9218/",
+  "https://www.rfc-editor.org/info/rfc9421/",
   {
-    "url": "https://www.rfc-editor.org/info/rfc9530",
+    "url": "https://www.rfc-editor.org/info/rfc9530/",
     "formerNames": [
       "digest-headers"
     ]
   },
   {
-    "url": "https://www.rfc-editor.org/info/rfc9649",
+    "url": "https://www.rfc-editor.org/info/rfc9649/",
     "formerNames": [
       "webp"
     ]
   },
-  "https://www.rfc-editor.org/info/rfc9659",
+  "https://www.rfc-editor.org/info/rfc9659/",
   {
-    "url": "https://www.rfc-editor.org/info/rfc9842",
+    "url": "https://www.rfc-editor.org/info/rfc9842/",
     "formerNames": [
       "compression-dictionary"
     ]

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -365,7 +365,10 @@ async function runFilename(index, { previousIndex, log }) {
         }
         else {
           log(`- determine ${type} filename for ${spec.shortname}`);
-          spec[type].filename = await determineFilename(spec[type].url);
+          const filename = await determineFilename(spec[type].url);
+          if (filename) {
+            spec[type].filename = filename;
+          }
 
           // Sleep a bit as draft CSS WG server does not seem to like receiving too
           // many requests in a row.

--- a/test/index.js
+++ b/test/index.js
@@ -183,13 +183,13 @@ describe("The `index.json` list", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
-  it("contains filenames for all nightly URLs", () => {
-    const wrong = specs.filter(s => s.nightly && !s.nightly.filename);
+  it("contains filenames for all nightly URLs (except RFCs)", () => {
+    const wrong = specs.filter(s => s.nightly && !s.nightly.filename && s.organization !== 'IETF');
     assert.deepStrictEqual(wrong, []);
   });
 
-  it("contains filenames for all release URLs", () => {
-    const wrong = specs.filter(s => s.release && !s.release.filename);
+  it("contains filenames for all release URLs (except RFCs)", () => {
+    const wrong = specs.filter(s => s.release && !s.release.filename && s.organization !== 'IETF');
     assert.deepStrictEqual(wrong, []);
   });
 


### PR DESCRIPTION
The new RFC Editor no longer has a concept of filename. It just serves RFCs wiht a final `/` but there's no filename underneath. This update adjusts the logic to allow for entries without any `filename`. The JSON schema did not make that key mandatory but that was guaranteed by tests and detailed in the README, so this seems worth flagging as a breaking change.

Also, the RFC URLs should have been updated to also include a final `/` to avoid another redirect. Entries updated accordingly.