### PR TITLE
New `--skip-specs` option to `build-index` script

### DIFF
--- a/.github/workflows/build-skip-iso.yml
+++ b/.github/workflows/build-skip-iso.yml
@@ -6,6 +6,11 @@ on:
     # (see build.yml workflow for Saturday and Sunday)
     - cron: '10 */6 * * MON-FRI'
   workflow_dispatch:
+    inputs:
+      skipSpecs:
+        description: "Spec URLs to skip (CSV string)"
+        required: false
+        type: string
 
 jobs:
   fetch:
@@ -37,7 +42,9 @@ jobs:
     - name: Build new index file
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run build-skip-iso
+      run: node src/build-index.js --skip-fetch=iso --skip-specs=$SKIP_SPECS
+      env:
+        SKIP_SPECS: ${{ github.event_name == 'workflow_dispatch' && inputs.skipSpecs || 'none' }}
 
     - name: Test new index file
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
     # (see build-skip-iso.yml workflow for rest of the week)
     - cron: '10 18 * * SAT,SUN'
   workflow_dispatch:
+    inputs:
+      skipSpecs:
+        description: "Spec URLs to skip (CSV string)"
+        required: false
+        type: string
 
 jobs:
   fetch:
@@ -37,7 +42,9 @@ jobs:
     - name: Build new index file
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npm run build
+      run: node src/build-index.js --skip-specs=$SKIP_SPECS
+      env:
+        SKIP_SPECS: ${{ github.event_name == 'workflow_dispatch' && inputs.skipSpecs || 'none' }}
 
     - name: Test new index file
       env:

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -64,7 +64,7 @@ const steps = [
   {
     shortname: "groups",
     title: "Fetch organization/groups info",
-    run: index => fetchGroups(index, { githubToken })
+    run: (index, options) => fetchGroups(index, Object.assign({ githubToken }, options))
   },
   {
     shortname: "info",
@@ -79,7 +79,7 @@ const steps = [
   {
     shortname: "repository",
     title: "Determine repositories",
-    run: index => computeRepository(index, { githubToken })
+    run: (index, options) => computeRepository(index, Object.assign({ githubToken }, options))
   },
   {
     shortname: "standing",
@@ -201,7 +201,7 @@ async function runSkeleton(specs, { log }) {
   return index;
 }
 
-async function runFetchLastPublished(index) {
+async function runFetchLastPublished(index, options) {
   const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'web-specs-'));
   await exec('npm install web-specs', { cwd: tmpdir });
   const lastIndexFile = path.join(tmpdir, 'node_modules', 'web-specs', 'index.json');
@@ -214,7 +214,12 @@ async function runFetchLastPublished(index) {
     const last = lastIndex.find(s => s.shortname === spec.shortname) ??
       lastIndex.find(s => s.url === spec.url);
     if (last) {
+      if (options?.skipSpecs?.includes(spec.url)) {
+        // Goal is to reuse last info in any case
+        spec = structuredClone(last);
+      }
       spec.__last = last;
+
     }
     return spec;
   });
@@ -224,8 +229,8 @@ async function runFetchLastPublished(index) {
   return decoratedIndex;
 }
 
-async function runInfo(specs) {
-  const specInfo = await fetchInfo(specs);
+async function runInfo(specs, options) {
+  const specInfo = await fetchInfo(specs, options);
   const index = specs.map(spec => {
     // Make a copy of the spec object and extend it with the info we retrieved
     // from the source
@@ -329,10 +334,13 @@ async function runShortTitle(index) {
 }
 
 
-async function runPages(index) {
+async function runPages(index, options) {
   const browser = await puppeteer.launch();
   try {
     for (const spec of index) {
+      if (options?.skipSpecs?.includes(spec.url)) {
+        continue;
+      }
       if (spec.release && (spec.multipage === "all" || spec.multipage === "release")) {
         spec.release.pages = await extractPages(spec.release.url, browser);
       }
@@ -392,15 +400,20 @@ async function runFilename(index, { previousIndex, log }) {
  * catalog ("all" may be used as well but does not skip additional fetches
  * for now).
  *
+ * The `skipSpecs` option can be used to make build skip a list of specs,
+ * reusing last published info for them instead. Option takes a comma-separated
+ * list of spec URLs. The option is useful to temporarily skip a spec that's
+ * not available for external reasons to propagate other changes.
+ *
  * The function throws in case of errors.
  */
-async function generateIndex(specs, { step = "all", previousIndex = null, log = console.log, skipFetch = null } = {}) {
+async function generateIndex(specs, { step = "all", previousIndex = null, log = console.log, skipFetch = null, skipSpecs = null } = {}) {
   let index = specs;
 
   const actualSteps = steps.filter(s => step === "all" || s.shortname === step);
   for (const step of actualSteps) {
     log(`${step.title}...`);
-    index = await step.run(index, { previousIndex, log, skipFetch });
+    index = await step.run(index, { previousIndex, log, skipFetch, skipSpecs });
     log(`${step.title}... done`);
   }
 
@@ -446,6 +459,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   for (const cliOption of cliOptions) {
     if (cliOption.startsWith('--skip-fetch=')) {
       options.skipFetch = cliOption.substring('--skip-fetch='.length);
+    }
+    else if (cliOption.startsWith('--skip-specs=')) {
+      options.skipSpecs = cliOption.substring('--skip-specs='.length).split(',');
     }
   }
 

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -462,6 +462,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     }
     else if (cliOption.startsWith('--skip-specs=')) {
       options.skipSpecs = cliOption.substring('--skip-specs='.length).split(',');
+      if (options.skipSpecs[0] === 'none') {
+        delete options.skipSpecs;
+      }
     }
   }
 

--- a/src/compute-repository.js
+++ b/src/compute-repository.js
@@ -49,6 +49,9 @@ export default async function (specs, options) {
   const repoPathCache = new Map();
   const userCache = new Map();
 
+  const filteredSpecs = specs.filter(spec =>
+    !options?.skipSpecs?.includes(spec.url));
+
   /**
    * Take a GitHub repo owner name (lowercase version) and retrieve the real
    * owner name (with possible uppercase characters) from the GitHub API.
@@ -183,7 +186,7 @@ export default async function (specs, options) {
   }
 
   // Compute GitHub repositories with lowercase owner names
-  const repos = specs.map(spec => spec.nightly && (spec.nightly.repository !== null) ?
+  const repos = filteredSpecs.map(spec => spec.nightly && (spec.nightly.repository !== null) ?
     parseSpecUrl(spec.nightly.repository ?? spec.nightly.url) :
     null);
 
@@ -197,7 +200,7 @@ export default async function (specs, options) {
   }
 
   // Compute final repo URL and add source file if possible
-  for (const spec of specs) {
+  for (const spec of filteredSpecs) {
     const repo = repos.shift();
     if (repo && await isRealRepo(repo)) {
       spec.nightly.repository = `https://github.com/${repo.owner}/${repo.name}`;

--- a/src/determine-filename.js
+++ b/src/determine-filename.js
@@ -17,9 +17,9 @@ export default async function (url) {
   }
 
   // RFC-editor HTML rendering
-  const rfcMatch = url.match(/\/rfc\/(rfc[0-9]+)$/);
+  const rfcMatch = url.match(/\/info\/(rfc[0-9]+)$/);
   if (rfcMatch) {
-    return rfcMatch[1] + '.html';
+    return null;
   }
 
   // Make sure that url ends with a "/"

--- a/src/fetch-groups.js
+++ b/src/fetch-groups.js
@@ -37,8 +37,9 @@ export default async function (specs, options) {
   const cache = {};
 
   for (const spec of specs) {
-    if (spec.__last?.standing === 'discontinued' &&
-        (!spec.standing || spec.standing === 'discontinued')) {
+    if (options?.skipSpecs?.includes(spec.url) ||
+        (spec.__last?.standing === 'discontinued' &&
+          (!spec.standing || spec.standing === 'discontinued'))) {
       spec.organization = spec.__last.organization;
       spec.groups = spec.__last.groups;
       continue;

--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -41,11 +41,12 @@ import Octokit from "./octokit.js";
 import ThrottledQueue from "./throttled-queue.js";
 import fetchJSON from "./fetch-json.js";
 
-async function useKnownInfoWhereAppropriate(specs) {
+async function useKnownInfoWhereAppropriate(specs, options) {
   const results = {};
   for (const spec of specs) {
-    if (spec.__last?.standing === 'discontinued' &&
-        (!spec.standing || spec.standing === 'discontinued')) {
+    if (options?.skipSpecs?.includes(spec.url) ||
+        (spec.__last?.standing === 'discontinued' &&
+          (!spec.standing || spec.standing === 'discontinued'))) {
       results[spec.shortname] = spec.__last;
     }
     else if (spec.url.match(/\.iso\.org/)) {


### PR DESCRIPTION
Fixes #2509 by introducing a new option to the build script that takes a comma-separate list of URLs as value and makes the build script reuse the last published info for these entries without trying to gather information for the spec.

The option should only be used to force a build when we run in a situation where one of the specs has a temporary hiccup (as illustrated by the WASM proposal repository deleted by accident), to be able to propagate other changes.