### PR TITLE
Temporarily disable test on ED fallback

### DIFF
--- a/test/fetch-info.js
+++ b/test/fetch-info.js
@@ -346,13 +346,16 @@ describe("fetch-info module", function () {
       assert.equal(info[other.shortname].title, "High Resolution Time Level 2");
     });
 
+    /*
+    // Need to mock requests, see:
+    // https://github.com/w3c/browser-specs/issues/2565
     it("sets the nightly URL to the release URL as a fallback", timeout, async () => {
       const spec = getW3CSpec("pointerevents3");
       const info = await fetchInfo([spec]);
       assert.ok(info[spec.shortname]);
       assert.equal(info[spec.shortname].source, "w3c");
       assert.equal(info[spec.shortname].nightly.url, "https://www.w3.org/TR/pointerevents3/");
-    });
+    });*/
   });
 
   describe("fetch from all sources", () => {


### PR DESCRIPTION
See #2565 for context and underlying tracking issue.

The test now fails because the spec now points to an actual Editor's Draft. I do not have another real example in mind for now, and the proper solution would be to mock the request in any case. I'm disabling the test in the meantime.