### PR TITLE
Drop trailing slash in IETF alternate URLs

### DIFF
--- a/src/compute-alternate-urls.js
+++ b/src/compute-alternate-urls.js
@@ -14,8 +14,12 @@ export default function (spec) {
   // Document well-known patterns also used in other specs
   // datatracker and (now deprecated) tools.ietf.org
   if (spec.organization === "IETF" && spec.url.startsWith("https://www.rfc-editor.org/info/")) {
-    alternate.add(spec.url.replace("https://www.rfc-editor.org/info/", "https://datatracker.ietf.org/doc/html/"));
-    alternate.add(spec.url.replace("https://www.rfc-editor.org/info/", "https://tools.ietf.org/html/"));
+    alternate.add(spec.url
+      .replace("https://www.rfc-editor.org/info/", "https://datatracker.ietf.org/doc/html/")
+      .replace(/\/$/, ""));
+    alternate.add(spec.url
+      .replace("https://www.rfc-editor.org/info/", "https://tools.ietf.org/html/")
+      .replace(/\/$/, ""));
   }
 
   // Add alternate w3c.github.io URLs for CSS specs


### PR DESCRIPTION
As canonical IETF URLs got a trailing slash, the alternate URLs also did. That's not incorrect (the URLs work and do not lead to a redirect), but since we always had them without a trailing slash, it seems good to keep the same info in the index. CI tests also failed because of that.