### PR TITLE
Add "Discontinued Draft" status to nightly schema

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -71,6 +71,7 @@
         "Draft Deliverable",
         "Draft Finding",
         "Draft Registry",
+        "Discontinued Draft",
         "Editor's Draft",
         "Experimental",
         "Final Deliverable",


### PR DESCRIPTION
For some reason, the JSON schema only allowed the "Discontinued Draft" status for the `release` version of a spec, probably because that status has only ever been used in a W3C context. As we know use it for some of the IETF drafts, it needs to be allowed for the `nightly` version as well.

Note: While that changes the JSON schema, I would argue that this remains a minor change for consumers.