### PR TITLE
Auto-flag expired IETF drafts as discontinued drafts

### DIFF
--- a/src/fetch-info.js
+++ b/src/fetch-info.js
@@ -304,7 +304,8 @@ async function fetchInfoFromIETF(specs, options) {
     // For the status, use the std_level property, which contains one of the
     // statuses in https://datatracker.ietf.org/api/v1/name/stdlevelname/
     // The property is null for an unpublished Editor's Draft.
-    const status = jsonDoc.std_level ?? "Editor's Draft";
+    const status = jsonDoc.std_level ??
+      (jsonDoc.state === "Expired" ? "Discontinued Draft" : "Editor's Draft");
 
     const specInfo = { title: jsonDoc.title, nightly, status };
 

--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -114,6 +114,14 @@ describe("fetch-info module", function () {
 
     it("identifies discontinued IETF specs", timeout, async () => {
       const info = await fetchInfo([
+        { url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header/", shortname: "idempotency-key-header" }
+      ]);
+      assert.ok(info["idempotency-key-header"]);
+      assert.equal(info["idempotency-key-header"].nightly?.status, "Discontinued Draft");
+    });
+
+    it("identifies discontinued IETF specs (with new specs)", timeout, async () => {
+      const info = await fetchInfo([
         { url: "https://www.rfc-editor.org/info/rfc7230/", shortname: "rfc7230" },
         { url: "https://www.rfc-editor.org/info/rfc9110/", shortname: "rfc9110" },
         { url: "https://www.rfc-editor.org/info/rfc9112/", shortname: "rfc9112" }


### PR DESCRIPTION
See discussion in #2536. The code that fetches information about an IETF draft now leverages the `state` property in the JSON to set the status to `"Discontinued Draft"` for `"Expired"` IETF drafts.

This will also automatically switch the standing of the underlying spec in browser-specs to `"discontinued"`.

The update will impact the 3 identified expired IETF drafts mentioned in the issue:
- The Idempotency-Key HTTP Header Field
- Client Hint Reliability
- Cookies Having Independent Partitioned State specification