### PR TITLE
Update URL of shacl12-profiling

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -641,7 +641,6 @@
       "shacl12-compact-syntax"
     ]
   },
-  "https://w3c.github.io/data-shapes/shacl12-profiling/",
   {
     "shortname": "execCommand",
     "standing": "pending",
@@ -1866,6 +1865,7 @@
   "https://www.w3.org/TR/service-workers/",
   "https://www.w3.org/TR/shacl12-core/",
   "https://www.w3.org/TR/shacl12-node-expr/",
+  "https://www.w3.org/TR/shacl12-profiling/",
   {
     "url": "https://www.w3.org/TR/shacl12-rules/",
     "formerNames": [


### PR DESCRIPTION
Spec was published as a First Public Working Draft.

Fixes #2556 (Update done manually as logic does not yet properly handle URL updates)