### PR TITLE
Allow Puppeteer's post-install script by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "reffy": "^21.1.0",
     "rimraf": "^6.1.3",
     "undici": "^8.10.0"
+  },
+  "allowScripts": {
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
Npm now defaults to blocking post-install scripts of dependencies. This adds Puppeteer (any version) to the allow-list as described in: https://pptr.dev/troubleshooting#blocked-install-scripts