### PR TITLE
Soft Navigations is now "good"

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -983,10 +983,7 @@
     "url": "https://wicg.github.io/sms-one-time-codes/",
     "shortTitle": "SMS One-Time Codes"
   },
-  {
-    "url": "https://wicg.github.io/soft-navigations/",
-    "standing": "pending"
-  },
+  "https://wicg.github.io/soft-navigations/",
   "https://wicg.github.io/storage-buckets/",
   "https://wicg.github.io/trust-token-api/",
   {


### PR DESCRIPTION
The Soft Navigations spec was included [unflagged in Chrome 151](https://chromestatus.com/feature/5144837209194496) so I believe it should no longer be "pending".

It's still in WICG so not yet a "standard", but is up to date and being maintained.