### PR TITLE
Fix computation of URLs for IETF specs

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -291,7 +291,7 @@ async function fetchInfoFromIETF(specs, options) {
         nightly = `https://httpwg.org/specs/${lastRevision.name}.html`
       }
       else {
-        nightly = `https://www.rfc-editor.org/info/${lastRevision.name}`;
+        nightly = `https://www.rfc-editor.org/info/${lastRevision.name}/`;
       }
     }
     else if (jsonDoc.group?.acronym === 'httpbis' || jsonDoc.group?.acronym === 'httpstate') {

--- a/test/compute-shortname.js
+++ b/test/compute-shortname.js
@@ -54,7 +54,7 @@ describe("compute-shortname module", () => {
     });
 
     it("handles IETF RFCs", () => {
-      assertName("https://www.rfc-editor.org/info/rfc2397", "rfc2397");
+      assertName("https://www.rfc-editor.org/info/rfc2397/", "rfc2397");
     });
 
     it("handles IETF group drafts", () => {

--- a/test/fetch-groups.js
+++ b/test/fetch-groups.js
@@ -58,7 +58,7 @@ describe("fetch-groups module (without API keys)", function () {
   });
 
   it("handles IETF RFCs", timeout, async () => {
-    const res = await fetchGroupsFor("https://www.rfc-editor.org/info/rfc9110");
+    const res = await fetchGroupsFor("https://www.rfc-editor.org/info/rfc9110/");
     assert.equal(res.organization, "IETF");
     assert.deepStrictEqual(res.groups, [{
       name: "HTTP Working Group",

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -46,19 +46,19 @@ describe("fetch-info module", function () {
   describe("fetch from IETF datatracker", () => {
     it("fetches info about RFCs from datatracker", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/info/rfc7578",
+        url: "https://www.rfc-editor.org/info/rfc7578/",
         shortname: "rfc7578"
       };
       const info = await fetchInfo([spec]);
       assert.ok(info[spec.shortname]);
       assert.equal(info[spec.shortname].title, "Returning Values from Forms: multipart/form-data");
       assert.equal(info[spec.shortname].source, "ietf");
-      assert.equal(info[spec.shortname].nightly.url, "https://www.rfc-editor.org/info/rfc7578");
+      assert.equal(info[spec.shortname].nightly.url, "https://www.rfc-editor.org/info/rfc7578/");
     });
 
     it("fetches info about HTTP WG RFCs from datatracker", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/info/rfc9110",
+        url: "https://www.rfc-editor.org/info/rfc9110/",
         shortname: "rfc9110"
       };
       const info = await fetchInfo([spec]);
@@ -92,7 +92,7 @@ describe("fetch-info module", function () {
 
     it("extracts a suitable nightly URL from an IETF HTTP State Management Mechanism WG RFC", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/info/rfc6265",
+        url: "https://www.rfc-editor.org/info/rfc6265/",
         shortname: "rfc6265"
       };
       const info = await fetchInfo([spec]);
@@ -103,7 +103,7 @@ describe("fetch-info module", function () {
 
     it("uses the rfc-editor URL as nightly for an IETF HTTP WG RFC not published under httpwg.org", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/info/rfc9163",
+        url: "https://www.rfc-editor.org/info/rfc9163/",
         shortname: "rfc9163"
       };
       const info = await fetchInfo([spec]);
@@ -114,9 +114,9 @@ describe("fetch-info module", function () {
 
     it("identifies discontinued IETF specs", timeout, async () => {
       const info = await fetchInfo([
-        { url: "https://www.rfc-editor.org/info/rfc7230", shortname: "rfc7230" },
-        { url: "https://www.rfc-editor.org/info/rfc9110", shortname: "rfc9110" },
-        { url: "https://www.rfc-editor.org/info/rfc9112", shortname: "rfc9112" }
+        { url: "https://www.rfc-editor.org/info/rfc7230/", shortname: "rfc7230" },
+        { url: "https://www.rfc-editor.org/info/rfc9110/", shortname: "rfc9110" },
+        { url: "https://www.rfc-editor.org/info/rfc9112/", shortname: "rfc9112" }
       ]);
       assert.ok(info["rfc7230"]);
       assert.equal(info["rfc7230"].standing, "discontinued");
@@ -125,12 +125,12 @@ describe("fetch-info module", function () {
 
     it("throws when a discontinued IETF spec is obsoleted by an unknown spec", timeout, async () => {
       const spec = {
-        url: "https://www.rfc-editor.org/info/rfc7230",
+        url: "https://www.rfc-editor.org/info/rfc7230/",
         shortname: "rfc7230"
       };
       await assert.rejects(
         fetchInfo([spec]),
-        /^Error: IETF spec at (.*)rfc7230 is obsoleted by rfc9110 which is not in the list.$/);
+        /^Error: IETF spec at (.*)rfc7230\/ is obsoleted by rfc9110 which is not in the list.$/);
     });
 
     it("throws when an IETF URL needs to be updated", timeout, async () => {


### PR DESCRIPTION
I forgot one place where a final `/` needed to be added. And also forgot to update a number of tests to reflect the changes.