### PR TITLE
Add explicit path to source file for `css-nav-1`

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -1338,7 +1338,12 @@
     "shortTitle": "CSS Multicol 2"
   },
   "https://www.w3.org/TR/css-namespaces-3/",
-  "https://www.w3.org/TR/css-nav-1/",
+  {
+    "url": "https://www.w3.org/TR/css-nav-1/",
+    "nightly": {
+      "sourcePath": "css-spatial-nav-1/Overview.bs"
+    }
+  },
   "https://www.w3.org/TR/css-nesting-1/",
   "https://www.w3.org/TR/css-overflow-3/",
   "https://www.w3.org/TR/css-overflow-4/ delta",


### PR DESCRIPTION
The CSS WG adopted a new shortname for the CSS Spatial Navigation spec: `css-spatial-nav-1`. However, the /TR spec currently still uses the former shortname `css-nav-1`. I suspect that will change in the future, but we need to stick to the former shortname in browser-specs in the meantime.

This created a hiccup during build because the code that sets the `sourcePath` property uses the known shortname and thus expects to find the source file under a `css-nav-1` folder.

This update sets the `sourcePath` explicitly to target the `css-spatial-nav-1` folder in the CSS WG repository. To be dropped if and once the spec shortname changes.