### PR TITLE
Handle empty "Rationale" sections in issues

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -226,7 +226,7 @@ Examples:
           // the Rationale section. We'll use that to tell the build to also
           // delete the associated entry from the list.
           const reED = /\[Editor's Draft\]\((.+?)\) already in the list/i;
-          const match = section.value.match(reED);
+          const match = section.value?.match(reED);
           if (match) {
             custom.knownUrl = match[1];
           }

--- a/src/find-specs.js
+++ b/src/find-specs.js
@@ -562,7 +562,7 @@ async function fetchKnownCandidates() {
       const rationaleSection = sections.find(section => section.title === "Rationale");
       const reRepository = /repository: \[.*?\]\((.+?)\)/i;
       if (rationaleSection) {
-        const match = rationaleSection.value.match(reRepository);
+        const match = rationaleSection.value?.match(reRepository);
         if (match) {
           entry.repo = match[1].replace(/https:\/\/github\.com\//, "");
           if (multiRepos[entry.repo]) {


### PR DESCRIPTION
The code that parses open issues creates a null value when the section contains "No response", but the rest of the code did not expect a null value.

Presence of a spec issue with an empty "Rationale" section crashed the `find-specs` job in particular.