### PR TITLE
Flag the Sanitizer API as discontinued

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -943,7 +943,13 @@
     ]
   },
   "https://wicg.github.io/responsive-image-client-hints/",
-  "https://wicg.github.io/sanitizer-api/",
+  {
+    "url": "https://wicg.github.io/sanitizer-api/",
+    "standing": "discontinued",
+    "obsoletedBy": [
+      "html"
+    ]
+  },
   "https://wicg.github.io/savedata/",
   "https://wicg.github.io/scheduling-apis/",
   "https://wicg.github.io/scroll-to-text-fragment/",


### PR DESCRIPTION
The spec was upstreamed to the HTML spec last week, creating dfn and IDL duplicates.

Note that some updates still need to be upstreamed as a follow-up, but these updates do not touch definitions and IDL, and my expectation is that there will be no further work on the incubation afterwards.