### PR TITLE
Setup Node.js after checkout in workflows

### DIFF
--- a/.github/workflows/check-suggested-spec.yml
+++ b/.github/workflows/check-suggested-spec.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      - name: Setup node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: .node-version
-
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           ref: main
+
+      - name: Setup node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/submit-suggested-spec.yml
+++ b/.github/workflows/submit-suggested-spec.yml
@@ -26,15 +26,15 @@ jobs:
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      - name: Setup node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: .node-version
-
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           ref: main
+
+      - name: Setup node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Workflows now read the version of Node.js to use from the `.node-version` file. A couple of them attempted to setup Node.js before checking out the repository, which cannot work. This update makes sure the checkout action runs before the setup-node action in all workflows.